### PR TITLE
Fix ArbGid capitalization

### DIFF
--- a/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbGid.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbGid.scala
@@ -11,10 +11,10 @@ import eu.timepit.refined.scalacheck.numeric._
 
 trait ArbGid {
 
-  implicit def ArbGid[A](implicit ev: Gid[A]): Arbitrary[A] =
+  implicit def arbGid[A](implicit ev: Gid[A]): Arbitrary[A] =
     Arbitrary(arbitrary[PosLong].map(ev.isoPosLong.reverseGet))
 
-  implicit def CogGid[A](implicit ev: Gid[A]): Cogen[A] =
+  implicit def cogGid[A](implicit ev: Gid[A]): Cogen[A] =
     Cogen[Long].contramap(ev.isoPosLong.get(_).value)
 
 }


### PR DESCRIPTION
A minuscule change, but it something that I've wasted time on twice now.  `ArbGid` containing `ArbGid` makes it so that 

```
import lucuma.core.util.arb.ArbGid
```

followed by

```
import ArbGid._
```

prevents the `implicit def ArbGid` definition from being seen by the implicit lookup.
