### PR TITLE
Add inactive obs statuses

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/ObsStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/ObsStatus.scala
@@ -11,18 +11,32 @@ import lucuma.core.util.Display
 sealed abstract class ObsStatus(val label: String) extends Product with Serializable
 
 object ObsStatus {
-  case object New       extends ObsStatus("New")
-  case object Included  extends ObsStatus("Included")
-  case object Proposed  extends ObsStatus("Proposed")
-  case object Approved  extends ObsStatus("Approved")
-  case object ForReview extends ObsStatus("For Review")
-  case object Ready     extends ObsStatus("Ready")
-  case object Ongoing   extends ObsStatus("Ongoing")
-  case object Observed  extends ObsStatus("Observed")
+  case object New             extends ObsStatus("New")
+  case object Included        extends ObsStatus("Included")
+  case object Proposed        extends ObsStatus("Proposed")
+  case object Approved        extends ObsStatus("Approved")
+  case object ForReview       extends ObsStatus("For Review")
+  case object Ready           extends ObsStatus("Ready")
+  case object Ongoing         extends ObsStatus("Ongoing")
+  case object InactiveReady   extends ObsStatus("Inactive (Ready)")
+  case object InactiveOngoing extends ObsStatus("Inactive (Ongoing)")
+  case object Observed        extends ObsStatus("Observed")
 
   /** @group Typeclass Instances */
   implicit val ObsStatusEnumerated: Enumerated[ObsStatus] =
-    Enumerated.of(New, Included, Proposed, Approved, ForReview, Ready, Ongoing, Observed)
+    Enumerated.of(
+      New,
+      Included,
+      Proposed,
+      Approved,
+      ForReview,
+      Ready,
+      Ongoing,
+      InactiveReady,
+      InactiveOngoing,
+      Observed
+    )
 
-  implicit val ObsStatusDisplay: Display[ObsStatus] = Display.byShortName(_.label)
+  implicit val ObsStatusDisplay: Display[ObsStatus] =
+    Display.byShortName(_.label)
 }


### PR DESCRIPTION
From the inception document:

> There is a pull-down menu that shows the current status, and with appropriate permissions, allows changing the status.  Each observation may also be separately marked as either "Active'' or "Inactive'' (the vertical toggle switch on the right side of the badge) which allows PIs to prevent or halt execution of "Ready'' or "Ongoing'' observations while retaining their status information.

The description seems to make the active vs. inactive state apply only to `Ready` and `Ongoing` observations status options.  If that's the case, we should add two new observation statuses to reflect whether the observation is active when otherwise in `Ready` or `Ongoing`.  That's what this PR would accomplish.

That said, I'm not sure if this is the intent.  Should it be possible to mark an observation `Inactive` regardless of its observation status?  For example, a `ForReview` but `Inactive` observation or an `Observed` and yet `Active` observation?