### PR TITLE
Move string case transformation to StringOps

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/String.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/String.scala
@@ -43,34 +43,22 @@ object StringOps {
   // Case transformation implementation adapted from:
   // https://github.com/circe/circe-generic-extras/blob/master/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
 
-  private sealed trait Case extends Product with Serializable {
-    def convert(s: String): String =
-      this match {
-        case LowerCase => s.toLowerCase
-        case UpperCase => s.toUpperCase
-      }
-  }
-
-  private case object LowerCase extends Case
-  private case object UpperCase extends Case
-
   private val basePattern: Pattern = Pattern.compile("([A-Z]+)([A-Z][a-z])")
   private val swapPattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
 
-  private def transformation(replacement: String, caze: Case): String => String =
-    s => {
-      val partial = basePattern.matcher(s).replaceAll(replacement)
-      caze.convert(swapPattern.matcher(partial).replaceAll(replacement))
-    }
+  private def transformation(input: String, replacement: String): String = {
+    val partial = basePattern.matcher(input).replaceAll(replacement)
+    swapPattern.matcher(partial).replaceAll(replacement)
+  }
 
-  private val snakeCaseTransformation: String => String =
-    transformation("$1_$2", LowerCase)
+  private def snakeCaseTransformation(s: String): String =
+    transformation(s, "$1_$2").toLowerCase
 
-  private val screamingSnakeCaseTransformation: String => String =
-    transformation("$1_$2", UpperCase)
+  private def screamingSnakeCaseTransformation(s: String): String =
+    transformation(s, "$1_$2").toUpperCase
 
-  private val kebabCaseTransformation: String => String =
-    transformation("$1-$2", LowerCase)
+  private def kebabCaseTransformation(s: String): String =
+    transformation(s, "$1-$2").toLowerCase
 
 }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/String.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/String.scala
@@ -3,6 +3,8 @@
 
 package lucuma.core.syntax
 
+import java.util.regex.Pattern
+
 final class StringOps(val self: String) extends AnyVal {
 
   private def parse[A](f: String => A): Option[A] =
@@ -15,6 +17,60 @@ final class StringOps(val self: String) extends AnyVal {
   def parseDoubleOption: Option[Double]         = parse(_.toDouble)
   def parseBooleanOption: Option[Boolean]       = parse(_.toBoolean)
   def parseBigDecimalOption: Option[BigDecimal] = parse(BigDecimal(_))
+
+  /**
+   * Converts the `String` to "snake case" (eg "foo_bar").
+   */
+  def toSnakeCase: String =
+    StringOps.snakeCaseTransformation(self)
+
+  /**
+   * Converts the `String` to "screaming snake case" (eg "FOO_BAR").
+   */
+  def toScreamingSnakeCase: String =
+    StringOps.screamingSnakeCaseTransformation(self)
+
+  /**
+   * Converts the `String` to "kebab case" (eg "foo-bar").
+   */
+  def toKebabCase: String =
+    StringOps.kebabCaseTransformation(self)
+
+}
+
+object StringOps {
+
+  // Case transformation implementation adapted from:
+  // https://github.com/circe/circe-generic-extras/blob/master/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+
+  private sealed trait Case extends Product with Serializable {
+    def convert(s: String): String =
+      this match {
+        case LowerCase => s.toLowerCase
+        case UpperCase => s.toUpperCase
+      }
+  }
+
+  private case object LowerCase extends Case
+  private case object UpperCase extends Case
+
+  private val basePattern: Pattern = Pattern.compile("([A-Z]+)([A-Z][a-z])")
+  private val swapPattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
+
+  private def transformation(replacement: String, caze: Case): String => String =
+    s => {
+      val partial = basePattern.matcher(s).replaceAll(replacement)
+      caze.convert(swapPattern.matcher(partial).replaceAll(replacement))
+    }
+
+  private val snakeCaseTransformation: String => String =
+    transformation("$1_$2", LowerCase)
+
+  private val screamingSnakeCaseTransformation: String => String =
+    transformation("$1_$2", UpperCase)
+
+  private val kebabCaseTransformation: String => String =
+    transformation("$1-$2", LowerCase)
 
 }
 


### PR DESCRIPTION
Adds the various `String` case transformations to `StringOps` to make them generally available.  In particular, I need the "screaming snake case" transformation to generate a GraphQL enum type from `Enumerated` instances.