### PR TITLE
change orcid a bit

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/OrcidId.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/OrcidId.scala
@@ -6,6 +6,7 @@ package lucuma.core.model
 import cats.Eq
 import io.circe._
 import java.net.URI
+import scala.util.matching.Regex
 
 /**
  * The ORCID iD is an https URI with a 16-digit number that is compatible with the ISO Standard
@@ -13,35 +14,47 @@ import java.net.URI
  * is a checksum that is either 0-9, or X.
  * @see https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
  */
-sealed abstract case class OrcidId(value: URI)
+sealed abstract case class OrcidId(uri: URI) {
+
+  /**
+   * Although the ORCID iD is technically a URI, the portion following `https://orcid.org/` is what
+   * we use as the serial form (and what we display to the user).
+   */
+  final lazy val value: String = uri.getPath().drop(1)
+
+}
 object OrcidId {
 
-  private val Pat = raw"https://orcid.org/(\d{4})-(\d{4})-(\d{4})-(\d{3})([\dX])".r
-
-  def fromUri(uri: URI): Either[String, OrcidId] =
-    fromString(uri.toString)
-
-  def fromString(s: String): Either[String, OrcidId] =
+  private val ValuePat   = raw"(\d{4})-(\d{4})-(\d{4})-(\d{3})([\dX])"
+  private val ValueRegex = ValuePat.r
+  private val UriRegex   = s"https://orcid.org/$ValuePat".r
+  private def parseWith(s: String, re: Regex): Either[String, OrcidId] =
     s match {
-      case Pat(a, b, c, d, x) =>
+      case re(a, b, c, d, x) =>
         if (checkDigit(a + b + c + d) == x)
-          Right(new OrcidId(new URI(s)) {})
+          Right(new OrcidId(new URI(s"https://orcid.org/$a-$b-$c-$d$x")) {})
         else
           Left(s"Invalid ORCID iD (bad checksum): $s")
       case _ => Left(s"Invalid ORCID iD: $s")
     }
 
+  def fromUri(uri: URI): Either[String, OrcidId] =
+    parseWith(uri.toString, UriRegex)
+
+  def fromValue(s: String): Either[String, OrcidId] =
+    parseWith(s, ValueRegex)
+
   implicit val EqOrcid: Eq[OrcidId] =
-    Eq.by(_.value.toString)
+    Eq.by(_.value)
 
   implicit val encoder: Encoder[OrcidId] =
-    Encoder[String].contramap(_.value.toString)
+    Encoder[String].contramap(_.value)
 
   implicit val decoder: Decoder[OrcidId] =
-    Decoder[String].emap(s => fromString(s))
+    Decoder[String].emap(s => fromValue(s))
 
   // adapted from the code at the link above
-  def checkDigit(baseDigits: String): String = {
+  private[model] def checkDigit(baseDigits: String): String = {
     require(baseDigits.forall(c => c >= '0' && c <= '9'))
     val total = baseDigits.foldLeft(0) { (acc, c) =>
       val digit = c - '0'

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbOrcidId.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbOrcidId.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.core.util.arb
+package lucuma.core.model.arb
 
 import cats.implicits._
 import lucuma.core.model.OrcidId
@@ -17,7 +17,7 @@ trait ArbOrcidId {
     Arbitrary {
       (digits(4), digits(4), digits(4), digits(3)).mapN { case (a, b, c, d) =>
         val x = OrcidId.checkDigit(a + b + c + d)
-        OrcidId.fromString(s"https://orcid.org/$a-$b-$c-$d$x") match {
+        OrcidId.fromValue(s"$a-$b-$c-$d$x") match {
           case Left(s)  => sys.error(s)
           case Right(o) => o
         }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/OrcidIdSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/OrcidIdSuite.scala
@@ -3,12 +3,14 @@
 
 package lucuma.core.model
 
-import lucuma.core.util.arb._
+import lucuma.core.model.arb._
 
 import munit._
+import cats.implicits._
 import cats.kernel.laws.discipline.EqTests
 import io.circe.testing.CodecTests
 import io.circe.testing.instances.arbitraryJson
+import org.scalacheck.Prop
 
 final class OrcidIdSuite extends DisciplineSuite {
   import ArbOrcidId._
@@ -16,5 +18,17 @@ final class OrcidIdSuite extends DisciplineSuite {
   // Laws
   checkAll("OrcidId", EqTests[OrcidId].eqv)
   checkAll("OrcidId", CodecTests[OrcidId].unserializableCodec)
+
+  test("round-rip through uri") {
+    Prop.forAll { (o: OrcidId) =>
+      OrcidId.fromUri(o.uri) === Right(o)
+    }
+  }
+
+  test("round-rip through value") {
+    Prop.forAll { (o: OrcidId) =>
+      OrcidId.fromValue(o.value) === Right(o)
+    }
+  }
 
 }


### PR DESCRIPTION
ORCID iD is technically a URI but in practice the portion after `https://orcid.org/` (which I call the `value` here) is what we use. So this change adds support for `value` and ensures that you can round-trip through it (as well as through the full URI).