### PR TITLE
Optional (as in monocle) Ops

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/Lens.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/Lens.scala
@@ -7,7 +7,7 @@ import cats.data.State
 import monocle.Lens
 import monocle.state.all._
 
-final class LensEditorOps[S, A](val self: Lens[S, A]) extends AnyVal {
+final class LensOps[S, A](val self: Lens[S, A]) extends AnyVal {
   def edit(a: A): State[S, A] =
     self.assign(a)
 
@@ -21,9 +21,9 @@ final class LensEditorOps[S, A](val self: Lens[S, A]) extends AnyVal {
     edit(a)
 }
 
-trait ToLensEditorOps {
-  implicit def ToLensOps[S, B](l: Lens[S, B]): LensEditorOps[S, B] =
-    new LensEditorOps(l)
+trait ToLensOps {
+  implicit def ToLensOps[S, B](l: Lens[S, B]): LensOps[S, B] =
+    new LensOps(l)
 }
 
-object lens extends ToLensEditorOps
+object lens extends ToLensOps

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/Optional.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/Optional.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.optics.syntax
+
+import cats.data.State
+import monocle.Optional
+import monocle.state.all._
+
+final class OptionalOps[S, A](val self: Optional[S, A]) extends AnyVal {
+
+  def edit(a: A): State[S, Option[A]] =
+    self.assign(a)
+
+  @inline def :=(a: A): State[S, Option[A]] =
+    edit(a)
+
+  def edit(a: Option[A]): State[S, Option[A]] =
+    a.fold(self.st)(self.assign)
+
+  @inline def :=(a: Option[A]): State[S, Option[A]] =
+    edit(a)
+
+}
+
+trait ToOptionalOps {
+  implicit def ToOptionalOps[S, A](opt: Optional[S, A]): OptionalOps[S, A] =
+    new OptionalOps[S, A](opt)
+}
+
+object optional extends ToOptionalOps

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/syntax/package.scala
@@ -4,5 +4,7 @@
 package lucuma.core.optics
 
 package object syntax {
-  object all extends ToPrismOps with ToLensEditorOps
+  object all extends ToLensOps
+                with ToOptionalOps
+                with ToPrismOps
 }


### PR DESCRIPTION
Adds the same syntax that @cquiroz brought over for `Lens` but for `Optional`.  I renamed these to `LensOps` and `OptionalOps` because the editor referred to something in the API codebase and maybe we'll want to add other syntax at some point.