### PR TITLE
Mag value truncation fix

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/MagnitudeValue.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/MagnitudeValue.scala
@@ -9,6 +9,8 @@ import cats.Show
 import lucuma.core.optics.Format
 import spire.math.Rational
 
+import java.math.RoundingMode
+
 import scala.util.Try
 
 /**
@@ -55,7 +57,7 @@ object MagnitudeValue {
     Format[Int, MagnitudeValue](v => Some(new MagnitudeValue(v)), _.scaledValue)
       .imapA[BigDecimal](
         n => new java.math.BigDecimal(n).movePointLeft(3),
-        d => d.underlying.movePointRight(3).intValue
+        d => d.underlying.movePointRight(3).setScale(0, RoundingMode.HALF_UP).intValue
       )
 
   /**

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/MagnitudeValueSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/MagnitudeValueSuite.scala
@@ -44,4 +44,9 @@ final class MagnitudeValueSuite extends DisciplineSuite {
     }
   }
 
+  test("MagnitudeValue rounding") {
+    assertEquals(MagnitudeValue.fromBigDecimal.unsafeGet(BigDecimal("1.0004")).scaledValue, 1000)
+    assertEquals(MagnitudeValue.fromBigDecimal.unsafeGet(BigDecimal("1.0005")).scaledValue, 1001)
+  }
+
 }


### PR DESCRIPTION
Updates the `MagnitudeValue.fromBigDecimal` `Format` optic to round up.  See https://app.clubhouse.io/lucuma/story/615/truncation-vs-rounding