### PR TITLE
Create types Angle180µas and Angle360µas

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Angle.scala
@@ -12,15 +12,15 @@ import lucuma.core.optics._
 import monocle.{ Iso, Prism }
 
 /**
-  * Exact angles represented as integral microarcseconds. These values form a commutative group over
-  * addition, where the inverse is reflection around the 0-180° axis. The subgroup of angles where
-  * integral microarcseconds correspond with clock microseconds (i.e., where they are evenly
-  * divisible by 15 microarcseconds) is represented by the HourAgle subtype.
-  *
-  * Lawful conversion to and from other types/scales is provided by optics defined on the companion
-  * object. Floating-point conversions are provided directly
-  * @param toMicroarcseconds This angle in microarcseconds. Exact.
-  */
+ * Exact angles represented as integral microarcseconds. These values form a commutative group over
+ * addition, where the inverse is reflection around the 0-180° axis. The subgroup of angles where
+ * integral microarcseconds correspond with clock microseconds (i.e., where they are evenly
+ * divisible by 15 microarcseconds) is represented by the HourAgle subtype.
+ *
+ * Lawful conversion to and from other types/scales is provided by optics defined on the companion
+ * object. Floating-point conversions are provided directly
+ * @param toMicroarcseconds This angle in microarcseconds. Exact.
+ */
 sealed class Angle protected (val toMicroarcseconds: Long) {
 
   // Sanity checks … should be correct via the companion constructor.
@@ -28,109 +28,109 @@ sealed class Angle protected (val toMicroarcseconds: Long) {
   assert(toMicroarcseconds < Angle.µasPer360, s"Invariant violated. $toMicroarcseconds is >= 360°.")
 
   /**
-    * Flip this angle 180°. Equivalent to `mirrorBy(this + Angle90)`. Exact, invertible.
-    * @group Transformations
-    */
+   * Flip this angle 180°. Equivalent to `mirrorBy(this + Angle90)`. Exact, invertible.
+   * @group Transformations
+   */
   def flip: Angle =
     this + Angle.Angle180
 
   /**
-    * Additive inverse of this angle, equivalent to `mirrorBy Angle0`. Exact, invertible.
-    * @group Transformations
-    */
+   * Additive inverse of this angle, equivalent to `mirrorBy Angle0`. Exact, invertible.
+   * @group Transformations
+   */
   def unary_- : Angle =
     Angle.fromMicroarcseconds(-toMicroarcseconds.toLong)
 
   /**
-    * Mirror image of this angle, when the mirror stands at angle `a`; or picture picking up the
-    * circle and flipping it over, around a line drawn from the center going off in direction `a`.
-    * So `(88° mirrorBy 90°) = 92°` for instance, as is `88° mirrorBy 270°` since it's the same
-    * line. This operation is specified completely by the identity `b - a = (a mirrorBy b) - b`.
-    * @group Transformations
-    */
+   * Mirror image of this angle, when the mirror stands at angle `a`; or picture picking up the
+   * circle and flipping it over, around a line drawn from the center going off in direction `a`.
+   * So `(88° mirrorBy 90°) = 92°` for instance, as is `88° mirrorBy 270°` since it's the same
+   * line. This operation is specified completely by the identity `b - a = (a mirrorBy b) - b`.
+   * @group Transformations
+   */
   def mirrorBy(a: Angle): Angle = {
     val Δ = a.toMicroarcseconds - toMicroarcseconds
     Angle.fromMicroarcseconds(toMicroarcseconds + Δ * 2L)
   }
 
   /**
-    * Angle corresponding to the bisection of this Angle.  Approximate, non-invertible.
-    * @group Transformations
-    */
+   * Angle corresponding to the bisection of this Angle.  Approximate, non-invertible.
+   * @group Transformations
+   */
   def bisect: Angle =
     Angle.fromMicroarcseconds(toMicroarcseconds / 2L)
 
   /**
-    * This angle in decimal degrees. Approximate, non-invertible.
-    * @group Conversions
-    */
+   * This angle in decimal degrees. Approximate, non-invertible.
+   * @group Conversions
+   */
   def toDoubleDegrees: Double =
     toMicroarcseconds.toDouble / Angle.µasPerDegree.toDouble
 
   /**
-    * This angle in signed decimal degrees. Approximate, non-invertible
-    * @group Conversions
-    */
+   * This angle in signed decimal degrees. Approximate, non-invertible
+   * @group Conversions
+   */
   def toSignedDoubleDegrees: Double =
     Angle.signedMicroarcseconds.get(this).toDouble / Angle.µasPerDegree.toDouble
 
   /**
-    * This angle in decimal radian, [0 .. 2π) Approximate, non-invertible
-    * @group Conversions
-    */
+   * This angle in decimal radian, [0 .. 2π) Approximate, non-invertible
+   * @group Conversions
+   */
   def toDoubleRadians: Double =
     toDoubleDegrees.toRadians
 
   /**
-    * This angle in signed decimal radians, [-π .. π) Approximate, non-invertible
-    * @group Conversions
-    */
+   * This angle in signed decimal radians, [-π .. π) Approximate, non-invertible
+   * @group Conversions
+   */
   def toSignedDoubleRadians: Double =
     toSignedDoubleDegrees.toRadians
 
   /**
-    * Sum of this angle and `a`. Exact, commutative, invertible.
-    * @group Operations
-    */
+   * Sum of this angle and `a`. Exact, commutative, invertible.
+   * @group Operations
+   */
   def +(a: Angle): Angle =
     Angle.fromMicroarcseconds(toMicroarcseconds + a.toMicroarcseconds)
 
   /**
-    * Difference of this angle and `a`. Exact, invertible.
-    * @group Operations
-    */
+   * Difference of this angle and `a`. Exact, invertible.
+   * @group Operations
+   */
   def -(a: Angle): Angle =
     Angle.fromMicroarcseconds(toMicroarcseconds - a.toMicroarcseconds)
 
   /**
-    * This angle as an Offset.P. Exact, invertible.
-    *
-    * @group Conversions
-    */
+   * This angle as an Offset.P. Exact, invertible.
+   *
+   * @group Conversions
+   */
   def p: Offset.P =
     Offset.P(this)
 
   /**
-    * This angle as an Offset.Q. Exact, invertible.
-    *
-    * @group Conversions
-    */
+   * This angle as an Offset.Q. Exact, invertible.
+   *
+   * @group Conversions
+   */
   def q: Offset.Q =
     Offset.Q(this)
 
   /**
-    * This angle as an offset in p.  Exact, invertible.
-    *
-    * @group Conversions
-    */
+   * This angle as an offset in p.  Exact, invertible.
+   *
+   * @group Conversions
+   */
   def offsetInP: Offset =
     Offset(p, Offset.Q.Zero)
 
   /**
-    * This angle as an offset in q.  Exact, invertible.
-    *
-    * @group Conversions
-    */
+   * This angle as an offset in q.  Exact, invertible.
+   *
+   * @group Conversions
+   */
   def offsetInQ: Offset =
     Offset(Offset.P.Zero, q)
 
@@ -151,8 +151,8 @@ sealed class Angle protected (val toMicroarcseconds: Long) {
     toMicroarcseconds.toInt
 
   /**
-    * angle difference or separation between two angles in the range [0 .. π]
-    */
+   * angle difference or separation between two angles in the range [0 .. π]
+   */
   def difference(a: Angle): Angle =
     Angle.difference(this, a)
 }
@@ -181,41 +181,41 @@ object Angle extends AngleOptics {
   lazy val Angle270: Angle = degrees.reverseGet(270)
 
   /**
-    * Construct a new Angle of the given magnitude in integral microarcseconds, modulo 360°. Exact.
-    * @group Constructors
-    */
+   * Construct a new Angle of the given magnitude in integral microarcseconds, modulo 360°. Exact.
+   * @group Constructors
+   */
   def fromMicroarcseconds(µas: Long): Angle = {
     val µasʹ = ((µas % µasPer360) + µasPer360) % µasPer360
     new Angle(µasʹ)
   }
 
   /**
-    * Construct a new Angle of the given magnitude in double degrees, modulo 360°. Approximate.
-    * @group Constructors
-    */
+   * Construct a new Angle of the given magnitude in double degrees, modulo 360°. Approximate.
+   * @group Constructors
+   */
   def fromDoubleDegrees(ds: Double): Angle =
     // Changing this to use µasPerDegree changes the precision of the
     // ImprovedSkyCalc calculations.
     fromMicroarcseconds((ds * 60 * 60 * 1000 * 1000).toLong)
 
   /**
-    * Construct a new Angle of the given magnitude in double arcseconds, modulo 360°. Approximate.
-    * @group Constructors
-    */
+   * Construct a new Angle of the given magnitude in double arcseconds, modulo 360°. Approximate.
+   * @group Constructors
+   */
   def fromDoubleArcseconds(as: Double): Angle =
     fromMicroarcseconds((as * 1000 * 1000).toLong)
 
   /**
-    * Construct a new Angle of the given magnitude in radians, modulo 2π. Approximate.
-    * @group Constructors
-    */
+   * Construct a new Angle of the given magnitude in radians, modulo 2π. Approximate.
+   * @group Constructors
+   */
   def fromDoubleRadians(rad: Double): Angle =
     fromDoubleDegrees(rad.toDegrees)
 
   /**
-    * Angle forms a commutative group.
-    * @group Typeclass Instances
-    */
+   * Angle forms a commutative group.
+   * @group Typeclass Instances
+   */
   implicit val AngleCommutativeGroup: CommutativeGroup[Angle] =
     new CommutativeGroup[Angle] {
       val empty: Angle = Angle0
@@ -228,23 +228,23 @@ object Angle extends AngleOptics {
     Show.fromToString
 
   /**
-    * Angles are equal if their magnitudes are equal.
-    * @group Typeclass Instances
-    */
+   * Angles are equal if their magnitudes are equal.
+   * @group Typeclass Instances
+   */
   implicit val AngleEqual: Eq[Angle] =
     Eq.fromUniversalEquals
 
   /**
-    * Sorts Angle by magnitude [0, 360) degrees. Not implicit.
-    * @group Typeclass Instances
-    */
+   * Sorts Angle by magnitude [0, 360) degrees. Not implicit.
+   * @group Typeclass Instances
+   */
   val AngleOrder: Order[Angle] =
     Order.by(_.toMicroarcseconds)
 
   /**
-    * Sorts Angle by signed angle, so [-180, 180).  Not implicit.
-    * @group Typeclass Instances
-    */
+   * Sorts Angle by signed angle, so [-180, 180).  Not implicit.
+   * @group Typeclass Instances
+   */
   val SignedAngleOrder: Order[Angle] =
     Order.by(signedMicroarcseconds.get)
 
@@ -259,9 +259,9 @@ object Angle extends AngleOptics {
   }
 
   /**
-    * Integral angle represented as a sum of degrees, arcminutes, arcseconds, milliarcseconds and
-    * microarcseconds. This type is exact and isomorphic to Angle.
-    */
+   * Integral angle represented as a sum of degrees, arcminutes, arcseconds, milliarcseconds and
+   * microarcseconds. This type is exact and isomorphic to Angle.
+   */
   final case class DMS(toAngle: Angle) {
     val (
       degrees: Int,
@@ -281,10 +281,10 @@ object Angle extends AngleOptics {
   }
 
   /**
-    * Construct a new Angle of the given magnitude as a sum of degrees, arcminutes, arcseconds,
-    * milliarcseconds, and microarcseconds. Exact modulo 360°.
-    * @group Constructors
-    */
+   * Construct a new Angle of the given magnitude as a sum of degrees, arcminutes, arcseconds,
+   * milliarcseconds, and microarcseconds. Exact modulo 360°.
+   * @group Constructors
+   */
   def fromDMS(
     degrees:         Int,
     arcminutes:      Int,
@@ -301,9 +301,9 @@ object Angle extends AngleOptics {
     )
 
   /**
-    * Calculate the angle difference or separation between two angles.
-    * The calculation is such that you get the minimal angle in the range [0 .. π]
-    */
+   * Calculate the angle difference or separation between two angles.
+   * The calculation is such that you get the minimal angle in the range [0 .. π]
+   */
   def difference(α: Angle, ϐ: Angle): Angle = {
     import cats.syntax.all._ // To get order syntax
     implicit val order: Order[Angle] = AngleOrder
@@ -316,16 +316,16 @@ object Angle extends AngleOptics {
 trait AngleOptics extends OpticsHelpers { this: Angle.type =>
 
   /**
-    * Microarcseconds, in [0, 360°).
-    * @group Optics
-    */
+   * Microarcseconds, in [0, 360°).
+   * @group Optics
+   */
   lazy val microarcseconds: SplitMono[Angle, Long] =
     SplitMono(_.toMicroarcseconds, Angle.fromMicroarcseconds)
 
   /**
-    * Signed microarcseconds, exact, in [-180°, 180°).
-    * @group Optics
-    */
+   * Signed microarcseconds, exact, in [-180°, 180°).
+   * @group Optics
+   */
   lazy val signedMicroarcseconds: SplitMono[Angle, Long] = {
     lazy val µas360 = Angle.Angle180.toMicroarcseconds * 2L
     microarcseconds.imapB[Long](
@@ -341,82 +341,82 @@ trait AngleOptics extends OpticsHelpers { this: Angle.type =>
     )
 
   /**
-    * Signed decimal milliarcseconds, exact, in [-180°, 180°).
-    * @group Optics
-    */
+   * Signed decimal milliarcseconds, exact, in [-180°, 180°).
+   * @group Optics
+   */
   lazy val signedDecimalMilliarcseconds: SplitMono[Angle, BigDecimal] =
     signedDecimalMicroarcsecondsScaled(3)
 
   /**
-    * Signed decimal arcseconds, exact, in [-180°, 180°).
-    * @group Optics
-    */
+   * Signed decimal arcseconds, exact, in [-180°, 180°).
+   * @group Optics
+   */
   lazy val signedDecimalArcseconds: SplitMono[Angle, BigDecimal] =
     signedDecimalMicroarcsecondsScaled(6)
 
   /**
-    * Milliarcseconds, in [0, 360°).
-    * @group Optics
-    */
+   * Milliarcseconds, in [0, 360°).
+   * @group Optics
+   */
   lazy val milliarcseconds: Wedge[Angle, Int] =
     microarcseconds.scaled(1000L)
 
   /**
-    * Arcseconds, in [0, 360°).
-    * @group Optics
-    */
+   * Arcseconds, in [0, 360°).
+   * @group Optics
+   */
   lazy val arcseconds: Wedge[Angle, Int] =
     microarcseconds.scaled(1000L * 1000L)
 
   /**
-    * Arcminutes, in [0, 360°).
-    * @group Optics
-    */
+   * Arcminutes, in [0, 360°).
+   * @group Optics
+   */
   lazy val arcminutes: Wedge[Angle, Int] =
     microarcseconds.scaled(1000L * 1000L * 60L)
 
   /**
-    * Degrees, in [0, 360).
-    * @group Optics
-    */
+   * Degrees, in [0, 360).
+   * @group Optics
+   */
   lazy val degrees: Wedge[Angle, Int] = microarcseconds.scaled(µasPerDegree)
 
   /**
-    * This angle, rounded down to the nearest HourAngle.
-    * @group Optics
-    */
+   * This angle, rounded down to the nearest HourAngle.
+   * @group Optics
+   */
   lazy val hourAngle: SplitEpi[Angle, HourAngle] =
     SplitEpi(a => HourAngle.microseconds.reverseGet(a.toMicroarcseconds.toLong / 15L), identity)
 
   /**
-    * This angle as an HourAngle, where defined.
-    * @group Optics
-    */
+   * This angle as an HourAngle, where defined.
+   * @group Optics
+   */
   lazy val hourAngleExact: Prism[Angle, HourAngle] =
     Prism((a: Angle) => if (a.toMicroarcseconds % 15L === 0L) Some(hourAngle.get(a)) else None)(
       identity
     )
 
   /**
-    * This angle as an DMS.
-    * @group Optics
-    */
+   * This angle as an DMS.
+   * @group Optics
+   */
   lazy val dms: Iso[Angle, DMS] =
     Iso(DMS(_))(_.toAngle)
 
   /**
-    * String parsed as unsigned DMS.
-    * @see [[lucuma.core.math.parser.AngleParsers]]
-    * @group Optics
-    */
+   * String parsed as unsigned DMS.
+   * @see [[lucuma.core.math.parser.AngleParsers]]
+   * @group Optics
+   */
   lazy val fromStringDMS: Format[String, Angle] =
     Format(AngleParsers.dms.parseExact, dms.get(_).format)
 
   /**
-    * String parsed as signed DMS.
-    * @see [[lucuma.core.math.parser.AngleParsers]]
-    * @group Optics
-    */
+   * String parsed as signed DMS.
+   * @see [[lucuma.core.math.parser.AngleParsers]]
+   * @group Optics
+   */
   lazy val fromStringSignedDMS: Format[String, Angle] =
     Format(fromStringDMS.getOption,
            a =>
@@ -427,61 +427,61 @@ trait AngleOptics extends OpticsHelpers { this: Angle.type =>
 }
 
 /**
-  * Exact hour angles represented as integral microseconds. These values form a commutative group
-  * over addition, where the inverse is reflection around the 0-12h axis. This is a subgroup of the
-  * integral Angles where microarcseconds are evenly divisible by 15.
-  *
-  * Lawful conversion to and from other types/scales is provided by optics defined on the companion
-  * object. Floating-point conversions are provided directly
-  * @see The helpful [[https://en.wikipedia.org/wiki/Hour_angle Wikipedia]] article.
-  */
+ * Exact hour angles represented as integral microseconds. These values form a commutative group
+ * over addition, where the inverse is reflection around the 0-12h axis. This is a subgroup of the
+ * integral Angles where microarcseconds are evenly divisible by 15.
+ *
+ * Lawful conversion to and from other types/scales is provided by optics defined on the companion
+ * object. Floating-point conversions are provided directly
+ * @see The helpful [[https://en.wikipedia.org/wiki/Hour_angle Wikipedia]] article.
+ */
 final class HourAngle private (µas: Long) extends Angle(µas) {
 
   // Sanity checks … should be correct via the companion constructor.
   assert(toMicroarcseconds % 15 === 0, s"Invariant violated. $µas isn't divisible by 15.")
 
   /**
-    * Flip this HourAngle by 12h. This is logically identical to the superclass implementation
-    * and serves only to refine the return type. Exact, invertible.
-    * @group Transformations
-    */
+   * Flip this HourAngle by 12h. This is logically identical to the superclass implementation
+   * and serves only to refine the return type. Exact, invertible.
+   * @group Transformations
+   */
   override def flip: HourAngle =
     this + HourAngle.HourAngle12
 
   /**
-    * Additive inverse of this HourAngle (by mirroring around the 0-12h axis). This is logically
-    * identical to the superclass implementation and serves only to refine the return type. Exact,
-    * invertible.
-    * @group Transformations
-    */
+   * Additive inverse of this HourAngle (by mirroring around the 0-12h axis). This is logically
+   * identical to the superclass implementation and serves only to refine the return type. Exact,
+   * invertible.
+   * @group Transformations
+   */
   override def unary_- : HourAngle =
     HourAngle.fromMicroseconds(-toMicroseconds)
 
   /**
-    * This `HourAngle` in microseconds. Exact.
-    * @group Conversions
-    */
+   * This `HourAngle` in microseconds. Exact.
+   * @group Conversions
+   */
   def toMicroseconds: Long =
     toMicroarcseconds / 15
 
   /**
-    * This `HourAngle` in decimal hours. Approximate.
-    * @group Conversions
-    */
+   * This `HourAngle` in decimal hours. Approximate.
+   * @group Conversions
+   */
   def toDoubleHours: Double =
     toMicroseconds.toDouble / HourAngle.µsPerHour
 
   /**
-    * Sum of this HourAngle and `ha`. Exact, commutative, invertible.
-    * @group Operations
-    */
+   * Sum of this HourAngle and `ha`. Exact, commutative, invertible.
+   * @group Operations
+   */
   def +(ha: HourAngle): HourAngle =
     HourAngle.fromMicroseconds(toMicroseconds + ha.toMicroseconds)
 
   /**
-    * Difference of this HourAngle and `ha`. Exact, invertible.
-    * @group Operations
-    */
+   * Difference of this HourAngle and `ha`. Exact, invertible.
+   * @group Operations
+   */
   def -(ha: HourAngle): HourAngle =
     HourAngle.fromMicroseconds(toMicroseconds - ha.toMicroseconds)
 
@@ -502,9 +502,9 @@ object HourAngle extends HourAngleOptics {
   lazy val HourAngle12: HourAngle = hours.reverseGet(12)
 
   /**
-    * Construct a new Angle of the given magnitude in integral microseconds, modulo 24h. Exact.
-    * @group Constructors
-    */
+   * Construct a new Angle of the given magnitude in integral microseconds, modulo 24h. Exact.
+   * @group Constructors
+   */
   def fromMicroseconds(µs: Long): HourAngle = {
     val µsPer24 = 24L * µsPerHour
     val µsʹ     = ((µs % µsPer24) + µsPer24) % µsPer24
@@ -512,24 +512,24 @@ object HourAngle extends HourAngleOptics {
   }
 
   /**
-    * Construct a new HourAngle of the given magnitude in floating point hours, modulo 24h. Approximate.
-    * @group Constructors
-    */
+   * Construct a new HourAngle of the given magnitude in floating point hours, modulo 24h. Approximate.
+   * @group Constructors
+   */
   def fromDoubleHours(hs: Double): HourAngle =
     fromMicroseconds((hs * µsPerHour).round)
 
   /**
-    * Construct a new HourAngle of the given magnitude in double degrees, modulo 360°. Approximate.
-    * @group Constructors
-    */
+   * Construct a new HourAngle of the given magnitude in double degrees, modulo 360°. Approximate.
+   * @group Constructors
+   */
   def fromDoubleDegrees(deg: Double): HourAngle =
     Angle.hourAngle.get(Angle.fromDoubleDegrees(deg))
 
   /**
-    * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,
-    * milliseconds, and microseconds. Exact modulo 24h.
-    * @group Constructors
-    */
+   * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,
+   * milliseconds, and microseconds. Exact modulo 24h.
+   * @group Constructors
+   */
   def fromHMS(
     hours:        Int,
     minutes:      Int,
@@ -546,9 +546,9 @@ object HourAngle extends HourAngleOptics {
     )
 
   /**
-    * HourAngle forms a commutative group.
-    * @group Typeclass Instances
-    */
+   * HourAngle forms a commutative group.
+   * @group Typeclass Instances
+   */
   implicit val AngleCommutativeGroup: CommutativeGroup[HourAngle] =
     new CommutativeGroup[HourAngle] {
       val empty: HourAngle = HourAngle0
@@ -561,16 +561,16 @@ object HourAngle extends HourAngleOptics {
     Show.fromToString
 
   /**
-    * Angles are equal if their magnitudes are equal.
-    * @group Typeclass Instances
-    */
+   * Angles are equal if their magnitudes are equal.
+   * @group Typeclass Instances
+   */
   implicit val HourAngleEqual: Eq[HourAngle] =
     Eq.by(_.toMicroarcseconds)
 
   /**
-    * Integral hour angle represented as a sum of hours, minutes, seconds, milliseconds, and
-    * microseconds. This type is exact and isomorphic to HourAngle.
-    */
+   * Integral hour angle represented as a sum of hours, minutes, seconds, milliseconds, and
+   * microseconds. This type is exact and isomorphic to HourAngle.
+   */
   final case class HMS(toHourAngle: HourAngle) {
     def toAngle: Angle            = toHourAngle // forget it's an hour angle
     val (
@@ -594,57 +594,57 @@ object HourAngle extends HourAngleOptics {
 trait HourAngleOptics extends OpticsHelpers { this: HourAngle.type =>
 
   /**
-    * This `HourAngle` as an `Angle`.
-    * @group Optics
-    */
+   * This `HourAngle` as an `Angle`.
+   * @group Optics
+   */
   lazy val angle: SplitMono[HourAngle, Angle] = Angle.hourAngle.reverse
 
   /**
-    * This `HourAngle` in microseconds.
-    * @group Optics
-    */
+   * This `HourAngle` in microseconds.
+   * @group Optics
+   */
   lazy val microseconds: SplitMono[HourAngle, Long] =
     SplitMono(_.toMicroseconds, HourAngle.fromMicroseconds)
 
   /**
-    * This `HourAngle` in milliseconds.
-    * @group Optics
-    */
+   * This `HourAngle` in milliseconds.
+   * @group Optics
+   */
   lazy val milliseconds: Wedge[HourAngle, Int] =
     microseconds.scaled(1000L)
 
   /**
-    * This `HourAngle` in seconds.
-    * @group Optics
-    */
+   * This `HourAngle` in seconds.
+   * @group Optics
+   */
   lazy val seconds: Wedge[HourAngle, Int] =
     microseconds.scaled(1000L * 1000L)
 
   /**
-    * This `HourAngle` in minutes.
-    * @group Optics
-    */
+   * This `HourAngle` in minutes.
+   * @group Optics
+   */
   lazy val minutes: Wedge[HourAngle, Int] =
     microseconds.scaled(1000L * 1000L * 60L)
 
   /**
-    * This `HourAngle` in hours.
-    * @group Optics
-    */
+   * This `HourAngle` in hours.
+   * @group Optics
+   */
   lazy val hours: Wedge[HourAngle, Int] =
     microseconds.scaled(1000L * 1000L * 60L * 60L)
 
   /**
-    * This `HourAngle` as an `HMS`.
-    * @group Optics
-    */
+   * This `HourAngle` as an `HMS`.
+   * @group Optics
+   */
   lazy val hms: Iso[HourAngle, HMS] =
     Iso(HMS(_))(_.toHourAngle)
 
   /**
-    * String in HMS as an `HourAngle`/
-    * @group Optics
-    */
+   * String in HMS as an `HourAngle`/
+   * @group Optics
+   */
   lazy val fromStringHMS: Format[String, HourAngle] =
     Format(AngleParsers.hms.parseExact, HMS(_).format)
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Angle.scala
@@ -12,127 +12,125 @@ import lucuma.core.optics._
 import monocle.{ Iso, Prism }
 
 /**
- * Exact angles represented as integral microarcseconds. These values form a commutative group over
- * addition, where the inverse is reflection around the 0-180° axis. The subgroup of angles where
- * integral microarcseconds correspond with clock microseconds (i.e., where they are evenly
- * divisible by 15 microarcseconds) is represented by the HourAgle subtype.
- *
- * Lawful conversion to and from other types/scales is provided by optics defined on the companion
- * object. Floating-point conversions are provided directly
- * @param toMicroarcseconds This angle in microarcseconds. Exact.
- */
+  * Exact angles represented as integral microarcseconds. These values form a commutative group over
+  * addition, where the inverse is reflection around the 0-180° axis. The subgroup of angles where
+  * integral microarcseconds correspond with clock microseconds (i.e., where they are evenly
+  * divisible by 15 microarcseconds) is represented by the HourAgle subtype.
+  *
+  * Lawful conversion to and from other types/scales is provided by optics defined on the companion
+  * object. Floating-point conversions are provided directly
+  * @param toMicroarcseconds This angle in microarcseconds. Exact.
+  */
 sealed class Angle protected (val toMicroarcseconds: Long) {
 
   // Sanity checks … should be correct via the companion constructor.
   assert(toMicroarcseconds >= 0, s"Invariant violated. $toMicroarcseconds is negative.")
-  assert(toMicroarcseconds < 360L * 60L * 60L * 1000L * 1000L,
-         s"Invariant violated. $toMicroarcseconds is >= 360°."
-  )
+  assert(toMicroarcseconds < Angle.µasPer360, s"Invariant violated. $toMicroarcseconds is >= 360°.")
 
   /**
-   * Flip this angle 180°. Equivalent to `mirrorBy(this + Angle90)`. Exact, invertible.
-   * @group Transformations
-   */
+    * Flip this angle 180°. Equivalent to `mirrorBy(this + Angle90)`. Exact, invertible.
+    * @group Transformations
+    */
   def flip: Angle =
     this + Angle.Angle180
 
   /**
-   * Additive inverse of this angle, equivalent to `mirrorBy Angle0`. Exact, invertible.
-   * @group Transformations
-   */
+    * Additive inverse of this angle, equivalent to `mirrorBy Angle0`. Exact, invertible.
+    * @group Transformations
+    */
   def unary_- : Angle =
     Angle.fromMicroarcseconds(-toMicroarcseconds.toLong)
 
   /**
-   * Mirror image of this angle, when the mirror stands at angle `a`; or picture picking up the
-   * circle and flipping it over, around a line drawn from the center going off in direction `a`.
-   * So `(88° mirrorBy 90°) = 92°` for instance, as is `88° mirrorBy 270°` since it's the same
-   * line. This operation is specified completely by the identity `b - a = (a mirrorBy b) - b`.
-   * @group Transformations
-   */
+    * Mirror image of this angle, when the mirror stands at angle `a`; or picture picking up the
+    * circle and flipping it over, around a line drawn from the center going off in direction `a`.
+    * So `(88° mirrorBy 90°) = 92°` for instance, as is `88° mirrorBy 270°` since it's the same
+    * line. This operation is specified completely by the identity `b - a = (a mirrorBy b) - b`.
+    * @group Transformations
+    */
   def mirrorBy(a: Angle): Angle = {
     val Δ = a.toMicroarcseconds - toMicroarcseconds
     Angle.fromMicroarcseconds(toMicroarcseconds + Δ * 2L)
   }
 
   /**
-   * Angle corresponding to the bisection of this Angle.  Approximate, non-invertible.
-   * @group Transformations
-   */
+    * Angle corresponding to the bisection of this Angle.  Approximate, non-invertible.
+    * @group Transformations
+    */
   def bisect: Angle =
     Angle.fromMicroarcseconds(toMicroarcseconds / 2L)
 
   /**
-   * This angle in decimal degrees. Approximate, non-invertible.
-   * @group Conversions
-   */
+    * This angle in decimal degrees. Approximate, non-invertible.
+    * @group Conversions
+    */
   def toDoubleDegrees: Double =
-    toMicroarcseconds.toDouble / (60.0 * 60.0 * 1000.0 * 1000.0)
+    toMicroarcseconds.toDouble / Angle.µasPerDegree.toDouble
 
   /**
-   * This angle in signed decimal degrees. Approximate, non-invertible
-   * @group Conversions
-   */
+    * This angle in signed decimal degrees. Approximate, non-invertible
+    * @group Conversions
+    */
   def toSignedDoubleDegrees: Double =
-    Angle.signedMicroarcseconds.get(this).toDouble / (60.0 * 60.0 * 1000.0 * 1000.0)
+    Angle.signedMicroarcseconds.get(this).toDouble / Angle.µasPerDegree.toDouble
 
   /**
-   * This angle in decimal radian, [0 .. 2π) Approximate, non-invertible
-   * @group Conversions
-   */
+    * This angle in decimal radian, [0 .. 2π) Approximate, non-invertible
+    * @group Conversions
+    */
   def toDoubleRadians: Double =
     toDoubleDegrees.toRadians
 
   /**
-   * This angle in signed decimal radians, [-π .. π) Approximate, non-invertible
-   * @group Conversions
-   */
+    * This angle in signed decimal radians, [-π .. π) Approximate, non-invertible
+    * @group Conversions
+    */
   def toSignedDoubleRadians: Double =
     toSignedDoubleDegrees.toRadians
 
   /**
-   * Sum of this angle and `a`. Exact, commutative, invertible.
-   * @group Operations
-   */
+    * Sum of this angle and `a`. Exact, commutative, invertible.
+    * @group Operations
+    */
   def +(a: Angle): Angle =
     Angle.fromMicroarcseconds(toMicroarcseconds + a.toMicroarcseconds)
 
   /**
-   * Difference of this angle and `a`. Exact, invertible.
-   * @group Operations
-   */
+    * Difference of this angle and `a`. Exact, invertible.
+    * @group Operations
+    */
   def -(a: Angle): Angle =
     Angle.fromMicroarcseconds(toMicroarcseconds - a.toMicroarcseconds)
 
   /**
-   * This angle as an Offset.P. Exact, invertible.
-   *
-   * @group Conversions
-   */
+    * This angle as an Offset.P. Exact, invertible.
+    *
+    * @group Conversions
+    */
   def p: Offset.P =
     Offset.P(this)
 
   /**
-   * This angle as an Offset.Q. Exact, invertible.
-   *
-   * @group Conversions
-   */
+    * This angle as an Offset.Q. Exact, invertible.
+    *
+    * @group Conversions
+    */
   def q: Offset.Q =
     Offset.Q(this)
 
   /**
-   * This angle as an offset in p.  Exact, invertible.
-   *
-   * @group Conversions
-   */
+    * This angle as an offset in p.  Exact, invertible.
+    *
+    * @group Conversions
+    */
   def offsetInP: Offset =
     Offset(p, Offset.Q.Zero)
 
   /**
-   * This angle as an offset in q.  Exact, invertible.
-   *
-   * @group Conversions
-   */
+    * This angle as an offset in q.  Exact, invertible.
+    *
+    * @group Conversions
+    */
   def offsetInQ: Offset =
     Offset(Offset.P.Zero, q)
 
@@ -153,13 +151,22 @@ sealed class Angle protected (val toMicroarcseconds: Long) {
     toMicroarcseconds.toInt
 
   /**
-   * angle difference or separation between two angles in the range [0 .. π]
-   */
+    * angle difference or separation between two angles in the range [0 .. π]
+    */
   def difference(a: Angle): Angle =
     Angle.difference(this, a)
 }
 
 object Angle extends AngleOptics {
+  type Angle180µas = 648000000000L  // 180 * µasPerDegree
+  type Angle360µas = 1296000000000L // 360 * µasPerDegree
+
+  val µasPerDegree: Long = 60L * 60L * 1000L * 1000L
+  val µasPer180: Long    = valueOf[Angle180µas]
+  val µasPer360: Long    = valueOf[Angle360µas]
+
+  assert(Angle.µasPer180 == Angle.µasPerDegree * 180L, "Singleton type Angle180µas is incorrect")
+  assert(Angle.µasPer360 == Angle.µasPerDegree * 360L, "Singleton type Angle360µas is incorrect")
 
   /** @group Constants */
   lazy val Angle0: Angle = degrees.reverseGet(0)
@@ -174,40 +181,41 @@ object Angle extends AngleOptics {
   lazy val Angle270: Angle = degrees.reverseGet(270)
 
   /**
-   * Construct a new Angle of the given magnitude in integral microarcseconds, modulo 360°. Exact.
-   * @group Constructors
-   */
+    * Construct a new Angle of the given magnitude in integral microarcseconds, modulo 360°. Exact.
+    * @group Constructors
+    */
   def fromMicroarcseconds(µas: Long): Angle = {
-    val µasPer360 = 360L * 60L * 60L * 1000L * 1000L
-    val µasʹ      = ((µas % µasPer360) + µasPer360) % µasPer360
+    val µasʹ = ((µas % µasPer360) + µasPer360) % µasPer360
     new Angle(µasʹ)
   }
 
   /**
-   * Construct a new Angle of the given magnitude in double degrees, modulo 360°. Approximate.
-   * @group Constructors
-   */
+    * Construct a new Angle of the given magnitude in double degrees, modulo 360°. Approximate.
+    * @group Constructors
+    */
   def fromDoubleDegrees(ds: Double): Angle =
+    // Changing this to use µasPerDegree changes the precision of the
+    // ImprovedSkyCalc calculations.
     fromMicroarcseconds((ds * 60 * 60 * 1000 * 1000).toLong)
 
   /**
-   * Construct a new Angle of the given magnitude in double arcseconds, modulo 360°. Approximate.
-   * @group Constructors
-   */
+    * Construct a new Angle of the given magnitude in double arcseconds, modulo 360°. Approximate.
+    * @group Constructors
+    */
   def fromDoubleArcseconds(as: Double): Angle =
     fromMicroarcseconds((as * 1000 * 1000).toLong)
 
   /**
-   * Construct a new Angle of the given magnitude in radians, modulo 2π. Approximate.
-   * @group Constructors
-   */
+    * Construct a new Angle of the given magnitude in radians, modulo 2π. Approximate.
+    * @group Constructors
+    */
   def fromDoubleRadians(rad: Double): Angle =
     fromDoubleDegrees(rad.toDegrees)
 
   /**
-   * Angle forms a commutative group.
-   * @group Typeclass Instances
-   */
+    * Angle forms a commutative group.
+    * @group Typeclass Instances
+    */
   implicit val AngleCommutativeGroup: CommutativeGroup[Angle] =
     new CommutativeGroup[Angle] {
       val empty: Angle = Angle0
@@ -220,23 +228,23 @@ object Angle extends AngleOptics {
     Show.fromToString
 
   /**
-   * Angles are equal if their magnitudes are equal.
-   * @group Typeclass Instances
-   */
+    * Angles are equal if their magnitudes are equal.
+    * @group Typeclass Instances
+    */
   implicit val AngleEqual: Eq[Angle] =
     Eq.fromUniversalEquals
 
   /**
-   * Sorts Angle by magnitude [0, 360) degrees. Not implicit.
-   * @group Typeclass Instances
-   */
+    * Sorts Angle by magnitude [0, 360) degrees. Not implicit.
+    * @group Typeclass Instances
+    */
   val AngleOrder: Order[Angle] =
     Order.by(_.toMicroarcseconds)
 
   /**
-   * Sorts Angle by signed angle, so [-180, 180).  Not implicit.
-   * @group Typeclass Instances
-   */
+    * Sorts Angle by signed angle, so [-180, 180).  Not implicit.
+    * @group Typeclass Instances
+    */
   val SignedAngleOrder: Order[Angle] =
     Order.by(signedMicroarcseconds.get)
 
@@ -246,14 +254,14 @@ object Angle extends AngleOptics {
     val ms = (micros / 1000L)                 % 1000L
     val s  = (micros / (1000L * 1000L))       % 60L
     val m  = (micros / (1000L * 1000L * 60L)) % 60L
-    val d  = micros / (1000L * 1000L * 60L * 60L)
+    val d  = micros / µasPerDegree
     (d.toInt, m.toInt, s.toInt, ms.toInt, µs.toInt)
   }
 
   /**
-   * Integral angle represented as a sum of degrees, arcminutes, arcseconds, milliarcseconds and
-   * microarcseconds. This type is exact and isomorphic to Angle.
-   */
+    * Integral angle represented as a sum of degrees, arcminutes, arcseconds, milliarcseconds and
+    * microarcseconds. This type is exact and isomorphic to Angle.
+    */
   final case class DMS(toAngle: Angle) {
     val (
       degrees: Int,
@@ -273,10 +281,10 @@ object Angle extends AngleOptics {
   }
 
   /**
-   * Construct a new Angle of the given magnitude as a sum of degrees, arcminutes, arcseconds,
-   * milliarcseconds, and microarcseconds. Exact modulo 360°.
-   * @group Constructors
-   */
+    * Construct a new Angle of the given magnitude as a sum of degrees, arcminutes, arcseconds,
+    * milliarcseconds, and microarcseconds. Exact modulo 360°.
+    * @group Constructors
+    */
   def fromDMS(
     degrees:         Int,
     arcminutes:      Int,
@@ -289,13 +297,13 @@ object Angle extends AngleOptics {
         milliarcseconds.toLong * 1000 +
         arcseconds.toLong * 1000 * 1000 +
         arcminutes.toLong * 1000 * 1000 * 60 +
-        degrees.toLong * 1000 * 1000 * 60 * 60
+        degrees.toLong * µasPerDegree
     )
 
   /**
-   * Calculate the angle difference or separation between two angles.
-   * The calculation is such that you get the minimal angle in the range [0 .. π]
-   */
+    * Calculate the angle difference or separation between two angles.
+    * The calculation is such that you get the minimal angle in the range [0 .. π]
+    */
   def difference(α: Angle, ϐ: Angle): Angle = {
     import cats.syntax.all._ // To get order syntax
     implicit val order: Order[Angle] = AngleOrder
@@ -308,16 +316,16 @@ object Angle extends AngleOptics {
 trait AngleOptics extends OpticsHelpers { this: Angle.type =>
 
   /**
-   * Microarcseconds, in [0, 360°).
-   * @group Optics
-   */
+    * Microarcseconds, in [0, 360°).
+    * @group Optics
+    */
   lazy val microarcseconds: SplitMono[Angle, Long] =
     SplitMono(_.toMicroarcseconds, Angle.fromMicroarcseconds)
 
   /**
-   * Signed microarcseconds, exact, in [-180°, 180°).
-   * @group Optics
-   */
+    * Signed microarcseconds, exact, in [-180°, 180°).
+    * @group Optics
+    */
   lazy val signedMicroarcseconds: SplitMono[Angle, Long] = {
     lazy val µas360 = Angle.Angle180.toMicroarcseconds * 2L
     microarcseconds.imapB[Long](
@@ -333,82 +341,82 @@ trait AngleOptics extends OpticsHelpers { this: Angle.type =>
     )
 
   /**
-   * Signed decimal milliarcseconds, exact, in [-180°, 180°).
-   * @group Optics
-   */
+    * Signed decimal milliarcseconds, exact, in [-180°, 180°).
+    * @group Optics
+    */
   lazy val signedDecimalMilliarcseconds: SplitMono[Angle, BigDecimal] =
     signedDecimalMicroarcsecondsScaled(3)
 
   /**
-   * Signed decimal arcseconds, exact, in [-180°, 180°).
-   * @group Optics
-   */
+    * Signed decimal arcseconds, exact, in [-180°, 180°).
+    * @group Optics
+    */
   lazy val signedDecimalArcseconds: SplitMono[Angle, BigDecimal] =
     signedDecimalMicroarcsecondsScaled(6)
 
   /**
-   * Milliarcseconds, in [0, 360°).
-   * @group Optics
-   */
+    * Milliarcseconds, in [0, 360°).
+    * @group Optics
+    */
   lazy val milliarcseconds: Wedge[Angle, Int] =
     microarcseconds.scaled(1000L)
 
   /**
-   * Arcseconds, in [0, 360°).
-   * @group Optics
-   */
+    * Arcseconds, in [0, 360°).
+    * @group Optics
+    */
   lazy val arcseconds: Wedge[Angle, Int] =
     microarcseconds.scaled(1000L * 1000L)
 
   /**
-   * Arcminutes, in [0, 360°).
-   * @group Optics
-   */
+    * Arcminutes, in [0, 360°).
+    * @group Optics
+    */
   lazy val arcminutes: Wedge[Angle, Int] =
     microarcseconds.scaled(1000L * 1000L * 60L)
 
   /**
-   * Degrees, in [0, 360).
-   * @group Optics
-   */
-  lazy val degrees: Wedge[Angle, Int] = microarcseconds.scaled(1000L * 1000L * 60L * 60L)
+    * Degrees, in [0, 360).
+    * @group Optics
+    */
+  lazy val degrees: Wedge[Angle, Int] = microarcseconds.scaled(µasPerDegree)
 
   /**
-   * This angle, rounded down to the nearest HourAngle.
-   * @group Optics
-   */
+    * This angle, rounded down to the nearest HourAngle.
+    * @group Optics
+    */
   lazy val hourAngle: SplitEpi[Angle, HourAngle] =
     SplitEpi(a => HourAngle.microseconds.reverseGet(a.toMicroarcseconds.toLong / 15L), identity)
 
   /**
-   * This angle as an HourAngle, where defined.
-   * @group Optics
-   */
+    * This angle as an HourAngle, where defined.
+    * @group Optics
+    */
   lazy val hourAngleExact: Prism[Angle, HourAngle] =
     Prism((a: Angle) => if (a.toMicroarcseconds % 15L === 0L) Some(hourAngle.get(a)) else None)(
       identity
     )
 
   /**
-   * This angle as an DMS.
-   * @group Optics
-   */
+    * This angle as an DMS.
+    * @group Optics
+    */
   lazy val dms: Iso[Angle, DMS] =
     Iso(DMS(_))(_.toAngle)
 
   /**
-   * String parsed as unsigned DMS.
-   * @see [[lucuma.core.math.parser.AngleParsers]]
-   * @group Optics
-   */
+    * String parsed as unsigned DMS.
+    * @see [[lucuma.core.math.parser.AngleParsers]]
+    * @group Optics
+    */
   lazy val fromStringDMS: Format[String, Angle] =
     Format(AngleParsers.dms.parseExact, dms.get(_).format)
 
   /**
-   * String parsed as signed DMS.
-   * @see [[lucuma.core.math.parser.AngleParsers]]
-   * @group Optics
-   */
+    * String parsed as signed DMS.
+    * @see [[lucuma.core.math.parser.AngleParsers]]
+    * @group Optics
+    */
   lazy val fromStringSignedDMS: Format[String, Angle] =
     Format(fromStringDMS.getOption,
            a =>
@@ -419,61 +427,61 @@ trait AngleOptics extends OpticsHelpers { this: Angle.type =>
 }
 
 /**
- * Exact hour angles represented as integral microseconds. These values form a commutative group
- * over addition, where the inverse is reflection around the 0-12h axis. This is a subgroup of the
- * integral Angles where microarcseconds are evenly divisible by 15.
- *
- * Lawful conversion to and from other types/scales is provided by optics defined on the companion
- * object. Floating-point conversions are provided directly
- * @see The helpful [[https://en.wikipedia.org/wiki/Hour_angle Wikipedia]] article.
- */
+  * Exact hour angles represented as integral microseconds. These values form a commutative group
+  * over addition, where the inverse is reflection around the 0-12h axis. This is a subgroup of the
+  * integral Angles where microarcseconds are evenly divisible by 15.
+  *
+  * Lawful conversion to and from other types/scales is provided by optics defined on the companion
+  * object. Floating-point conversions are provided directly
+  * @see The helpful [[https://en.wikipedia.org/wiki/Hour_angle Wikipedia]] article.
+  */
 final class HourAngle private (µas: Long) extends Angle(µas) {
 
   // Sanity checks … should be correct via the companion constructor.
   assert(toMicroarcseconds % 15 === 0, s"Invariant violated. $µas isn't divisible by 15.")
 
   /**
-   * Flip this HourAngle by 12h. This is logically identical to the superclass implementation
-   * and serves only to refine the return type. Exact, invertible.
-   * @group Transformations
-   */
+    * Flip this HourAngle by 12h. This is logically identical to the superclass implementation
+    * and serves only to refine the return type. Exact, invertible.
+    * @group Transformations
+    */
   override def flip: HourAngle =
     this + HourAngle.HourAngle12
 
   /**
-   * Additive inverse of this HourAngle (by mirroring around the 0-12h axis). This is logically
-   * identical to the superclass implementation and serves only to refine the return type. Exact,
-   * invertible.
-   * @group Transformations
-   */
+    * Additive inverse of this HourAngle (by mirroring around the 0-12h axis). This is logically
+    * identical to the superclass implementation and serves only to refine the return type. Exact,
+    * invertible.
+    * @group Transformations
+    */
   override def unary_- : HourAngle =
     HourAngle.fromMicroseconds(-toMicroseconds)
 
   /**
-   * This `HourAngle` in microseconds. Exact.
-   * @group Conversions
-   */
+    * This `HourAngle` in microseconds. Exact.
+    * @group Conversions
+    */
   def toMicroseconds: Long =
     toMicroarcseconds / 15
 
   /**
-   * This `HourAngle` in decimal hours. Approximate.
-   * @group Conversions
-   */
+    * This `HourAngle` in decimal hours. Approximate.
+    * @group Conversions
+    */
   def toDoubleHours: Double =
     toMicroseconds.toDouble / HourAngle.µsPerHour
 
   /**
-   * Sum of this HourAngle and `ha`. Exact, commutative, invertible.
-   * @group Operations
-   */
+    * Sum of this HourAngle and `ha`. Exact, commutative, invertible.
+    * @group Operations
+    */
   def +(ha: HourAngle): HourAngle =
     HourAngle.fromMicroseconds(toMicroseconds + ha.toMicroseconds)
 
   /**
-   * Difference of this HourAngle and `ha`. Exact, invertible.
-   * @group Operations
-   */
+    * Difference of this HourAngle and `ha`. Exact, invertible.
+    * @group Operations
+    */
   def -(ha: HourAngle): HourAngle =
     HourAngle.fromMicroseconds(toMicroseconds - ha.toMicroseconds)
 
@@ -494,9 +502,9 @@ object HourAngle extends HourAngleOptics {
   lazy val HourAngle12: HourAngle = hours.reverseGet(12)
 
   /**
-   * Construct a new Angle of the given magnitude in integral microseconds, modulo 24h. Exact.
-   * @group Constructors
-   */
+    * Construct a new Angle of the given magnitude in integral microseconds, modulo 24h. Exact.
+    * @group Constructors
+    */
   def fromMicroseconds(µs: Long): HourAngle = {
     val µsPer24 = 24L * µsPerHour
     val µsʹ     = ((µs % µsPer24) + µsPer24) % µsPer24
@@ -504,24 +512,24 @@ object HourAngle extends HourAngleOptics {
   }
 
   /**
-   * Construct a new HourAngle of the given magnitude in floating point hours, modulo 24h. Approximate.
-   * @group Constructors
-   */
+    * Construct a new HourAngle of the given magnitude in floating point hours, modulo 24h. Approximate.
+    * @group Constructors
+    */
   def fromDoubleHours(hs: Double): HourAngle =
     fromMicroseconds((hs * µsPerHour).round)
 
   /**
-   * Construct a new HourAngle of the given magnitude in double degrees, modulo 360°. Approximate.
-   * @group Constructors
-   */
+    * Construct a new HourAngle of the given magnitude in double degrees, modulo 360°. Approximate.
+    * @group Constructors
+    */
   def fromDoubleDegrees(deg: Double): HourAngle =
     Angle.hourAngle.get(Angle.fromDoubleDegrees(deg))
 
   /**
-   * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,
-   * milliseconds, and microseconds. Exact modulo 24h.
-   * @group Constructors
-   */
+    * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,
+    * milliseconds, and microseconds. Exact modulo 24h.
+    * @group Constructors
+    */
   def fromHMS(
     hours:        Int,
     minutes:      Int,
@@ -538,9 +546,9 @@ object HourAngle extends HourAngleOptics {
     )
 
   /**
-   * HourAngle forms a commutative group.
-   * @group Typeclass Instances
-   */
+    * HourAngle forms a commutative group.
+    * @group Typeclass Instances
+    */
   implicit val AngleCommutativeGroup: CommutativeGroup[HourAngle] =
     new CommutativeGroup[HourAngle] {
       val empty: HourAngle = HourAngle0
@@ -553,16 +561,16 @@ object HourAngle extends HourAngleOptics {
     Show.fromToString
 
   /**
-   * Angles are equal if their magnitudes are equal.
-   * @group Typeclass Instances
-   */
+    * Angles are equal if their magnitudes are equal.
+    * @group Typeclass Instances
+    */
   implicit val HourAngleEqual: Eq[HourAngle] =
     Eq.by(_.toMicroarcseconds)
 
   /**
-   * Integral hour angle represented as a sum of hours, minutes, seconds, milliseconds, and
-   * microseconds. This type is exact and isomorphic to HourAngle.
-   */
+    * Integral hour angle represented as a sum of hours, minutes, seconds, milliseconds, and
+    * microseconds. This type is exact and isomorphic to HourAngle.
+    */
   final case class HMS(toHourAngle: HourAngle) {
     def toAngle: Angle            = toHourAngle // forget it's an hour angle
     val (
@@ -586,57 +594,57 @@ object HourAngle extends HourAngleOptics {
 trait HourAngleOptics extends OpticsHelpers { this: HourAngle.type =>
 
   /**
-   * This `HourAngle` as an `Angle`.
-   * @group Optics
-   */
+    * This `HourAngle` as an `Angle`.
+    * @group Optics
+    */
   lazy val angle: SplitMono[HourAngle, Angle] = Angle.hourAngle.reverse
 
   /**
-   * This `HourAngle` in microseconds.
-   * @group Optics
-   */
+    * This `HourAngle` in microseconds.
+    * @group Optics
+    */
   lazy val microseconds: SplitMono[HourAngle, Long] =
     SplitMono(_.toMicroseconds, HourAngle.fromMicroseconds)
 
   /**
-   * This `HourAngle` in milliseconds.
-   * @group Optics
-   */
+    * This `HourAngle` in milliseconds.
+    * @group Optics
+    */
   lazy val milliseconds: Wedge[HourAngle, Int] =
     microseconds.scaled(1000L)
 
   /**
-   * This `HourAngle` in seconds.
-   * @group Optics
-   */
+    * This `HourAngle` in seconds.
+    * @group Optics
+    */
   lazy val seconds: Wedge[HourAngle, Int] =
     microseconds.scaled(1000L * 1000L)
 
   /**
-   * This `HourAngle` in minutes.
-   * @group Optics
-   */
+    * This `HourAngle` in minutes.
+    * @group Optics
+    */
   lazy val minutes: Wedge[HourAngle, Int] =
     microseconds.scaled(1000L * 1000L * 60L)
 
   /**
-   * This `HourAngle` in hours.
-   * @group Optics
-   */
+    * This `HourAngle` in hours.
+    * @group Optics
+    */
   lazy val hours: Wedge[HourAngle, Int] =
     microseconds.scaled(1000L * 1000L * 60L * 60L)
 
   /**
-   * This `HourAngle` as an `HMS`.
-   * @group Optics
-   */
+    * This `HourAngle` as an `HMS`.
+    * @group Optics
+    */
   lazy val hms: Iso[HourAngle, HMS] =
     Iso(HMS(_))(_.toHourAngle)
 
   /**
-   * String in HMS as an `HourAngle`/
-   * @group Optics
-   */
+    * String in HMS as an `HourAngle`/
+    * @group Optics
+    */
   lazy val fromStringHMS: Format[String, HourAngle] =
     Format(AngleParsers.hms.parseExact, HMS(_).format)
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/Parallax.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Parallax.scala
@@ -17,12 +17,12 @@ import spire.math.Rational
 import spire.std.long._
 
 /**
-  * Parallax stored as microarcseconds
-  * Normally parallax is expressed in milliarcseconds but simbad reports them
-  * with a higher precision thus using microarcseconds gives us enough space.
-  * Parallax values need to be in the interval [0°, 180°].
-  * 180° is a theoretical limit - actual astronomical values will be very small.
-  */
+ * Parallax stored as microarcseconds
+ * Normally parallax is expressed in milliarcseconds but simbad reports them
+ * with a higher precision thus using microarcseconds gives us enough space.
+ * Parallax values need to be in the interval [0°, 180°].
+ * 180° is a theoretical limit - actual astronomical values will be very small.
+ */
 sealed abstract case class Parallax protected (
   μas: Quantity[Parallax.LongParallaxμas, MicroArcSecond]
 ) {
@@ -37,9 +37,9 @@ object Parallax extends ParallaxOptics {
   type LongParallaxμas = Long Refined Parallaxμas
 
   /**
-    * The `No parallax`
-    * @group Constructors
-    */
+   * The `No parallax`
+   * @group Constructors
+   */
   val Zero: Parallax = applyUnsafe(0L)
 
   // Internal unbounded constructor
@@ -54,11 +54,11 @@ object Parallax extends ParallaxOptics {
     Order.by(_.μas)
 
   /**
-    * Construct a new Parallax of the given magnitude in integral microarcseconds. Exact.
-    * Finds the normalized signed angle for the microarcseconds, then takes
-    * the absolute value.
-    * @group Constructors
-    */
+   * Construct a new Parallax of the given magnitude in integral microarcseconds. Exact.
+   * Finds the normalized signed angle for the microarcseconds, then takes
+   * the absolute value.
+   * @group Constructors
+   */
   def fromMicroarcseconds(μas: Long): Parallax =
     applyUnsafe(Angle.signedMicroarcseconds.normalize(μas).abs)
 }
@@ -66,16 +66,16 @@ object Parallax extends ParallaxOptics {
 sealed trait ParallaxOptics {
 
   /**
-    * This `Parallax` in microarcseconds. modulo 180°.
-    */
+   * This `Parallax` in microarcseconds. modulo 180°.
+   */
   lazy val microarcseconds: SplitMono[Parallax, Long] =
     SplitMono(_.μas.value, Parallax.fromMicroarcseconds)
 
   lazy val μas: SplitMono[Parallax, Long] = microarcseconds
 
   /**
-    * This `Parallax` as in milliarcseconds.
-    */
+   * This `Parallax` as in milliarcseconds.
+   */
   lazy val milliarcseconds: SplitMono[Parallax, BigDecimal] =
     microarcseconds
       .imapB(_.underlying.movePointRight(3).longValue,

--- a/modules/core/shared/src/main/scala/lucuma/core/math/Parallax.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Parallax.scala
@@ -33,7 +33,7 @@ sealed abstract case class Parallax protected (
 }
 
 object Parallax extends ParallaxOptics {
-  type Parallaxμas     = Interval.Closed[0, 648000000000L]
+  type Parallaxμas     = Interval.Closed[0, Angle.Angle180µas]
   type LongParallaxμas = Long Refined Parallaxμas
 
   /**

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ParallaxSpec.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ParallaxSpec.scala
@@ -24,7 +24,7 @@ final class ParallaxSpec extends CatsSuite {
 
   test("fromMicroarcseconds") {
     def toμas(deg: Int, μas: Int = 0): Long =
-      deg.toLong * 60L * 60L * 1000L * 1000L + μas.toLong
+      deg.toLong * Angle.µasPerDegree + μas.toLong
     def from(deg:  Int, μas: Int = 0)       =
       Parallax.fromMicroarcseconds(toμas(deg, μas)).μas.value.value
     from(12) shouldEqual toμas(12)


### PR DESCRIPTION
Based on a comment by Rob in PR #244 about creating types to eliminate some Magic Numbers when creating refined types. 