### PR TITLE
Rename Ifu enums to avoid confusions

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/GmosNorthFpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/GmosNorthFpu.scala
@@ -35,13 +35,13 @@ object GmosNorthFpu {
   /** @group Constructors */ case object LongSlit_1_50 extends GmosNorthFpu("LongSlit_1_50", "1.5\"", "Longslit 1.50 arcsec", Some(Angle.fromDoubleArcseconds(1.50)), Angle.fromDoubleArcseconds(0.000))
   /** @group Constructors */ case object LongSlit_2_00 extends GmosNorthFpu("LongSlit_2_00", "2.0\"", "Longslit 2.00 arcsec", Some(Angle.fromDoubleArcseconds(2.00)), Angle.fromDoubleArcseconds(0.000))
   /** @group Constructors */ case object LongSlit_5_00 extends GmosNorthFpu("LongSlit_5_00", "5.0\"", "Longslit 5.00 arcsec", Some(Angle.fromDoubleArcseconds(5.00)), Angle.fromDoubleArcseconds(0.000))
-  /** @group Constructors */ case object Ifu1 extends GmosNorthFpu("Ifu1", "IFU-2", "IFU 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(33.500))
-  /** @group Constructors */ case object Ifu2 extends GmosNorthFpu("Ifu2", "IFU-B", "IFU Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(31.750))
-  /** @group Constructors */ case object Ifu3 extends GmosNorthFpu("Ifu3", "IFU-R", "IFU Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(35.250))
+  /** @group Constructors */ case object Ifu2 extends GmosNorthFpu("Ifu2", "IFU-2", "IFU 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(33.500))
+  /** @group Constructors */ case object IfuBlue extends GmosNorthFpu("IfuBlue", "IFU-B", "IFU Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(31.750))
+  /** @group Constructors */ case object IfuRed extends GmosNorthFpu("IfuRed", "IFU-R", "IFU Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(35.250))
 
   /** All members of GmosNorthFpu, in canonical order. */
   val all: List[GmosNorthFpu] =
-    List(Ns0, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00, Ifu1, Ifu2, Ifu3)
+    List(Ns0, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00, Ifu2, IfuBlue, IfuRed)
 
   /** Select the member of GmosNorthFpu with the given tag, if any. */
   def fromTag(s: String): Option[GmosNorthFpu] =

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/GmosNorthFpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/GmosNorthFpu.scala
@@ -35,13 +35,13 @@ object GmosNorthFpu {
   /** @group Constructors */ case object LongSlit_1_50 extends GmosNorthFpu("LongSlit_1_50", "1.5\"", "Longslit 1.50 arcsec", Some(Angle.fromDoubleArcseconds(1.50)), Angle.fromDoubleArcseconds(0.000))
   /** @group Constructors */ case object LongSlit_2_00 extends GmosNorthFpu("LongSlit_2_00", "2.0\"", "Longslit 2.00 arcsec", Some(Angle.fromDoubleArcseconds(2.00)), Angle.fromDoubleArcseconds(0.000))
   /** @group Constructors */ case object LongSlit_5_00 extends GmosNorthFpu("LongSlit_5_00", "5.0\"", "Longslit 5.00 arcsec", Some(Angle.fromDoubleArcseconds(5.00)), Angle.fromDoubleArcseconds(0.000))
-  /** @group Constructors */ case object Ifu2 extends GmosNorthFpu("Ifu2", "IFU-2", "IFU 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(33.500))
+  /** @group Constructors */ case object Ifu2Slits extends GmosNorthFpu("Ifu2Slits", "IFU-2", "IFU 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(33.500))
   /** @group Constructors */ case object IfuBlue extends GmosNorthFpu("IfuBlue", "IFU-B", "IFU Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(31.750))
   /** @group Constructors */ case object IfuRed extends GmosNorthFpu("IfuRed", "IFU-R", "IFU Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(35.250))
 
   /** All members of GmosNorthFpu, in canonical order. */
   val all: List[GmosNorthFpu] =
-    List(Ns0, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00, Ifu2, IfuBlue, IfuRed)
+    List(Ns0, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00, Ifu2Slits, IfuBlue, IfuRed)
 
   /** Select the member of GmosNorthFpu with the given tag, if any. */
   def fromTag(s: String): Option[GmosNorthFpu] =

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/GmosSouthFpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/GmosSouthFpu.scala
@@ -35,16 +35,16 @@ object GmosSouthFpu {
   /** @group Constructors */ case object LongSlit_1_50 extends GmosSouthFpu("LongSlit_1_50", "1.5\"", "Longslit 1.50 arcsec", Some(Angle.fromDoubleArcseconds(1.50)), Angle.fromDoubleArcseconds(0.000))
   /** @group Constructors */ case object LongSlit_2_00 extends GmosSouthFpu("LongSlit_2_00", "2.0\"", "Longslit 2.00 arcsec", Some(Angle.fromDoubleArcseconds(2.00)), Angle.fromDoubleArcseconds(0.000))
   /** @group Constructors */ case object LongSlit_5_00 extends GmosSouthFpu("LongSlit_5_00", "5.0\"", "Longslit 5.00 arcsec", Some(Angle.fromDoubleArcseconds(5.00)), Angle.fromDoubleArcseconds(0.000))
-  /** @group Constructors */ case object Ifu1 extends GmosSouthFpu("Ifu1", "IFU-2", "IFU 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(-31.750))
-  /** @group Constructors */ case object Ifu2 extends GmosSouthFpu("Ifu2", "IFU-B", "IFU Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(-30.875))
-  /** @group Constructors */ case object Ifu3 extends GmosSouthFpu("Ifu3", "IFU-R", "IFU Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(-32.625))
-  /** @group Constructors */ case object IfuN extends GmosSouthFpu("IfuN", "IFU-NS-2", "IFU N and S 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(-31.750))
-  /** @group Constructors */ case object IfuNB extends GmosSouthFpu("IfuNB", "IFU-NS-B", "IFU N and S Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(-30.875))
-  /** @group Constructors */ case object IfuNR extends GmosSouthFpu("IfuNR", "IFU-NS-R", "IFU N and S Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(-32.625))
+  /** @group Constructors */ case object Ifu2 extends GmosSouthFpu("Ifu2", "IFU-2", "IFU 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(-31.750))
+  /** @group Constructors */ case object IfuBlue extends GmosSouthFpu("IfuBlue", "IFU-B", "IFU Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(-30.875))
+  /** @group Constructors */ case object IfuRed extends GmosSouthFpu("IfuRed", "IFU-R", "IFU Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(-32.625))
+  /** @group Constructors */ case object IfuNS2 extends GmosSouthFpu("IfuNS2", "IFU-NS-2", "IFU N and S 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(-31.750))
+  /** @group Constructors */ case object IfuNSBlue extends GmosSouthFpu("IfuNSBlue", "IFU-NS-B", "IFU N and S Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(-30.875))
+  /** @group Constructors */ case object IfuNSRed extends GmosSouthFpu("IfuNSRed", "IFU-NS-R", "IFU N and S Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(-32.625))
 
   /** All members of GmosSouthFpu, in canonical order. */
   val all: List[GmosSouthFpu] =
-    List(Bhros, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00, Ifu1, Ifu2, Ifu3, IfuN, IfuNB, IfuNR)
+    List(Bhros, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00, Ifu2, IfuBlue, IfuRed, IfuNS2, IfuNSBlue, IfuNSRed)
 
   /** Select the member of GmosSouthFpu with the given tag, if any. */
   def fromTag(s: String): Option[GmosSouthFpu] =

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/GmosSouthFpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/GmosSouthFpu.scala
@@ -35,16 +35,16 @@ object GmosSouthFpu {
   /** @group Constructors */ case object LongSlit_1_50 extends GmosSouthFpu("LongSlit_1_50", "1.5\"", "Longslit 1.50 arcsec", Some(Angle.fromDoubleArcseconds(1.50)), Angle.fromDoubleArcseconds(0.000))
   /** @group Constructors */ case object LongSlit_2_00 extends GmosSouthFpu("LongSlit_2_00", "2.0\"", "Longslit 2.00 arcsec", Some(Angle.fromDoubleArcseconds(2.00)), Angle.fromDoubleArcseconds(0.000))
   /** @group Constructors */ case object LongSlit_5_00 extends GmosSouthFpu("LongSlit_5_00", "5.0\"", "Longslit 5.00 arcsec", Some(Angle.fromDoubleArcseconds(5.00)), Angle.fromDoubleArcseconds(0.000))
-  /** @group Constructors */ case object Ifu2 extends GmosSouthFpu("Ifu2", "IFU-2", "IFU 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(-31.750))
+  /** @group Constructors */ case object Ifu2Slits extends GmosSouthFpu("Ifu2Slits", "IFU-2", "IFU 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(-31.750))
   /** @group Constructors */ case object IfuBlue extends GmosSouthFpu("IfuBlue", "IFU-B", "IFU Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(-30.875))
   /** @group Constructors */ case object IfuRed extends GmosSouthFpu("IfuRed", "IFU-R", "IFU Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(-32.625))
-  /** @group Constructors */ case object IfuNS2 extends GmosSouthFpu("IfuNS2", "IFU-NS-2", "IFU N and S 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(-31.750))
+  /** @group Constructors */ case object IfuNS2Slits extends GmosSouthFpu("IfuNS2Slits", "IFU-NS-2", "IFU N and S 2 Slits", Option.empty[Angle], Angle.fromDoubleArcseconds(-31.750))
   /** @group Constructors */ case object IfuNSBlue extends GmosSouthFpu("IfuNSBlue", "IFU-NS-B", "IFU N and S Left Slit (blue)", Option.empty[Angle], Angle.fromDoubleArcseconds(-30.875))
   /** @group Constructors */ case object IfuNSRed extends GmosSouthFpu("IfuNSRed", "IFU-NS-R", "IFU N and S Right Slit (red)", Option.empty[Angle], Angle.fromDoubleArcseconds(-32.625))
 
   /** All members of GmosSouthFpu, in canonical order. */
   val all: List[GmosSouthFpu] =
-    List(Bhros, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00, Ifu2, IfuBlue, IfuRed, IfuNS2, IfuNSBlue, IfuNSRed)
+    List(Bhros, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00, Ifu2Slits, IfuBlue, IfuRed, IfuNS2Slits, IfuNSBlue, IfuNSRed)
 
   /** Select the member of GmosSouthFpu with the given tag, if any. */
   def fromTag(s: String): Option[GmosSouthFpu] =

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/GmosScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/GmosScienceAreaGeometry.scala
@@ -35,7 +35,7 @@ object GmosScienceAreaGeometry {
         n =>
           n match {
             case GmosNorthFpu.Ns0 | GmosNorthFpu.Ns1 | GmosNorthFpu.Ns2 | GmosNorthFpu.Ns3 |
-                GmosNorthFpu.Ns4 | GmosNorthFpu.Ns5 | GmosNorthFpu.Ifu2 | GmosNorthFpu.IfuBlue |
+                GmosNorthFpu.Ns4 | GmosNorthFpu.Ns5 | GmosNorthFpu.Ifu2Slits | GmosNorthFpu.IfuBlue |
                 GmosNorthFpu.IfuRed =>
               ShapeExpression.empty
 
@@ -48,8 +48,8 @@ object GmosScienceAreaGeometry {
         s =>
           s match {
             case GmosSouthFpu.Bhros | GmosSouthFpu.Ns1 | GmosSouthFpu.Ns2 | GmosSouthFpu.Ns3 |
-                GmosSouthFpu.Ns4 | GmosSouthFpu.Ns5 | GmosSouthFpu.Ifu2 | GmosSouthFpu.IfuBlue |
-                GmosSouthFpu.IfuRed | GmosSouthFpu.IfuNS2 | GmosSouthFpu.IfuNSBlue |
+                GmosSouthFpu.Ns4 | GmosSouthFpu.Ns5 | GmosSouthFpu.Ifu2Slits | GmosSouthFpu.IfuBlue |
+                GmosSouthFpu.IfuRed | GmosSouthFpu.IfuNS2Slits | GmosSouthFpu.IfuNSBlue |
                 GmosSouthFpu.IfuNSRed =>
               ShapeExpression.empty
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/GmosScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/GmosScienceAreaGeometry.scala
@@ -35,8 +35,8 @@ object GmosScienceAreaGeometry {
         n =>
           n match {
             case GmosNorthFpu.Ns0 | GmosNorthFpu.Ns1 | GmosNorthFpu.Ns2 | GmosNorthFpu.Ns3 |
-                GmosNorthFpu.Ns4 | GmosNorthFpu.Ns5 | GmosNorthFpu.Ifu1 | GmosNorthFpu.Ifu2 |
-                GmosNorthFpu.Ifu3 =>
+                GmosNorthFpu.Ns4 | GmosNorthFpu.Ns5 | GmosNorthFpu.Ifu2 | GmosNorthFpu.IfuBlue |
+                GmosNorthFpu.IfuRed =>
               ShapeExpression.empty
 
             case GmosNorthFpu.LongSlit_0_25 | GmosNorthFpu.LongSlit_0_50 |
@@ -48,8 +48,9 @@ object GmosScienceAreaGeometry {
         s =>
           s match {
             case GmosSouthFpu.Bhros | GmosSouthFpu.Ns1 | GmosSouthFpu.Ns2 | GmosSouthFpu.Ns3 |
-                GmosSouthFpu.Ns4 | GmosSouthFpu.Ns5 | GmosSouthFpu.Ifu1 | GmosSouthFpu.Ifu2 |
-                GmosSouthFpu.Ifu3 | GmosSouthFpu.IfuN | GmosSouthFpu.IfuNB | GmosSouthFpu.IfuNR =>
+                GmosSouthFpu.Ns4 | GmosSouthFpu.Ns5 | GmosSouthFpu.Ifu2 | GmosSouthFpu.IfuBlue |
+                GmosSouthFpu.IfuRed | GmosSouthFpu.IfuNS2 | GmosSouthFpu.IfuNSBlue |
+                GmosSouthFpu.IfuNSRed =>
               ShapeExpression.empty
 
             case GmosSouthFpu.LongSlit_0_25 | GmosSouthFpu.LongSlit_0_50 |


### PR DESCRIPTION
For ages the `Ifu1` enum has been associated with `IFU-2` which is IMHO confusing.
I'm proposing we rename the `Ifu` enums to something more appropriate.

I fear this change my cause the telescope to implode but it seems we should do it.

Worth checking its effect in observe/seqexec @jluhrs 