### PR TITLE
Add catalogId to SiderealTracking Order

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
@@ -197,11 +197,12 @@ object SiderealTracking extends SiderealTrackingOptics {
     // This is premature optimization perhaps but it seems like it might make a
     // difference when sorting a long list of targets.
 
-    order(_.baseCoordinates) |+|
-      order(_.epoch) |+|
-      order(_.properMotion) |+|
+    order(_.baseCoordinates)  |+|
+      order(_.epoch)          |+|
+      order(_.properMotion)   |+|
       order(_.radialVelocity) |+|
-      order(_.parallax)
+      order(_.parallax)       |+|
+      order(_.catalogId)
 
   }
 }


### PR DESCRIPTION
A minor bug fix that adds `catalogId` to `Order[SiderealTracking]` so that two `SiderealTracking` instances that differ only by catalog id count as distinct according to `===`.