### PR TITLE
Add AngularSize to targets.

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/MagnitudeSystem.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/MagnitudeSystem.scala
@@ -7,9 +7,9 @@ package enum
 
 import cats.syntax.eq._
 import coulomb.Unitless
+import lucuma.core.math.units
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
-import lucuma.core.math.units
 
 /**
  * Enumerated type for magnitude system.

--- a/modules/core/shared/src/main/scala/lucuma/core/model/AngularSize.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/AngularSize.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.Show
+import lucuma.core.math.Angle
+import monocle.Focus
+import monocle.Lens
+
+/**
+ * Angular size of an object in the sky. The major axis is the longest one, but we don't enforce
+ * this.
+ */
+final case class AngularSize(majorAxis: Angle, minorAxis: Angle)
+
+object AngularSize {
+  val majorAxis: Lens[AngularSize, Angle] = Focus[AngularSize](_.majorAxis)
+  val minorAxis: Lens[AngularSize, Angle] = Focus[AngularSize](_.minorAxis)
+
+  /** @group Typeclass Instances */
+  implicit val AngularSizeShow: Show[AngularSize] =
+    Show.fromToString
+
+  /** @group Typeclass Instances */
+  implicit val AngularSizeEqual: Eq[AngularSize] =
+    Eq.fromUniversalEquals
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SpectralDistribution.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SpectralDistribution.scala
@@ -9,8 +9,8 @@ import cats.implicits._
 import coulomb.Quantity
 import coulomb.cats.implicits._
 import coulomb.si.Kelvin
-import eu.timepit.refined.types.numeric.PosBigDecimal
 import eu.timepit.refined.cats._
+import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.enum.NonStellarLibrarySpectrum
 import lucuma.core.enum.StellarLibrarySpectrum
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -23,12 +23,14 @@ import scala.collection.immutable.SortedMap
 sealed trait Target extends Product with Serializable {
   def name: NonEmptyString
   def magnitudes: SortedMap[MagnitudeBand, Magnitude]
+  def angularSize: Option[AngularSize]
 }
 
 final case class SiderealTarget(
-  name:       NonEmptyString,
-  tracking:   SiderealTracking,
-  magnitudes: SortedMap[MagnitudeBand, Magnitude]
+  name:        NonEmptyString,
+  tracking:    SiderealTracking,
+  magnitudes:  SortedMap[MagnitudeBand, Magnitude],
+  angularSize: Option[AngularSize]
 ) extends Target
 
 object SiderealTarget extends SiderealTargetOptics {
@@ -56,7 +58,8 @@ object SiderealTarget extends SiderealTargetOptics {
 final case class NonsiderealTarget(
   name:         NonEmptyString,
   ephemerisKey: EphemerisKey,
-  magnitudes:   SortedMap[MagnitudeBand, Magnitude]
+  magnitudes:   SortedMap[MagnitudeBand, Magnitude],
+  angularSize:  Option[AngularSize]
 ) extends Target
 
 object NonsiderealTarget extends NonsiderealTargetOptics {
@@ -83,9 +86,9 @@ object NonsiderealTarget extends NonsiderealTargetOptics {
 object Target extends WithId('t') with TargetOptics {
 
   implicit val TargetEq: Eq[Target] = Eq.instance {
-    case (a @ SiderealTarget(_, _, _), b @ SiderealTarget(_, _, _))       => a === b
-    case (a @ NonsiderealTarget(_, _, _), b @ NonsiderealTarget(_, _, _)) => a === b
-    case _                                                                => false
+    case (a @ SiderealTarget(_, _, _, _), b @ SiderealTarget(_, _, _, _))       => a === b
+    case (a @ NonsiderealTarget(_, _, _, _), b @ NonsiderealTarget(_, _, _, _)) => a === b
+    case _                                                                      => false
   }
 
   /**
@@ -96,12 +99,12 @@ object Target extends WithId('t') with TargetOptics {
    */
   val TrackOrder: Order[Target] =
     Order.from {
-      case (a @ SiderealTarget(_, _, _), b @ SiderealTarget(_, _, _))       =>
+      case (a @ SiderealTarget(_, _, _, _), b @ SiderealTarget(_, _, _, _))       =>
         SiderealTarget.TrackOrder.compare(a, b)
-      case (a @ NonsiderealTarget(_, _, _), b @ NonsiderealTarget(_, _, _)) =>
+      case (a @ NonsiderealTarget(_, _, _, _), b @ NonsiderealTarget(_, _, _, _)) =>
         NonsiderealTarget.TrackOrder.compare(a, b)
-      case (NonsiderealTarget(_, _, _), _)                                  => -1
-      case _                                                                => 1
+      case (NonsiderealTarget(_, _, _, _), _)                                     => -1
+      case _                                                                      => 1
     }
 
   /**
@@ -111,12 +114,12 @@ object Target extends WithId('t') with TargetOptics {
    */
   val NameOrder: Order[Target] =
     Order.from {
-      case (a @ SiderealTarget(_, _, _), b @ SiderealTarget(_, _, _))       =>
+      case (a @ SiderealTarget(_, _, _, _), b @ SiderealTarget(_, _, _, _))       =>
         SiderealTarget.NameOrder.compare(a, b)
-      case (a @ NonsiderealTarget(_, _, _), b @ NonsiderealTarget(_, _, _)) =>
+      case (a @ NonsiderealTarget(_, _, _, _), b @ NonsiderealTarget(_, _, _, _)) =>
         NonsiderealTarget.NameOrder.compare(a, b)
-      case (NonsiderealTarget(_, _, _), _)                                  => -1
-      case _                                                                => 1
+      case (NonsiderealTarget(_, _, _, _), _)                                     => -1
+      case _                                                                      => 1
     }
 }
 
@@ -217,8 +220,8 @@ trait TargetOptics { this: Target.type =>
   /** @group Optics */
   val name: Lens[Target, NonEmptyString] =
     Lens[Target, NonEmptyString](_.name)(v => {
-      case t @ SiderealTarget(_, _, _)    => SiderealTarget.name.replace(v)(t)
-      case t @ NonsiderealTarget(_, _, _) => NonsiderealTarget.name.replace(v)(t)
+      case t @ SiderealTarget(_, _, _, _)    => SiderealTarget.name.replace(v)(t)
+      case t @ NonsiderealTarget(_, _, _, _) => NonsiderealTarget.name.replace(v)(t)
     })
 
   /** @group Optics */
@@ -232,8 +235,8 @@ trait TargetOptics { this: Target.type =>
   /** @group Optics */
   val magnitudes: Lens[Target, SortedMap[MagnitudeBand, Magnitude]] =
     Lens[Target, SortedMap[MagnitudeBand, Magnitude]](_.magnitudes)(v => {
-      case t @ SiderealTarget(_, _, _)    => SiderealTarget.magnitudes.replace(v)(t)
-      case t @ NonsiderealTarget(_, _, _) => NonsiderealTarget.magnitudes.replace(v)(t)
+      case t @ SiderealTarget(_, _, _, _)    => SiderealTarget.magnitudes.replace(v)(t)
+      case t @ NonsiderealTarget(_, _, _, _) => NonsiderealTarget.magnitudes.replace(v)(t)
     })
 
   /** @group Optics */

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbAngularSize.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbAngularSize.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import lucuma.core.math.Angle
+import lucuma.core.model.AngularSize
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen._
+import org.scalacheck._
+
+trait ArbAngularSize {
+  import lucuma.core.math.arb.ArbAngle._
+
+  implicit val arbAngularSize: Arbitrary[AngularSize] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Angle]
+        b <- arbitrary[Angle]
+      } yield AngularSize(Angle.AngleOrder.max(a, b), Angle.AngleOrder.min(a, b))
+    }
+
+  implicit val cogAngularSize: Cogen[AngularSize] =
+    Cogen[(Angle, Angle)].contramap(a => (a.majorAxis, a.minorAxis))
+}
+
+object ArbAngularSize extends ArbAngularSize

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSpectralDistribution.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSpectralDistribution.scala
@@ -8,8 +8,8 @@ import cats.implicits._
 import coulomb.refined._
 import coulomb.si.Kelvin
 import eu.timepit.refined.numeric.Positive
-import lucuma.core.enum.StellarLibrarySpectrum
 import lucuma.core.enum.NonStellarLibrarySpectrum
+import lucuma.core.enum.StellarLibrarySpectrum
 import lucuma.core.util.arb.ArbEnumerated._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
@@ -20,6 +20,7 @@ trait ArbTarget {
   import ArbEphemerisKey._
   import ArbSiderealTracking._
   import ArbMagnitude._
+  import ArbAngularSize._
   import ArbEnumerated._
 
   implicit val arbSiderealTarget: Arbitrary[SiderealTarget] =
@@ -28,7 +29,8 @@ trait ArbTarget {
         n <- arbitrary[NonEmptyString]
         t <- arbitrary[SiderealTracking]
         m <- arbitrary[Vector[(MagnitudeBand, Magnitude)]]
-      } yield SiderealTarget(n, t, SortedMap(m: _*))
+        s <- arbitrary[Option[AngularSize]]
+      } yield SiderealTarget(n, t, SortedMap(m: _*), s)
     }
 
   implicit val arbNonsiderealTarget: Arbitrary[NonsiderealTarget] =
@@ -37,7 +39,8 @@ trait ArbTarget {
         n <- arbitrary[NonEmptyString]
         t <- arbitrary[EphemerisKey]
         m <- arbitrary[Vector[(MagnitudeBand, Magnitude)]]
-      } yield NonsiderealTarget(n, t, SortedMap(m: _*))
+        s <- arbitrary[Option[AngularSize]]
+      } yield NonsiderealTarget(n, t, SortedMap(m: _*), s)
     }
 
   implicit val arbTarget: Arbitrary[Target] = Arbitrary(
@@ -55,8 +58,8 @@ trait ArbTarget {
   implicit val cogTarget: Cogen[Target] =
     Cogen[Either[SiderealTarget, NonsiderealTarget]]
       .contramap {
-        case t @ SiderealTarget(_, _, _)    => t.asLeft
-        case t @ NonsiderealTarget(_, _, _) => t.asRight
+        case t @ SiderealTarget(_, _, _, _)    => t.asLeft
+        case t @ NonsiderealTarget(_, _, _, _) => t.asRight
       }
 }
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/AngularSizeSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/AngularSizeSuite.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.kernel.laws.discipline._
+import lucuma.core.model.arb._
+import munit._
+
+class AngularSizeSuite extends DisciplineSuite {
+  import ArbAngularSize._
+
+  // Laws
+  checkAll("Eq[AngularSize]", EqTests[AngularSize].eqv)
+}


### PR DESCRIPTION
The idea is to pull angular size information from catalogs when available so that we can present a full image of the target in the visualizer by setting the right FOV.

We can store this information in the ODB or not. We probably want to. Regardless of that, in explore we store the FOV in the separate user preferences DB if the user changes it. The target's `AngularSize` will be the default.