### PR TITLE
Allow testing Format/Split*/Wedge laws without coverage check.

### DIFF
--- a/modules/testkit/src/main/scala/lucuma/core/optics/laws/FormatProps.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/optics/laws/FormatProps.scala
@@ -8,7 +8,6 @@ import cats.syntax.all._
 import lucuma.core.optics.Format
 
 final case class FormatLaws[A, B](fab: Format[A, B]) {
-
   def normalize(a: A): IsEq[Option[B]] =
     fab.normalize(a).flatMap(fab.getOption) <-> fab.getOption(a)
 
@@ -19,6 +18,10 @@ final case class FormatLaws[A, B](fab: Format[A, B]) {
 
   def formatRoundTrip(b: B): IsEq[Option[B]] =
     fab.getOption(fab.reverseGet(b)) <-> Some(b)
+}
+
+final case class FormatProps[A, B](fab: Format[A, B]) {
+  val laws: FormatLaws[A, B] = FormatLaws(fab)
 
   // True if `a` is parsable but not in normal form. The existence of such a value in our test data
   // will show that `normalize` and `parseRoundTrip` are actually testing something.
@@ -27,5 +30,4 @@ final case class FormatLaws[A, B](fab: Format[A, B]) {
       case None     => false
       case Some(aʹ) => a =!= aʹ
     }
-
 }

--- a/modules/testkit/src/main/scala/lucuma/core/optics/laws/SplitEpiProps.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/optics/laws/SplitEpiProps.scala
@@ -8,7 +8,6 @@ import cats.syntax.all._
 import lucuma.core.optics.SplitEpi
 
 final case class SplitEpiLaws[A, B](fab: SplitEpi[A, B]) {
-
   def normalize(a: A): IsEq[B] =
     fab.get(fab.normalize(a)) <-> fab.get(a)
 
@@ -19,6 +18,10 @@ final case class SplitEpiLaws[A, B](fab: SplitEpi[A, B]) {
 
   def reverseGetRoundTrip(b: B): IsEq[B] =
     (fab.reverseGet.andThen(fab.get))(b) <-> b
+}
+
+final case class SplitEpiProps[A, B](fab: SplitEpi[A, B]) {
+  val laws: SplitEpiLaws[A, B] = SplitEpiLaws(fab)
 
   // True if `a` is parsable but not in normal form. The existence of such a value in our test data
   // will show that `normalize` and `parseRoundTrup` are actually testing something.

--- a/modules/testkit/src/main/scala/lucuma/core/optics/laws/SplitMonoProps.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/optics/laws/SplitMonoProps.scala
@@ -8,7 +8,6 @@ import cats.syntax.all._
 import lucuma.core.optics.SplitMono
 
 final case class SplitMonoLaws[A, B](fab: SplitMono[A, B]) {
-
   def normalize(b: B): IsEq[A] =
     fab.reverseGet(fab.normalize(b)) <-> fab.reverseGet(b)
 
@@ -19,6 +18,10 @@ final case class SplitMonoLaws[A, B](fab: SplitMono[A, B]) {
 
   def getRoundTrip(a: A): IsEq[A] =
     (fab.get.andThen(fab.reverseGet))(a) <-> a
+}
+
+final case class SplitMonoProps[A, B](fab: SplitMono[A, B]) {
+  val laws: SplitMonoLaws[A, B] = SplitMonoLaws(fab)
 
   // True if `a` is parsable but not in normal form. The existence of such a value in our test data
   // will show that `normalize` and `parseRoundTrup` are actually testing something.

--- a/modules/testkit/src/main/scala/lucuma/core/optics/laws/WedgeProps.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/optics/laws/WedgeProps.scala
@@ -8,7 +8,6 @@ import cats.syntax.all._
 import lucuma.core.optics.Wedge
 
 final case class WedgeLaws[A, B](fab: Wedge[A, B]) {
-
   def normalizeA(a: A): IsEq[B] =
     fab.get(fab.normalizeA(a)) <-> fab.get(a)
 
@@ -24,6 +23,10 @@ final case class WedgeLaws[A, B](fab: Wedge[A, B]) {
     val aʹ = fab.normalizeA(a)
     (fab.reverseGet.compose(fab.get))(aʹ) <-> aʹ
   }
+}
+
+final case class WedgeProps[A, B](fab: Wedge[A, B]) {
+  val laws: WedgeLaws[A, B] = WedgeLaws(fab)
 
   // Demonstrate coverage
   def demonstratesCoverageA(b: A)(implicit ev: Eq[A]): Boolean =


### PR DESCRIPTION
The coverage check allows us to make sure we are using the right optic, but it's not a law per se.

This PR keeps the coverage check when testing laws as usual, but also allows testing of just the optic laws without the coverage check. To do the latter, the syntax would be, for example:

`FormatTests(...).formatLaws`, or
`FormatTests(...).formatLawsWith(...)`