### PR TITLE
Minor updates for API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val catsTimeVersion             = "0.3.4"
 
 inThisBuild(
   Seq(
-    homepage := Some(url("https://github.com/gemini-hlsw/gsp-math")),
+    homepage := Some(url("https://github.com/gemini-hlsw/lucuma-core")),
     addCompilerPlugin(
       ("org.typelevel" % "kind-projector" % kindProjectorVersion).cross(CrossVersion.full)
     ),

--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/Enumerated.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/Enumerated.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.syntax
+
+import lucuma.core.util.Enumerated
+
+final class EnumeratedOps[A: Enumerated](a: A) {
+
+  def tag: String =
+    Enumerated[A].tag(a)
+
+}
+
+trait ToEnumeratedOps {
+
+  implicit def toEnumeratedOps[A: Enumerated](a: A): EnumeratedOps[A] =
+    new EnumeratedOps[A](a)
+
+}
+
+object enumerated extends ToEnumeratedOps

--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/package.scala
@@ -15,6 +15,7 @@ package object syntax {
   object all
       extends ToDisplayOps
       with ToDurationOps
+      with ToEnumeratedOps
       with ToInstantOps
       with ToIntOps
       with ToParserOps

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ProperVelocitySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ProperVelocitySuite.scala
@@ -4,6 +4,7 @@
 package lucuma.core.math
 import cats.kernel.laws.discipline._
 import lucuma.core.math.arb.ArbProperVelocity._
+import lucuma.core.optics.laws.discipline.SplitMonoTests
 import munit.DisciplineSuite
 
 final class ProperVelocitySuite extends DisciplineSuite {
@@ -11,4 +12,7 @@ final class ProperVelocitySuite extends DisciplineSuite {
   // Laws
   checkAll("Order[ProperVelocity]", OrderTests[ProperVelocity].order)
   checkAll("Monoid[ProperVelocity]", MonoidTests[ProperVelocity].monoid)
+
+  checkAll("milliarcsecondsPerYear", SplitMonoTests(ProperVelocity.milliarcsecondsPerYear).splitMono)
+
 }


### PR DESCRIPTION
This PR offers a couple of minor updates that I came across while porting from the old `gsp`stuff.

* `ProperVelocity.milliarcsecondsPerYear` optic 
* `Enumerated` syntax