### PR TITLE
Change GMOS Instrument enum tags

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/Instrument.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/Instrument.scala
@@ -9,37 +9,55 @@ import lucuma.core.util.Enumerated
 
 /**
  * Enumerated type for instruments.
- * @group Enumerations (Generated)
+ *
+ * @group Enumerations
  */
 sealed abstract class Instrument(
-  val tag: String,
+  val tag:       String,
   val shortName: String,
-  val longName: String,
-  val obsolete: Boolean
+  val longName:  String,
+  val obsolete:  Boolean
 ) extends Product with Serializable
 
 object Instrument {
 
-  /** @group Constructors */ case object Phoenix extends Instrument("Phoenix", "Phoenix", "Phoenix", false)
-  /** @group Constructors */ case object Michelle extends Instrument("Michelle", "Michelle", "Michelle", false)
-  /** @group Constructors */ case object Gnirs extends Instrument("Gnirs", "GNIRS", "GNIRS", false)
-  /** @group Constructors */ case object Niri extends Instrument("Niri", "NIRI", "NIRI", false)
-  /** @group Constructors */ case object Trecs extends Instrument("Trecs", "TReCS", "TReCS", false)
-  /** @group Constructors */ case object Nici extends Instrument("Nici", "NICI", "NICI", false)
-  /** @group Constructors */ case object Nifs extends Instrument("Nifs", "NIFS", "NIFS", false)
-  /** @group Constructors */ case object Gpi extends Instrument("Gpi", "GPI", "GPI", false)
-  /** @group Constructors */ case object Gsaoi extends Instrument("Gsaoi", "GSAOI", "GSAOI", false)
-  /** @group Constructors */ case object GmosS extends Instrument("GmosS", "GMOS-S", "GMOS South", false)
-  /** @group Constructors */ case object AcqCam extends Instrument("AcqCam", "AcqCam", "Acquisition Camera", false)
-  /** @group Constructors */ case object GmosN extends Instrument("GmosN", "GMOS-N", "GMOS North", false)
-  /** @group Constructors */ case object Bhros extends Instrument("Bhros", "bHROS", "bHROS", true)
-  /** @group Constructors */ case object Visitor extends Instrument("Visitor", "Visitor Instrument", "Visitor Instrument", false)
+  /** @group Constructors */ case object AcqCam     extends Instrument("AcqCam", "AcqCam", "Acquisition Camera", false)
+  /** @group Constructors */ case object Bhros      extends Instrument("Bhros", "bHROS", "bHROS", true)
   /** @group Constructors */ case object Flamingos2 extends Instrument("Flamingos2", "Flamingos2", "Flamingos 2", false)
-  /** @group Constructors */ case object Ghost extends Instrument("Ghost", "GHOST", "GHOST", false)
+  /** @group Constructors */ case object Ghost      extends Instrument("Ghost", "GHOST", "GHOST", false)
+  /** @group Constructors */ case object GmosNorth  extends Instrument("GmosNorth", "GMOS-N", "GMOS North", false)
+  /** @group Constructors */ case object GmosSouth  extends Instrument("GmosSouth", "GMOS-S", "GMOS South", false)
+  /** @group Constructors */ case object Gnirs      extends Instrument("Gnirs", "GNIRS", "GNIRS", false)
+  /** @group Constructors */ case object Gpi        extends Instrument("Gpi", "GPI", "GPI", false)
+  /** @group Constructors */ case object Gsaoi      extends Instrument("Gsaoi", "GSAOI", "GSAOI", false)
+  /** @group Constructors */ case object Michelle   extends Instrument("Michelle", "Michelle", "Michelle", false)
+  /** @group Constructors */ case object Nici       extends Instrument("Nici", "NICI", "NICI", false)
+  /** @group Constructors */ case object Nifs       extends Instrument("Nifs", "NIFS", "NIFS", false)
+  /** @group Constructors */ case object Niri       extends Instrument("Niri", "NIRI", "NIRI", false)
+  /** @group Constructors */ case object Phoenix    extends Instrument("Phoenix", "Phoenix", "Phoenix", false)
+  /** @group Constructors */ case object Trecs      extends Instrument("Trecs", "TReCS", "TReCS", false)
+  /** @group Constructors */ case object Visitor    extends Instrument("Visitor", "Visitor Instrument", "Visitor Instrument", false)
 
   /** All members of Instrument, in canonical order. */
   val all: List[Instrument] =
-    List(Phoenix, Michelle, Gnirs, Niri, Trecs, Nici, Nifs, Gpi, Gsaoi, GmosS, AcqCam, GmosN, Bhros, Visitor, Flamingos2, Ghost)
+    List(
+      AcqCam,
+      Bhros,
+      Flamingos2,
+      Ghost,
+      GmosNorth,
+      GmosSouth,
+      Gnirs,
+      Gpi,
+      Gsaoi,
+      Michelle,
+      Nici,
+      Nifs,
+      Niri,
+      Phoenix,
+      Trecs,
+      Visitor
+    )
 
   /** Select the member of Instrument with the given tag, if any. */
   def fromTag(s: String): Option[Instrument] =
@@ -52,8 +70,12 @@ object Instrument {
   /** @group Typeclass Instances */
   implicit val InstrumentEnumerated: Enumerated[Instrument] =
     new Enumerated[Instrument] {
-      def all = Instrument.all
-      def tag(a: Instrument) = a.tag
+      def all: List[Instrument] =
+        Instrument.all
+
+      def tag(a: Instrument): String =
+        a.tag
+
       override def unsafeFromTag(s: String): Instrument =
         Instrument.unsafeFromTag(s)
     }


### PR DESCRIPTION
Any objection to using `GmosNorth` and `GmosSouth` as the GMOS tags instead of `GmosN` and `GmosS`?  That's the only substantive change here.  I'd like to use the instrument tag in forming GraphQL type names and, say, `GmosNorthFilter` sits better with me than `GmosNFilter`.