### PR TITLE
Move lens editor ops to core

### DIFF
--- a/.github/workflows/clubhouse.yml
+++ b/.github/workflows/clubhouse.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: singingwolfboy/create-linked-clubhouse-story@v1.5
+        if: contains(github.event.pull_request.body, '[ch-new]') || contains(github.event.pull_request.labels.*.name, 'new clubhouse story')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           clubhouse-token: ${{ secrets.CLUBHOUSE_TOKEN }}
@@ -14,3 +15,10 @@ jobs:
           opened-state-name: In Development
           merged-state-name: Completed
           ignored-users: scala-steward
+          user-map: |
+            {
+              "rpiaggio": "5f4a944d-faa8-48d6-8611-f565df2715d5",
+              "swalker": "5dc4137c-a307-4be9-b530-4516dc2bf0bf",
+              "toddburnside": "5f493c15-019c-453f-8413-c08ec65675d9",
+              "tpolecat": "5f49319b-41f4-43c4-a303-9025445831e0"
+            }

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel"              %%% "cats-effect"            % catsEffectVersion,
       "com.github.julien-truffaut" %%% "monocle-core"           % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-macro"          % monocleVersion,
+      "com.github.julien-truffaut" %%% "monocle-state"          % monocleVersion,
       "edu.gemini"                 %%% "lucuma-jts"             % jtsVersion,
       "com.manyangled"             %%% "coulomb"                % coulombVersion,
       "com.manyangled"             %%% "coulomb-si-units"       % coulombVersion,

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/Lens.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/Lens.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.optics.syntax
+
+import cats.data.State
+import monocle.Lens
+import monocle.state.all._
+
+final class LensEditorOps[S, A](val self: Lens[S, A]) extends AnyVal {
+  def edit(a: A): State[S, A] =
+    self.assign(a)
+
+  @inline def :=(a: A): State[S, A] =
+    edit(a)
+
+  def edit(a: Option[A]): State[S, A] =
+    a.fold(self.st)(self.assign)
+
+  @inline def :=(a: Option[A]): State[S, A] =
+    edit(a)
+}
+
+trait ToLensEditorOps {
+  implicit def ToLensOps[S, B](l: Lens[S, B]): LensEditorOps[S, B] =
+    new LensEditorOps(l)
+}
+
+object lens extends ToLensEditorOps

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/package.scala
@@ -1,0 +1,8 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.optics
+
+package object syntax {
+  object all extends ToPrismOps with ToLensEditorOps
+}


### PR DESCRIPTION
Move the lens editor ops to core to be used by explore and tmp-api.
I also copied the clubhouse definition from explore, to only act when explicitly requested