### PR TITLE
Shareable Ids

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/Id.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Id.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosLong
+import lucuma.core.util.Gid
+
+/**
+ * Top-level shareable object ids.
+ */
+object Id {
+
+  final case class Asterism(value: PosLong) {
+    override def toString: String =
+      Gid[Asterism].show(this)
+  }
+
+  object Asterism {
+    implicit val GidAsterism: Gid[Asterism] =
+      Gid.instance('a', _.value, apply)
+  }
+
+  final case class Observation(value: PosLong) {
+    override def toString: String =
+      Gid[Observation].show(this)
+  }
+
+  object Observation {
+    implicit val GidObservation: Gid[Observation] =
+      Gid.instance('o', _.value, apply)
+  }
+
+  final case class Program(value: PosLong) {
+    override def toString: String =
+      Gid[Program].show(this)
+  }
+
+  object Program {
+    implicit val GidProgram: Gid[Program] =
+      Gid.instance('p', _.value, apply)
+  }
+
+  final case class Target(value: PosLong) {
+    override def toString: String =
+      Gid[Target].show(this)
+  }
+
+  object Target {
+    implicit val GidTarget: Gid[Target] =
+      Gid.instance('t', _.value, apply)
+  }
+
+}


### PR DESCRIPTION
The various user interfaces and backend services will need to identify top-level objects like targets and observations.  As discussed each kind of identifier should have its own Scala type.  Ideally we can all share the definitions of these identifiers so that they are not repeated.  I'm not sure this is the place for it, but wanted to offer it for comments.

This PR is straightforward, to put it charitably.  Perhaps with `opaque type`s it can be done better in the future?  Or perhaps there is already a preferred `newtype` alternative?  Everything I could think of seemed no better than simply repeating the same definitions each time.