### PR TITLE
Make the target orders complete

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -37,7 +37,7 @@ object Target extends WithId('t') with TargetOptics {
    * Not implicit.
    */
   val TargetTrackOrder: Order[Target] =
-    Order.by(t => (t.track, t.name))
+    Order.by(t => (t.track, t.name, t.magnitudes.toList))
 
   /**
    * Targets ordered by name first and then tracking information.
@@ -45,7 +45,7 @@ object Target extends WithId('t') with TargetOptics {
    * Not implicit.
    */
   val TargetNameOrder: Order[Target] =
-    Order.by(t => (t.name.value, t.track))
+    Order.by(t => (t.name, t.track, t.magnitudes.toList))
 
 }
 


### PR DESCRIPTION
I noticed the existing name and tracking target orders ignore magnitudes.  Magnitudes should be moved into the ITC source definition at some point, but until then is there a reason not to include them in the `Order` definitions?