### PR TITLE
Make proper motion nullable in SiderealTarget

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -273,14 +273,14 @@ trait TargetOptics { this: Target.type =>
     sidereal.andThen(SiderealTarget.epoch)
 
   /** @group Optics */
-  val properMotion: Optional[Target, ProperMotion] =
-    siderealTracking.andThen(SiderealTracking.properMotion.some)
+  val properMotion: Optional[Target, Option[ProperMotion]] =
+    siderealTracking.andThen(SiderealTracking.properMotion)
 
   /** @group Optics */
   val properMotionRA: Optional[Target, ProperMotion.RA] =
-    properMotion.andThen(ProperMotion.ra)
+    properMotion.some.andThen(ProperMotion.ra)
 
   /** @group Optics */
   val properMotionDec: Optional[Target, ProperMotion.Dec] =
-    properMotion.andThen(ProperMotion.dec)
+    properMotion.some.andThen(ProperMotion.dec)
 }


### PR DESCRIPTION
When updating the fake GPP ODB to use the latest `lucuma-core`, I took advantage of all the new (?) target optics instead of defining them locally as I had before.  I hit one snag with proper motion though.  In particular, we need to support `SiderealTarget`s with and without proper motion (just as we do for radial velocity).  Since it is optional in `SiderealTracking` it should be nullable in the GraphQL API as well.

This PR changes `Target.properMotion` to `Optional[Target, Option[ProperMotion]]` accordingly.  Does this seem reasonable?