### PR TITLE
Sanitize MagnitudeSystem tags

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/MagnitudeSystem.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/MagnitudeSystem.scala
@@ -7,6 +7,7 @@ package enum
 
 import cats.syntax.eq._
 import coulomb.Unitless
+import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 import lucuma.core.math.units
 
@@ -32,13 +33,13 @@ object MagnitudeSystem {
   /** @group Constructors */ case object Jy             extends MagnitudeSystem("Jy") {
                                                                   type Units = units.Jansky
                                                                 }
-  /** @group Constructors */ case object Watts          extends MagnitudeSystem("W/m²/µm") {
+  /** @group Constructors */ case object Watts          extends MagnitudeSystem("Watts") {
                                                                   type Units = units.WattsMag
                                                                 }
-  /** @group Constructors */ case object ErgsWavelength extends MagnitudeSystem("erg/s/cm²/Å") {
+  /** @group Constructors */ case object ErgsWavelength extends MagnitudeSystem("ErgsWavelength") {
                                                                   type Units = units.ErgsWavelengthMag
                                                                 }
-  /** @group Constructors */ case object ErgsFrequency  extends MagnitudeSystem("erg/s/cm²/Hz") {
+  /** @group Constructors */ case object ErgsFrequency  extends MagnitudeSystem("ErgsFrequency") {
                                                                   type Units = units.ErgsFrequencyMag
                                                                 }
   /** All members of MagnitudeSystem, in canonical order. */
@@ -61,5 +62,13 @@ object MagnitudeSystem {
       override def unsafeFromTag(s: String): MagnitudeSystem =
         MagnitudeSystem.unsafeFromTag(s)
     }
+
+  // This Display can be useful to nicely format the units
+  val unitDisplay: Display[MagnitudeSystem] = Display.byShortName {
+    case MagnitudeSystem.Watts          => "W/m²/µm"
+    case MagnitudeSystem.ErgsWavelength => "erg/s/cm²/Å"
+    case MagnitudeSystem.ErgsFrequency  => "erg/s/cm²/Hz"
+    case a                              => a.tag
+  }
 
 }


### PR DESCRIPTION
Turns out the tags with the funny units don't play nice with the json encoder/decoders. I'm giving them a simple tag and provide a `Display` for use on the UI