### PR TITLE
Change SiderealTarget.properMotion from Optional to Lens[..., Option[...]]

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -174,16 +174,16 @@ trait SiderealTargetOptics { this: SiderealTarget.type =>
     tracking.andThen(SiderealTracking.epoch)
 
   /** @group Optics */
-  val properMotion: Optional[SiderealTarget, ProperMotion] =
-    tracking.andThen(SiderealTracking.properMotion.some)
+  val properMotion: Lens[SiderealTarget, Option[ProperMotion]] =
+    tracking.andThen(SiderealTracking.properMotion)
 
   /** @group Optics */
   val properMotionRA: Optional[SiderealTarget, ProperMotion.RA] =
-    properMotion.andThen(ProperMotion.ra)
+    properMotion.some.andThen(ProperMotion.ra)
 
   /** @group Optics */
   val properMotionDec: Optional[SiderealTarget, ProperMotion.Dec] =
-    properMotion.andThen(ProperMotion.dec)
+    properMotion.some.andThen(ProperMotion.dec)
 }
 
 trait NonsiderealTargetOptics { this: NonsiderealTarget.type =>
@@ -276,14 +276,14 @@ trait TargetOptics { this: Target.type =>
     sidereal.andThen(SiderealTarget.epoch)
 
   /** @group Optics */
-  val properMotion: Optional[Target, ProperMotion] =
-    siderealTracking.andThen(SiderealTracking.properMotion.some)
+  val properMotion: Optional[Target, Option[ProperMotion]] =
+    sidereal.andThen(SiderealTarget.properMotion)
 
   /** @group Optics */
   val properMotionRA: Optional[Target, ProperMotion.RA] =
-    properMotion.andThen(ProperMotion.ra)
+    sidereal.andThen(SiderealTarget.properMotionRA)
 
   /** @group Optics */
   val properMotionDec: Optional[Target, ProperMotion.Dec] =
-    properMotion.andThen(ProperMotion.dec)
+    sidereal.andThen(SiderealTarget.properMotionDec)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -276,14 +276,14 @@ trait TargetOptics { this: Target.type =>
     sidereal.andThen(SiderealTarget.epoch)
 
   /** @group Optics */
-  val properMotion: Optional[Target, Option[ProperMotion]] =
-    siderealTracking.andThen(SiderealTracking.properMotion)
+  val properMotion: Optional[Target, ProperMotion] =
+    siderealTracking.andThen(SiderealTracking.properMotion.some)
 
   /** @group Optics */
   val properMotionRA: Optional[Target, ProperMotion.RA] =
-    properMotion.some.andThen(ProperMotion.ra)
+    properMotion.andThen(ProperMotion.ra)
 
   /** @group Optics */
   val properMotionDec: Optional[Target, ProperMotion.Dec] =
-    properMotion.some.andThen(ProperMotion.dec)
+    properMotion.andThen(ProperMotion.dec)
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -48,7 +48,7 @@ final class TargetSuite extends DisciplineSuite {
   checkAll("SiderealTarget.baseDec", LensTests(SiderealTarget.baseDec))
   checkAll("SiderealTarget.catalogId", LensTests(SiderealTarget.catalogId))
   checkAll("SiderealTarget.epoch", LensTests(SiderealTarget.epoch))
-  checkAll("SiderealTarget.properMotion", OptionalTests(SiderealTarget.properMotion))
+  checkAll("SiderealTarget.properMotion", LensTests(SiderealTarget.properMotion))
   checkAll("SiderealTarget.properMotionRA", OptionalTests(SiderealTarget.properMotionRA))
   checkAll("SiderealTarget.properMotionDec", OptionalTests(SiderealTarget.properMotionDec))
   checkAll(


### PR DESCRIPTION
`Target.properMotion.getOption` was erroneously returning `Some(None)` instead of `None` when there was no PM defined.