### PR TITLE
Epoch format

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/Epoch.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Epoch.scala
@@ -19,7 +19,7 @@ import java.time._
  * @param scheme This `Epoch`'s temporal scheme.
  * @see The Wikipedia [[https://en.wikipedia.org/wiki/Epoch_(astronomy) article]]
  */
-final class Epoch private (val scheme: Epoch.Scheme, private[math] val toMilliyears: Int) {
+final class Epoch private (val scheme: Epoch.Scheme, val toMilliyears: Int) {
 
   /** This `Epoch`'s year. Note that this value is not very useful without the `Scheme`. */
   def epochYear: Double =

--- a/modules/core/shared/src/main/scala/lucuma/core/math/Epoch.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Epoch.scala
@@ -3,12 +3,14 @@
 
 package lucuma.core.math
 
-import cats.{ Order, Show }
+import java.time._
+
+import cats.Order
+import cats.Show
 import cats.syntax.all._
 import lucuma.core.math.parser.EpochParsers
-import lucuma.core.syntax.parser._
 import lucuma.core.optics.Format
-import java.time._
+import lucuma.core.syntax.parser._
 
 /**
  * An epoch, the astronomer's equivalent of `Instant`, based on a fractional year in some temporal
@@ -142,6 +144,21 @@ trait EpochOptics { this: Epoch.type =>
     Format(
       s => EpochParsers.epoch.parseExact(s),
       e => f"${e.scheme.prefix}%s${e.toMilliyears / 1000}%d.${e.toMilliyears % 1000}%03d"
+    )
+
+  val fromStringNoScheme: Format[String, Epoch] =
+    Format(
+      s => EpochParsers.epochLenient.parseExact(s),
+      {
+        case e if e.toMilliyears % 1000 === 0 =>
+          f"${e.toMilliyears / 1000}%d"
+        case e if e.toMilliyears % 100 === 0  =>
+          f"${e.toMilliyears / 1000}%d.${(e.toMilliyears % 1000) / 100}%01d"
+        case e if e.toMilliyears % 10 === 0   =>
+          f"${e.toMilliyears / 1000}%d.${(e.toMilliyears % 1000) / 10}%02d"
+        case e =>
+          f"${e.toMilliyears / 1000}%d.${e.toMilliyears % 1000}%03d"
+      }
     )
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/parser/Epoch.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/parser/Epoch.scala
@@ -7,6 +7,7 @@ import cats.syntax.all._
 import atto._, Atto._
 import lucuma.core.math.Epoch
 import lucuma.core.parser.MiscParsers
+import lucuma.core.math.Epoch.Julian
 
 /** Parser for [[lucuma.core.math.Epoch]]. */
 trait EpochParsers {
@@ -30,5 +31,15 @@ trait EpochParsers {
       }
       .named("epoch")
 
+  /** Parser for an `Epoch` with a default Julian schemme. */
+  val epochLenient: Parser[Epoch] =
+    (opt(epochScheme), int <~ opt(char('.')), MiscParsers.frac(3))
+      .mapN {
+        case (s, y, f) =>
+          s.getOrElse(Julian).fromMilliyears(y * 1000 + f)
+      }
+      .named("epoch")
+
 }
+
 object EpochParsers extends EpochParsers

--- a/modules/core/shared/src/main/scala/lucuma/core/math/parser/Epoch.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/parser/Epoch.scala
@@ -38,7 +38,7 @@ trait EpochParsers {
         case (s, y, f) =>
           s.getOrElse(Julian).fromMilliyears(y * 1000 + f)
       }
-      .named("epoch")
+      .named("julianEpoch")
 
 }
 

--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbEpoch.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbEpoch.scala
@@ -3,13 +3,15 @@
 
 package lucuma.core.math.arb
 
-import lucuma.core.math.Epoch
 import java.time.LocalDateTime
-import org.scalacheck._
-import org.scalacheck.Gen._
-import org.scalacheck.Arbitrary._
-import lucuma.core.arb._
+
 import lucuma.core.arb.ArbTime
+import lucuma.core.arb._
+import lucuma.core.math.Epoch
+import lucuma.core.math.Epoch.Julian
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen._
+import org.scalacheck._
 
 trait ArbEpoch {
   import ArbTime._
@@ -34,10 +36,19 @@ trait ArbEpoch {
       s => Gen.const(s.replace("2", "0")) // create a leading zero, maybe (ok)
     )
 
-  // Strings that are often parsable as DMS.
+  // Strings that are often parsable as epoch
   val strings: Gen[String] =
     arbitrary[Epoch].map(Epoch.fromString.reverseGet).flatMapOneOf(Gen.const, perturbations: _*)
 
+  val stringsNoScheme: Gen[String] =
+    arbitrary[Epoch]
+      .map(Epoch.fromStringNoScheme.reverseGet)
+      .flatMapOneOf(Gen.const, perturbations: _*)
+
+  val arbJulianEpoch: Arbitrary[Epoch] =
+    Arbitrary {
+      arbitrary[LocalDateTime].map(Julian.fromLocalDateTime)
+    }
 }
 
 object ArbEpoch extends ArbEpoch

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/EpochSpec.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/EpochSpec.scala
@@ -3,43 +3,50 @@
 
 package lucuma.core.math
 
-import cats.tests.CatsSuite
 import cats.{ Eq, Show }
+import cats.implicits._
 import cats.kernel.laws.discipline._
 import lucuma.core.math.arb._
 import lucuma.core.optics.laws.discipline._
 import java.time.LocalDateTime
 import lucuma.core.arb.ArbTime
+import org.scalacheck.Prop._
+import lucuma.core.math.parser.EpochParsers._
+import lucuma.core.syntax.parser._
 
-final class EpochSpec extends CatsSuite {
+final class EpochSuite extends munit.DisciplineSuite {
   import ArbEpoch._
   import ArbTime._
 
   // Laws
   checkAll("Epoch", OrderTests[Epoch].order)
   checkAll("fromString", FormatTests(Epoch.fromString).formatWith(ArbEpoch.strings))
+  checkAll("fromStringNoScheme",
+           FormatTests(Epoch.fromStringNoScheme)
+             .formatWith(ArbEpoch.stringsNoScheme)(Eq[String], arbJulianEpoch, Eq[Epoch])
+  )
 
   test("Epoch.eq.natural") {
     forAll { (a: Epoch, b: Epoch) =>
-      a.equals(b) shouldEqual Eq[Epoch].eqv(a, b)
+      assertEquals(a.equals(b), Eq[Epoch].eqv(a, b))
     }
   }
 
   test("Epoch.show.natural") {
     forAll { (a: Epoch) =>
-      a.toString shouldEqual Show[Epoch].show(a)
+      assertEquals(a.toString, Show[Epoch].show(a))
     }
   }
 
   test("Epoch.until.identity") {
     forAll { (a: Epoch) =>
-      a.untilEpochYear(a.epochYear) shouldEqual 0.0
+      assertEquals(a.untilEpochYear(a.epochYear), 0.0)
     }
   }
 
   test("Epoch.until.sanity") {
     forAll { (a: Epoch, s: Short) =>
-      a.untilEpochYear(a.epochYear + s.toDouble) shouldEqual s.toDouble
+      assertEquals(a.untilEpochYear(a.epochYear + s.toDouble), s.toDouble)
     }
   }
 
@@ -47,8 +54,39 @@ final class EpochSpec extends CatsSuite {
     forAll { (s: Epoch.Scheme, d1: LocalDateTime, d2: LocalDateTime) =>
       val Δ1 = s.fromLocalDateTime(d1).untilLocalDateTime(d2)
       val Δ2 = s.fromLocalDateTime(d2).epochYear - s.fromLocalDateTime(d1).epochYear
-      Δ1 shouldEqual Δ2
+      assertEquals(Δ1, Δ2)
     }
   }
 
+  test("epochLenient") {
+    assertEquals(epochLenient.parseExact("J2014.123"), Epoch.Julian.fromMilliyears(2014123).some)
+    assertEquals(epochLenient.parseExact("J2014"), Epoch.Julian.fromMilliyears(2014000).some)
+    assertEquals(epochLenient.parseExact("J2014."), Epoch.Julian.fromMilliyears(2014000).some)
+    assertEquals(epochLenient.parseExact("J2014.1"), Epoch.Julian.fromMilliyears(2014100).some)
+    assertEquals(epochLenient.parseExact("2014.123"), Epoch.Julian.fromMilliyears(2014123).some)
+    assertEquals(epochLenient.parseExact("2014"), Epoch.Julian.fromMilliyears(2014000).some)
+    assertEquals(epochLenient.parseExact("2014."), Epoch.Julian.fromMilliyears(2014000).some)
+    assertEquals(epochLenient.parseExact("2014.1"), Epoch.Julian.fromMilliyears(2014100).some)
+    assertEquals(epochLenient.parseExact("2014.092"), Epoch.Julian.fromMilliyears(2014092).some)
+    assertEquals(epochLenient.parseExact("2014.002"), Epoch.Julian.fromMilliyears(2014002).some)
+  }
+
+  test("epochFormatNoScheme") {
+    assertEquals(Epoch.fromStringNoScheme.reverseGet(Epoch.Julian.fromMilliyears(2014123)),
+                 "2014.123"
+    )
+    assertEquals(Epoch.fromStringNoScheme.reverseGet(Epoch.Julian.fromMilliyears(2014000)), "2014")
+    assertEquals(Epoch.fromStringNoScheme.reverseGet(Epoch.Julian.fromMilliyears(2014300)),
+                 "2014.3"
+    )
+    assertEquals(Epoch.fromStringNoScheme.reverseGet(Epoch.Julian.fromMilliyears(2014092)),
+                 "2014.092"
+    )
+    assertEquals(Epoch.fromStringNoScheme.reverseGet(Epoch.Julian.fromMilliyears(2014002)),
+                 "2014.002"
+    )
+    assertEquals(Epoch.fromStringNoScheme.reverseGet(Epoch.Julian.fromMilliyears(2014350)),
+                 "2014.35"
+    )
+  }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += Resolver.sonatypeRepo("public")
 
 addSbtPlugin("edu.gemini"            % "sbt-lucuma"               % "0.3.0")
 addSbtPlugin("com.geirsson"          % "sbt-ci-release"           % "1.5.3")
-addSbtPlugin("org.scala-js"          % "sbt-scalajs"              % "1.3.0")
+addSbtPlugin("org.scala-js"          % "sbt-scalajs"              % "1.2.0")
 addSbtPlugin("org.portable-scala"    % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("com.timushev.sbt"      % "sbt-updates"              % "0.5.1")


### PR DESCRIPTION
This PR adds a `Format` that is more lenient letting you ignore the scheme part and with a different formatting removing the scheme and trailing zeros.

I expect to use this format to let users enter the value on the UI