### PR TITLE
remove cats-effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import sbtcrossproject.CrossType
 
 lazy val attoVersion                 = "0.9.2"
 lazy val catsVersion                 = "2.4.2"
-lazy val catsEffectVersion           = "2.4.0"
 lazy val kindProjectorVersion        = "0.11.3"
 lazy val monocleVersion              = "2.1.0"
 lazy val catsTestkitScalaTestVersion = "2.1.2"
@@ -40,7 +39,6 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "org.tpolecat"               %%% "atto-core"                  % attoVersion,
       "org.tpolecat"               %%% "atto-refined"               % attoVersion,
       "org.typelevel"              %%% "cats-core"                  % catsVersion,
-      "org.typelevel"              %%% "cats-effect"                % catsEffectVersion,
       "com.github.julien-truffaut" %%% "monocle-core"               % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-macro"              % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-state"              % monocleVersion,

--- a/modules/core/shared/src/main/scala/lucuma/core/model/LocalObservingNight.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/LocalObservingNight.scala
@@ -5,7 +5,6 @@ package lucuma.core.model
 
 import cats._
 import cats.data.Validated
-import cats.effect.Sync
 import cats.syntax.all._
 import lucuma.core.enum.Site
 import java.time._
@@ -114,15 +113,6 @@ object LocalObservingNight extends LocalObservingNightOptics {
    */
   def fromSiteAndInstant(s: Site, i: Instant): LocalObservingNight =
     fromZonedDateTime(ZonedDateTime.ofInstant(i, s.timezone))
-
-  /**
-   * Returns a program in M that computes the LocalObservingNight for the
-   * instant it is executed.
-   *
-   * @group Constructors
-   */
-  def current[M[_]: Sync]: M[LocalObservingNight] =
-    Sync[M].delay(LocalDateTime.now).map(fromLocalDateTime)
 
   /** Parse a LocalObservingNight like `20180307` from a String, if possible. */
   def fromString(s: String): Option[LocalObservingNight] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ObservingNight.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ObservingNight.scala
@@ -8,8 +8,6 @@ import lucuma.core.math.Interval
 import lucuma.core.enum.TwilightType
 
 import cats._
-import cats.effect.Sync
-import cats.syntax.all._
 import java.time._
 import monocle.Lens
 import monocle.macros.GenLens
@@ -91,15 +89,6 @@ object ObservingNight extends ObservingNightOptics {
    */
   def fromSiteAndInstant(s: Site, i: Instant): ObservingNight =
     ObservingNight(s, LocalObservingNight.fromSiteAndInstant(s, i))
-
-  /**
-   * Returns a program in M that computes the ObservingNight for the instant it
-   * is executed.
-   *
-   * @group Constructors
-   */
-  def current[M[_]: Sync](s: Site): M[ObservingNight] =
-    LocalObservingNight.current.map(_.atSite(s))
 
   /** @group Typeclass Instances. */
   implicit val ShowObservingNight: Show[ObservingNight] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Semester.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Semester.scala
@@ -4,7 +4,6 @@
 package lucuma.core.model
 
 import cats.{ Order, Show }
-import cats.effect.IO
 import lucuma.core.enum.{ Half, Site }
 import lucuma.core.model.parser.SemesterParsers
 import lucuma.core.syntax.parser._
@@ -119,10 +118,6 @@ object Semester {
   /** Semester for the zoned date and time of the given Site and Instant. */
   def fromSiteAndInstant(s: Site, i: Instant): Semester =
     fromZonedDateTime(ZonedDateTime.ofInstant(i, s.timezone))
-
-  /** Current semester. */
-  def current(s: Site): IO[Semester] =
-    IO(LocalDateTime.now(s.timezone)).map(fromLocalDateTime)
 
   /** Parse a full-year Semester like `2009A` from a String, if possible. */
   def fromString(s: String): Option[Semester] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/TwilightBoundedNight.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/TwilightBoundedNight.scala
@@ -9,8 +9,6 @@ import lucuma.core.enum.TwilightType
 import lucuma.core.math.skycalc.TwilightCalc
 
 import cats.{ Order, Show }
-import cats.effect.Sync
-import cats.syntax.all._
 
 import java.time.Instant
 import java.time.LocalDate
@@ -192,15 +190,6 @@ object TwilightBoundedNight extends TwilightBoundedNightOptics {
     i:            Instant
   ): TwilightBoundedNight =
     fromTwilightTypeAndSiteAndInstant(twilightType, s, i).get
-
-  /**
-   * Returns a program in M that computes a [[TwilightBoundedNight]]
-   * corresponding to the observing night for the instant it is executed.
-   *
-   * @group Constructors
-   */
-  def current[M[_]: Sync](twilightType: TwilightType, s: Site): M[Option[TwilightBoundedNight]] =
-    ObservingNight.current(s).map(_.twilightBounded(twilightType))
 
   /** @group Typeclass Instances. */
   implicit val ShowTwilightBoundedNight: Show[TwilightBoundedNight] =

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Timestamp.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Timestamp.scala
@@ -5,7 +5,6 @@ package lucuma.core.util
 
 import cats._
 import cats.syntax.all._
-import cats.effect.IO
 import lucuma.core.optics.Format
 import java.time.{ Instant, ZonedDateTime }
 import java.time.ZoneOffset.UTC
@@ -106,16 +105,6 @@ object Timestamp {
 
   val instant: Format[Instant, Timestamp] =
     Format[Instant, Timestamp](fromInstant, _.toInstant)
-
-  /** Creates a Timestamp representing the current time, truncated to the
-    * last integral number of microseconds.
-    *
-    * @group Constructors
-    */
-  def now: IO[Timestamp] =
-    IO {
-      unsafeFromInstant(Instant.now())
-    }
 
   /** Creates a Timestamp representing the current time using milliseconds
     * from the Java time epoch.


### PR DESCRIPTION
This removes core's dependency on Cats-Effect, which frees up downstream projects to upgrade to CE3 at their leisure (rather than forcing the upgrade). It was only used for a few convenience methods that needed to look at the clock, and these are easy enough to do inline when needed.