### PR TITLE
Allow pattern-match parsing for Ids.

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/WithId.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/WithId.scala
@@ -32,5 +32,8 @@ trait WithId {
 
     /** Convenience method to construct from a String */
     def parse(s: String): Option[Id] = GidId.fromString.getOption(s)
+
+    /** Allow pattern match style parsing */
+    def unapply[T](s: String): Option[Id] = parse(s)
   }
 }


### PR DESCRIPTION
When interfacing with JS libraries, in particular the drag'n'drop library we use, ids are passed back and forth as strings and there are situations where we have to figure out the type of objects based on their stringified `Id`.

The `unapply` method comes very handy for this, allowing us to do things like:

``` scala
string match {
  case Target.Id(targetId) => ... /* targetId is a Target.Id here */
  case Asterism.Id(asterismId) => ... /* asterismId is an Asterism.Id here */
  ...
}
```