### PR TITLE
ObsActiveStatus

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/ObsActiveStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/ObsActiveStatus.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.`enum`
+
+import lucuma.core.util.Enumerated
+import lucuma.core.util.Display
+import monocle.Iso
+
+/**
+ * Determines whether an observation should be considered active.  It, for
+ * example, "allows PIs to prevent or halt execution of "Ready'' or "Ongoing''
+ * observations while retaining their status information".
+ */
+sealed abstract class ObsActiveStatus(val label: String, val toBoolean: Boolean) extends Product with Serializable {
+
+  def fold[A](active: => A, inactive: => A): A =
+    this match {
+      case ObsActiveStatus.Active   => active
+      case ObsActiveStatus.Inactive => inactive
+    }
+
+}
+
+object ObsActiveStatus {
+
+  case object Active   extends ObsActiveStatus("Active", true)
+  case object Inactive extends ObsActiveStatus("Inactive", false)
+
+  /** @group Typeclass Instances */
+  implicit val EnumeratedObsActiveStatus: Enumerated[ObsActiveStatus] =
+    Enumerated.of(
+      Active,
+      Inactive
+    )
+
+  implicit val DisplayObsActiveStatus: Display[ObsActiveStatus] =
+    Display.byShortName(_.label)
+
+  val FromBoolean: Iso[Boolean, ObsActiveStatus] =
+    Iso[Boolean, ObsActiveStatus](b => if (b) Active else Inactive)(_.toBoolean)
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/ObsStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/ObsStatus.scala
@@ -11,16 +11,14 @@ import lucuma.core.util.Display
 sealed abstract class ObsStatus(val label: String) extends Product with Serializable
 
 object ObsStatus {
-  case object New             extends ObsStatus("New")
-  case object Included        extends ObsStatus("Included")
-  case object Proposed        extends ObsStatus("Proposed")
-  case object Approved        extends ObsStatus("Approved")
-  case object ForReview       extends ObsStatus("For Review")
-  case object Ready           extends ObsStatus("Ready")
-  case object Ongoing         extends ObsStatus("Ongoing")
-  case object InactiveReady   extends ObsStatus("Inactive (Ready)")
-  case object InactiveOngoing extends ObsStatus("Inactive (Ongoing)")
-  case object Observed        extends ObsStatus("Observed")
+  case object New       extends ObsStatus("New")
+  case object Included  extends ObsStatus("Included")
+  case object Proposed  extends ObsStatus("Proposed")
+  case object Approved  extends ObsStatus("Approved")
+  case object ForReview extends ObsStatus("For Review")
+  case object Ready     extends ObsStatus("Ready")
+  case object Ongoing   extends ObsStatus("Ongoing")
+  case object Observed  extends ObsStatus("Observed")
 
   /** @group Typeclass Instances */
   implicit val ObsStatusEnumerated: Enumerated[ObsStatus] =
@@ -32,8 +30,6 @@ object ObsStatus {
       ForReview,
       Ready,
       Ongoing,
-      InactiveReady,
-      InactiveOngoing,
       Observed
     )
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/ObsStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/ObsStatus.scala
@@ -11,18 +11,32 @@ import lucuma.core.util.Display
 sealed abstract class ObsStatus(val label: String) extends Product with Serializable
 
 object ObsStatus {
-  case object New       extends ObsStatus("New")
-  case object Included  extends ObsStatus("Included")
-  case object Proposed  extends ObsStatus("Proposed")
-  case object Approved  extends ObsStatus("Approved")
-  case object ForReview extends ObsStatus("For Review")
-  case object Ready     extends ObsStatus("Ready")
-  case object Ongoing   extends ObsStatus("Ongoing")
-  case object Observed  extends ObsStatus("Observed")
+  case object New             extends ObsStatus("New")
+  case object Included        extends ObsStatus("Included")
+  case object Proposed        extends ObsStatus("Proposed")
+  case object Approved        extends ObsStatus("Approved")
+  case object ForReview       extends ObsStatus("For Review")
+  case object Ready           extends ObsStatus("Ready")
+  case object Ongoing         extends ObsStatus("Ongoing")
+  case object InactiveReady   extends ObsStatus("Inactive (Ready)")
+  case object InactiveOngoing extends ObsStatus("Inactive (Ongoing)")
+  case object Observed        extends ObsStatus("Observed")
 
   /** @group Typeclass Instances */
   implicit val ObsStatusEnumerated: Enumerated[ObsStatus] =
-    Enumerated.of(New, Included, Proposed, Approved, ForReview, Ready, Ongoing, Observed)
+    Enumerated.of(
+      New,
+      Included,
+      Proposed,
+      Approved,
+      ForReview,
+      Ready,
+      Ongoing,
+      InactiveReady,
+      InactiveOngoing,
+      Observed
+    )
 
-  implicit val ObsStatusDisplay: Display[ObsStatus] = Display.byShortName(_.label)
+  implicit val ObsStatusDisplay: Display[ObsStatus] =
+    Display.byShortName(_.label)
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/enum/ObsActiveSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enum/ObsActiveSuite.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.`enum`
+
+import cats.kernel.laws.discipline.OrderTests
+import monocle.law.discipline.IsoTests
+import munit.DisciplineSuite
+
+final class ObsActiveSuite extends DisciplineSuite {
+
+  import lucuma.core.util.arb.ArbEnumerated._
+
+  checkAll("Order[ObsActiveStatus]", OrderTests[ObsActiveStatus].order)
+  checkAll("Iso[ObsActiveStatus]", IsoTests(ObsActiveStatus.FromBoolean))
+
+}


### PR DESCRIPTION
A second attempt to satisfy the model requirements of this part of the inception document:

> There is a pull-down menu that shows the current status, and with appropriate permissions, allows changing the status. Each observation may also be separately marked as either "Active'' or "Inactive'' (the vertical toggle switch on the right side of the badge) which allows PIs to prevent or halt execution of "Ready'' or "Ongoing'' observations while retaining their status information.

Adds an `ObsActiveStatus`, for want of a better name.