### PR TITLE
GID typeclass

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/util/Gid.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Gid.scala
@@ -1,0 +1,93 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import cats._
+import cats.implicits._
+import monocle.{ Iso, Prism }
+import scala.util.matching.Regex
+import eu.timepit.refined.char.Letter
+import eu.timepit.refined.types.numeric.PosLong
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined._
+import eu.timepit.refined.api.Refined
+
+/**
+ * A typeclass for Lucuma identifiers, which are of the form T-26fd21b3 where T is a constant,
+ * type-specific tag and the remainder is a positive hex-encoded Long, with lowercase alpha digits
+ * and no leading zeros (thus having a unique string representation).
+ *
+ * {{{
+ * case class Foo(id: Foo.Id, ...)
+ * object Foo {
+ *   case class Id(value: PosLong)
+ *   object Id {
+ *     implicit val GidId: Gid[Id] =
+ *       Gid.instance('f', _.value, apply)
+ *   }
+ * }
+ * }}}
+ *
+ * Database tables can use such values as primary keys.
+ *
+ * {{{
+ * CREATE DOMAIN foo_dom AS VARCHAR CHECK(VALUE ~ '^f-([1-9a-f][0-9a-f]*)$');
+ * CREATE SEQUENCE foo_seq START WITH 256;
+ * CREATE TABLE foo (
+ *   foo_id  varchar NOT NULL PRIMARY KEY DEFAULT 'f-' || to_hex(nextval('foo_seq')),
+ *   ...
+ * )
+ * }}}
+ */
+final class Gid[A](
+  val tag:        Char Refined Letter,
+  val isoPosLong: Iso[A, PosLong]
+) extends Order[A]
+     with Show[A] {
+
+  // We use this in a few places
+  private final val TagString: String = tag.value.toString
+
+  /** Gids have a unique String representation. */
+  final val fromString: Prism[String, A] = {
+
+    val R: Regex =
+      raw"^$TagString-([1-9a-f][0-9a-f]*)$$".r
+
+    def parse(s: String): Option[A] =
+      s match {
+        case R(s) =>
+          for {
+            signed <- Either.catchOnly[NumberFormatException](java.lang.Long.parseLong(s, 16)).toOption
+            pos    <- refineV[Positive](signed).toOption
+          } yield isoPosLong.reverseGet(pos)
+        case _ => None
+      }
+
+    def show(a: A): String =
+      s"$TagString-${isoPosLong.get(a).value.toHexString}"
+
+    Prism(parse)(show)
+
+  }
+
+  // Show
+  final override def show(a: A): String =
+    fromString.reverseGet(a)
+
+  // Order
+  final override def compare(a: A, b: A): Int =
+    isoPosLong.get(a).value compare isoPosLong.get(b).value
+
+}
+
+object Gid {
+
+  def apply[A](implicit ev: Gid[A]): ev.type = ev
+
+  def instance[A](tag: Char Refined Letter, toLong: A => PosLong, fromLong: PosLong => A): Gid[A] =
+    new Gid[A](tag, Iso(toLong)(fromLong))
+
+}
+

--- a/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbGid.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbGid.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util.arb
+
+import lucuma.core.util.Gid
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+import eu.timepit.refined.types.numeric.PosLong
+import eu.timepit.refined.scalacheck.numeric._
+
+trait ArbGid {
+
+  implicit def ArbGid[A](implicit ev: Gid[A]): Arbitrary[A] =
+    Arbitrary(arbitrary[PosLong].map(ev.isoPosLong.reverseGet))
+
+  implicit def CogGif[A](implicit ev: Gid[A]): Cogen[A] =
+    Cogen[Long].contramap(ev.isoPosLong.get(_).value)
+
+}
+
+object ArbGid extends ArbGid

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/GidSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/GidSuite.scala
@@ -4,17 +4,17 @@
 package lucuma.core.util
 
 import cats.implicits._
-import cats.kernel.laws.discipline.OrderTests
-import eu.timepit.refined.refineMV
+import cats.kernel.laws.discipline.{ BoundedEnumerableTests, OrderTests }
+import eu.timepit.refined.api.Refined
 import eu.timepit.refined.cats._
+import eu.timepit.refined.char.Letter
+import eu.timepit.refined.refineMV
 import eu.timepit.refined.scalacheck.all._
 import eu.timepit.refined.types.numeric.PosLong
 import lucuma.core.util.arb.ArbGid._
 import monocle.law.discipline.{ IsoTests, PrismTests }
 import munit._
 import org.scalacheck.Prop._
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.char.Letter
 
 final class GidSuite extends DisciplineSuite {
 
@@ -23,9 +23,10 @@ final class GidSuite extends DisciplineSuite {
     implicit val gid: Gid[Id] = Gid.instance(refineMV('i'), _.value, apply)
   }
 
-  checkAll("order", OrderTests[Id].order)
-  checkAll("isoPosLong", IsoTests(Gid[Id].isoPosLong))
-  checkAll("fromString", PrismTests(Gid[Id].fromString))
+  checkAll("Gid[Id]", BoundedEnumerableTests[Id].boundedEnumerable)
+  checkAll("Gid[Id]", OrderTests[Id].order)
+  checkAll("Gid[Id].isoPosLong", IsoTests(Gid[Id].isoPosLong))
+  checkAll("Gid[Id].fromString", PrismTests(Gid[Id].fromString))
 
   test("fromString: Tag") {
     forAll { (c: Char Refined Letter, n: PosLong) =>

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/GidSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/GidSuite.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import cats.implicits._
+import cats.kernel.laws.discipline.OrderTests
+import eu.timepit.refined.refineMV
+import eu.timepit.refined.cats._
+import eu.timepit.refined.scalacheck.all._
+import eu.timepit.refined.types.numeric.PosLong
+import lucuma.core.util.arb.ArbGid._
+import monocle.law.discipline.{ IsoTests, PrismTests }
+import munit._
+import org.scalacheck.Prop._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.char.Letter
+
+final class GidSuite extends DisciplineSuite {
+
+  case class Id(value: PosLong)
+  object Id {
+    implicit val gid: Gid[Id] = Gid.instance(refineMV('i'), _.value, apply)
+  }
+
+  checkAll("order", OrderTests[Id].order)
+  checkAll("isoPosLong", IsoTests(Gid[Id].isoPosLong))
+  checkAll("fromString", PrismTests(Gid[Id].fromString))
+
+  test("fromString: Tag") {
+    forAll { (c: Char Refined Letter, n: PosLong) =>
+      val s = s"${c.value}-${n.value.toHexString}"
+      assert(
+        Gid[Id].fromString.getOption(s).isDefined == (c === Gid[Id].tag),
+        s"$s should parse iff $c === ${Gid[Id].tag}"
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
This adds a **typeclass** for Gemini internal ids that have a canonical string representation and a type hint to help with debugging; i.e., `u-26fd21b3` identifies a `User`, at least in the SSO database. I don't know that there's a huge need to make the tags globally unique but we might have a wiki page for them or something.

The idea is that `Gid[A]` witnesses that
- `A` is isomorphic to `PosLong`
- `A` has a letter tag
- `A` has a canonical string representation `<letter>-<positive long in lowercase hex>`

Declare an instance thus:

```scala
case class Foo(id: Foo.Id, ...)
object Foo {
  case class Id(value: PosLong)
  object Id {
    implicit val GidId: Gid[Id] =
      Gid.instance(refineMV('f'), _.value, apply) // tag, to PosLong, from PosLong
  }
}
```

Within a database we can keep id types distinct by declaring domains, and auto-generate them with sequences.

```sql
CREATE DOMAIN foo_dom AS VARCHAR CHECK(VALUE ~ '^f-([1-9a-f][0-9a-f]*)$');
CREATE SEQUENCE foo_seq START WITH 256;
CREATE TABLE foo (
  foo_id  varchar NOT NULL PRIMARY KEY DEFAULT 'f-' || to_hex(nextval('foo_seq')),
  ...
)
```

Via the `fromString` prism provided by `Gid` we can derive codecs for Circe, doobie, skunk, etc., as well as GraphQL custom scalars.
