### PR TITLE
Add objectType to CatalogInfo. Move it to Target.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val catsScalacheckVersion = "0.3.1"
 inThisBuild(
   Seq(
     homepage                      := Some(url("https://github.com/gemini-hlsw/lucuma-core")),
+    versionScheme                 := Some("early-semver"),
     addCompilerPlugin(
       ("org.typelevel"             % "kind-projector" % kindProjectorVersion).cross(CrossVersion.full)
     ),
@@ -35,28 +36,28 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   .settings(
     name := "lucuma-core",
     libraryDependencies ++= Seq(
-      "org.tpolecat"      %%% "atto-core"                  % attoVersion,
-      "org.tpolecat"      %%% "atto-refined"               % attoVersion,
-      "org.typelevel"     %%% "cats-core"                  % catsVersion,
-      "dev.optics"        %%% "monocle-core"               % monocleVersion,
-      "dev.optics"        %%% "monocle-macro"              % monocleVersion,
-      "dev.optics"        %%% "monocle-state"              % monocleVersion,
-      "edu.gemini"        %%% "lucuma-jts"                 % jtsVersion,
-      "com.manyangled"    %%% "coulomb"                    % coulombVersion,
-      "com.manyangled"    %%% "coulomb-si-units"           % coulombVersion,
-      "com.manyangled"    %%% "coulomb-accepted-units"     % coulombVersion,
-      "com.manyangled"    %%% "coulomb-time-units"         % coulombVersion,
-      "com.manyangled"    %%% "coulomb-cats"               % coulombVersion,
-      "com.manyangled"    %%% "coulomb-refined"            % coulombVersion,
-      "com.manyangled"    %%% "coulomb-physical-constants" % coulombVersion,
-      "org.typelevel"     %%% "spire"                      % spireVersion,
-      "org.typelevel"     %%% "spire-extras"               % spireVersion,
-      "eu.timepit"        %%% "singleton-ops"              % singletonOpsVersion,
-      "eu.timepit"        %%% "refined"                    % refinedVersion,
-      "eu.timepit"        %%% "refined-cats"               % refinedVersion,
-      "org.typelevel"     %%% "cats-time"                  % catsTimeVersion,
-      "io.circe"          %%% "circe-core"                 % circeVersion,
-      "io.circe"          %%% "circe-refined"              % circeVersion
+      "org.tpolecat"   %%% "atto-core"                  % attoVersion,
+      "org.tpolecat"   %%% "atto-refined"               % attoVersion,
+      "org.typelevel"  %%% "cats-core"                  % catsVersion,
+      "dev.optics"     %%% "monocle-core"               % monocleVersion,
+      "dev.optics"     %%% "monocle-macro"              % monocleVersion,
+      "dev.optics"     %%% "monocle-state"              % monocleVersion,
+      "edu.gemini"     %%% "lucuma-jts"                 % jtsVersion,
+      "com.manyangled" %%% "coulomb"                    % coulombVersion,
+      "com.manyangled" %%% "coulomb-si-units"           % coulombVersion,
+      "com.manyangled" %%% "coulomb-accepted-units"     % coulombVersion,
+      "com.manyangled" %%% "coulomb-time-units"         % coulombVersion,
+      "com.manyangled" %%% "coulomb-cats"               % coulombVersion,
+      "com.manyangled" %%% "coulomb-refined"            % coulombVersion,
+      "com.manyangled" %%% "coulomb-physical-constants" % coulombVersion,
+      "org.typelevel"  %%% "spire"                      % spireVersion,
+      "org.typelevel"  %%% "spire-extras"               % spireVersion,
+      "eu.timepit"     %%% "singleton-ops"              % singletonOpsVersion,
+      "eu.timepit"     %%% "refined"                    % refinedVersion,
+      "eu.timepit"     %%% "refined-cats"               % refinedVersion,
+      "org.typelevel"  %%% "cats-time"                  % catsTimeVersion,
+      "io.circe"       %%% "circe-core"                 % circeVersion,
+      "io.circe"       %%% "circe-refined"              % circeVersion
     )
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
@@ -83,6 +83,8 @@ object UnitOfMeasure {
 trait GroupedUnitType[+UG] extends UnitType {
   override def withValue[N](value: N): GroupedUnitQty[N, UG] =
     GroupedUnitQty(value, this)
+
+  def ungrouped: UnitType = this
 }
 
 object GroupedUnitType {
@@ -95,7 +97,9 @@ object GroupedUnitType {
  * Type-parametrized runtime representation of physical unit `U` and its association to unit group
  * `UG`.
  */
-trait GroupedUnitOfMeasure[UG, U] extends UnitOfMeasure[U] with GroupedUnitType[UG]
+trait GroupedUnitOfMeasure[UG, U] extends UnitOfMeasure[U] with GroupedUnitType[UG] {
+  override def ungrouped: UnitOfMeasure[U] = this
+}
 
 object GroupedUnitOfMeasure {
   def apply[UG, U](implicit unit: UnitOfMeasure[U]): GroupedUnitOfMeasure[UG, U] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/BandBrightness.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/BandBrightness.scala
@@ -9,6 +9,7 @@ import lucuma.core.enum.Band
 import lucuma.core.math.BrightnessUnits._
 import lucuma.core.math.BrightnessValue
 import lucuma.core.math.dimensional._
+import lucuma.core.util.Enumerated
 import monocle.Focus
 import monocle.Lens
 
@@ -60,6 +61,26 @@ object BandBrightness {
     error:    BrightnessValue
   ): BandBrightness[T] =
     new BandBrightness(quantity, band, error.some)
+
+  def apply[T, U](value: BrightnessValue, band: Band, error: Option[BrightnessValue])(implicit
+    enumerated:          Enumerated[GroupedUnitType[Brightness[T]]],
+    unit:                UnitOfMeasure[U]
+  ): Option[BandBrightness[T]] =
+    enumerated.all
+      .find(_.ungrouped === unit)
+      .map(u => new BandBrightness(u.withValue(value), band, error))
+
+  def apply[T, U](value: BrightnessValue, band: Band, error: BrightnessValue)(implicit
+    enumerated:          Enumerated[GroupedUnitType[Brightness[T]]],
+    unit:                UnitOfMeasure[U]
+  ): Option[BandBrightness[T]] =
+    apply[T, U](value, band, error.some)
+
+  def apply[T, U](value: BrightnessValue, band: Band)(implicit
+    enumerated:          Enumerated[GroupedUnitType[Brightness[T]]],
+    unit:                UnitOfMeasure[U]
+  ): Option[BandBrightness[T]] =
+    apply[T, U](value, band, none)
 
   /** Secondary constructor using default units for the band. */
   def apply[T] = new GroupApplied[T]

--- a/modules/core/shared/src/main/scala/lucuma/core/model/CatalogInfo.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/CatalogInfo.scala
@@ -9,6 +9,8 @@ import eu.timepit.refined.cats._
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enum.CatalogName
+import monocle.Focus
+import monocle.Lens
 
 final case class CatalogInfo(catalog: CatalogName, id: NonEmptyString, objectType: String)
 
@@ -18,4 +20,17 @@ object CatalogInfo {
 
   def apply(catalog: CatalogName, id: String, objectType: String): Option[CatalogInfo] =
     refineV[NonEmpty](id).toOption.map(i => CatalogInfo(catalog, i, objectType))
+
+  /** @group Optics */
+  val catalog: Lens[CatalogInfo, CatalogName] =
+    Focus[CatalogInfo](_.catalog)
+
+  /** @group Optics */
+  val id: Lens[CatalogInfo, NonEmptyString] =
+    Focus[CatalogInfo](_.id)
+
+  /** @group Optics */
+  val objectType: Lens[CatalogInfo, String] =
+    Focus[CatalogInfo](_.objectType)
+
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/CatalogInfo.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/CatalogInfo.scala
@@ -4,6 +4,7 @@
 package lucuma.core.model
 
 import cats._
+import cats.syntax.all._
 import eu.timepit.refined._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.collection.NonEmpty
@@ -12,14 +13,30 @@ import lucuma.core.enum.CatalogName
 import monocle.Focus
 import monocle.Lens
 
-final case class CatalogInfo(catalog: CatalogName, id: NonEmptyString, objectType: String)
+final case class CatalogInfo(
+  catalog:    CatalogName,
+  id:         NonEmptyString,
+  objectType: Option[NonEmptyString]
+)
 
 object CatalogInfo {
   implicit val orderCatalogInfo: Order[CatalogInfo] =
     Order.by(x => (x.catalog, x.id, x.objectType))
 
-  def apply(catalog: CatalogName, id: String, objectType: String): Option[CatalogInfo] =
-    refineV[NonEmpty](id).toOption.map(i => CatalogInfo(catalog, i, objectType))
+  def apply(
+    catalog:    CatalogName,
+    id:         String,
+    objectType: String
+  ): Option[CatalogInfo] =
+    refineV[NonEmpty](id).toOption.map(i =>
+      CatalogInfo(catalog, i, refineV[NonEmpty](objectType).toOption)
+    )
+
+  def apply(
+    catalog: CatalogName,
+    id:      String
+  ): Option[CatalogInfo] =
+    refineV[NonEmpty](id).toOption.map(i => CatalogInfo(catalog, i, none))
 
   /** @group Optics */
   val catalog: Lens[CatalogInfo, CatalogName] =
@@ -30,7 +47,7 @@ object CatalogInfo {
     Focus[CatalogInfo](_.id)
 
   /** @group Optics */
-  val objectType: Lens[CatalogInfo, String] =
+  val objectType: Lens[CatalogInfo, Option[NonEmptyString]] =
     Focus[CatalogInfo](_.objectType)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/CatalogInfo.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/CatalogInfo.scala
@@ -10,12 +10,12 @@ import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enum.CatalogName
 
-final case class CatalogId(catalog: CatalogName, id: NonEmptyString)
+final case class CatalogInfo(catalog: CatalogName, id: NonEmptyString, objectType: String)
 
-object CatalogId {
-  implicit val orderCatalogId: Order[CatalogId] =
-    Order.by(x => (x.catalog, x.id))
+object CatalogInfo {
+  implicit val orderCatalogInfo: Order[CatalogInfo] =
+    Order.by(x => (x.catalog, x.id, x.objectType))
 
-  def apply(catalog: CatalogName, id: String): Option[CatalogId] =
-    refineV[NonEmpty](id).toOption.map(i => CatalogId(catalog, i))
+  def apply(catalog: CatalogName, id: String, objectType: String): Option[CatalogInfo] =
+    refineV[NonEmpty](id).toOption.map(i => CatalogInfo(catalog, i, objectType))
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
@@ -16,22 +16,32 @@ import scala.math.hypot
 import scala.math.sin
 
 /**
-  * Time-parameterized coordinates, based on an observed position at some point in time (called
-  * the `epoch`) and measured velocities in distance (`radialVelocity`; i.e., doppler shift) and
-  * position (`properMotion`) per year. Given this information we can compute the position at any
-  * instant in time. The references below are ''extremely'' helpful, so do check them out if you're
-  * trying to understand the implementation.
-  * @see The pretty good [[https://en.wikipedia.org/wiki/Proper_motion wikipedia]] article
-  * @see Astronomical Almanac 1984 [[https://babel.hathitrust.org/cgi/pt?id=uc1.b3754036;view=1up;seq=141 p.B39]]
-  * @see Astronomy and Astrophysics 134 (1984) [[http://articles.adsabs.harvard.edu/cgi-bin/nph-iarticle_query?bibcode=1984A%26A...134....1L&db_key=AST&page_ind=0&data_type=GIF&type=SCREEN_VIEW&classic=YES p.1-6]]
-  * @param baseCoordinates observed coordinates at `epoch`
-  * @param epoch           time of the base observation; typically `Epoch.J2000`
-  * @param properMotion    proper velocity '''per year''' in [[lucuma.core.math.RightAscension]] and [[lucuma.core.math.Declination]], if any
-  * @param radialVelocity  radial velocity (km/y, positive if receding), if any
-  * @param parallax        parallax, if any
-  */
+ * Time-parameterized coordinates, based on an observed position at some point in time (called the
+ * `epoch`) and measured velocities in distance (`radialVelocity`; i.e., doppler shift) and position
+ * (`properMotion`) per year. Given this information we can compute the position at any instant in
+ * time. The references below are ''extremely'' helpful, so do check them out if you're trying to
+ * understand the implementation.
+ * @see
+ *   The pretty good [[https://en.wikipedia.org/wiki/Proper_motion wikipedia]] article
+ * @see
+ *   Astronomical Almanac 1984
+ *   [[https://babel.hathitrust.org/cgi/pt?id=uc1.b3754036;view=1up;seq=141 p.B39]]
+ * @see
+ *   Astronomy and Astrophysics 134 (1984)
+ *   [[http://articles.adsabs.harvard.edu/cgi-bin/nph-iarticle_query?bibcode=1984A%26A...134....1L&db_key=AST&page_ind=0&data_type=GIF&type=SCREEN_VIEW&classic=YES p.1-6]]
+ * @param baseCoordinates
+ *   observed coordinates at `epoch`
+ * @param epoch
+ *   time of the base observation; typically `Epoch.J2000`
+ * @param properMotion
+ *   proper velocity '''per year''' in [[lucuma.core.math.RightAscension]] and
+ *   [[lucuma.core.math.Declination]], if any
+ * @param radialVelocity
+ *   radial velocity (km/y, positive if receding), if any
+ * @param parallax
+ *   parallax, if any
+ */
 final case class SiderealTracking(
-  catalogId:       Option[CatalogId],
   baseCoordinates: Coordinates,
   epoch:           Epoch,
   properMotion:    Option[ProperMotion],
@@ -58,18 +68,25 @@ object SiderealTracking extends SiderealTrackingOptics {
   import Constants.{ AstronomicalUnit, TwoPi }
 
   def const(cs: Coordinates): SiderealTracking =
-    SiderealTracking(none, cs, Epoch.J2000, None, None, None)
+    SiderealTracking(cs, Epoch.J2000, none, none, none)
 
   /**
-    * Coordinates corrected for proper motion
-    * @param baseCoordinates base coordinates
-    * @param epoch           the epoch
-    * @param properMotion    proper velocity per epoch year
-    * @param radialVelocity  radial velocity (km/sec, positive if receding)
-    * @param parallax        parallax
-    * @param elapsedYears    elapsed time in epoch years
-    * @return Coordinates corrected for proper motion
-    */
+   * Coordinates corrected for proper motion
+   * @param baseCoordinates
+   *   base coordinates
+   * @param epoch
+   *   the epoch
+   * @param properMotion
+   *   proper velocity per epoch year
+   * @param radialVelocity
+   *   radial velocity (km/sec, positive if receding)
+   * @param parallax
+   *   parallax
+   * @param elapsedYears
+   *   elapsed time in epoch years
+   * @return
+   *   Coordinates corrected for proper motion
+   */
   def coordinatesOn(
     baseCoordinates: Coordinates,
     epoch:           Epoch,
@@ -105,15 +122,22 @@ object SiderealTracking extends SiderealTrackingOptics {
   }
 
   /**
-    * Coordinates corrected for proper motion
-    * @param baseCoordinates base (ra, dec) in radians, [0 … 2π) and (-π/2 … π/2)
-    * @param daysPerYear     length of epoch year in fractonal days
-    * @param properMotion  proper velocity in (ra, dec) in radians per epoch year
-    * @param radialVelocity  radial velocity (km/sec, positive means away from earth)
-    * @param parallax        parallax in arcseconds (!)
-    * @param elapsedYears    elapsed time in epoch years
-    * @return (ra, dec) in radians, corrected for proper motion
-    */
+   * Coordinates corrected for proper motion
+   * @param baseCoordinates
+   *   base (ra, dec) in radians, [0 … 2π) and (-π/2 … π/2)
+   * @param daysPerYear
+   *   length of epoch year in fractonal days
+   * @param properMotion
+   *   proper velocity in (ra, dec) in radians per epoch year
+   * @param radialVelocity
+   *   radial velocity (km/sec, positive means away from earth)
+   * @param parallax
+   *   parallax in arcseconds (!)
+   * @param elapsedYears
+   *   elapsed time in epoch years
+   * @return
+   *   (ra, dec) in radians, corrected for proper motion
+   */
   // scalastyle:off method.length
   private def coordinatesOnʹ(
     baseCoordinates: Vec2,
@@ -160,7 +184,7 @@ object SiderealTracking extends SiderealTrackingOptics {
     val r         = hypot(x, y)
     val raʹ       = if (r === 0.0) 0.0 else atan2(y, x)
     val decʹ      = if (z === 0.0) 0.0 else atan2(z, r)
-    val raʹʹ = {
+    val raʹʹ      = {
       // Normalize to [0 .. 2π)
       val rem = raʹ % TwoPi
       if (rem < 0.0) rem + TwoPi else rem
@@ -192,8 +216,7 @@ object SiderealTracking extends SiderealTrackingOptics {
       order(_.epoch) |+|
       order(_.properMotion) |+|
       order(_.radialVelocity) |+|
-      order(_.parallax) |+|
-      order(_.catalogId)
+      order(_.parallax)
 
   }
 }
@@ -203,10 +226,6 @@ trait SiderealTrackingOptics {
   /** @group Optics */
   val baseCoordinates: Lens[SiderealTracking, Coordinates] =
     Focus[SiderealTracking](_.baseCoordinates)
-
-  /** @group Optics */
-  val catalogId: Lens[SiderealTracking, Option[CatalogId]] =
-    Focus[SiderealTracking](_.catalogId)
 
   /** @group Optics */
   val epoch: Lens[SiderealTracking, Epoch] =

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbCatalogInfo.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbCatalogInfo.scala
@@ -13,20 +13,21 @@ import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
 
-trait ArbCatalogId {
+trait ArbCatalogInfo {
   import ArbEnumerated._
 
-  implicit val arbCatalogId: Arbitrary[CatalogId] =
+  implicit val arbCatalogInfo: Arbitrary[CatalogInfo] =
     Arbitrary {
       for {
-        name <- arbitrary[CatalogName]
-        id   <- arbitrary[NonEmptyString]
-      } yield CatalogId(name, id)
+        name    <- arbitrary[CatalogName]
+        id      <- arbitrary[NonEmptyString]
+        objType <- arbitrary[String]
+      } yield CatalogInfo(name, id, objType)
     }
 
-  implicit val cogSemester: Cogen[CatalogId] =
-    Cogen[(CatalogName, String)].contramap(s => (s.catalog, s.id.value))
+  implicit val cogSemester: Cogen[CatalogInfo] =
+    Cogen[(CatalogName, String, String)].contramap(s => (s.catalog, s.id.value, s.objectType))
 
 }
 
-object ArbCatalogId extends ArbCatalogId
+object ArbCatalogInfo extends ArbCatalogInfo

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbCatalogInfo.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbCatalogInfo.scala
@@ -21,12 +21,14 @@ trait ArbCatalogInfo {
       for {
         name    <- arbitrary[CatalogName]
         id      <- arbitrary[NonEmptyString]
-        objType <- arbitrary[String]
+        objType <- arbitrary[Option[NonEmptyString]]
       } yield CatalogInfo(name, id, objType)
     }
 
   implicit val cogSemester: Cogen[CatalogInfo] =
-    Cogen[(CatalogName, String, String)].contramap(s => (s.catalog, s.id.value, s.objectType))
+    Cogen[(CatalogName, String, Option[String])].contramap(s =>
+      (s.catalog, s.id.value, s.objectType.map(_.value))
+    )
 
 }
 

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSiderealTracking.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSiderealTracking.scala
@@ -16,24 +16,21 @@ trait ArbSiderealTracking {
   import ArbProperMotion._
   import ArbRadialVelocity._
   import ArbParallax._
-  import ArbCatalogId._
 
   implicit val arbSiderealTracking: Arbitrary[SiderealTracking] =
     Arbitrary {
       for {
-        ci <- arbitrary[Option[CatalogId]]
         cs <- arbitrary[Coordinates]
         ap <- arbitrary[Epoch]
         pv <- arbitrary[Option[ProperMotion]]
         rv <- arbitrary[Option[RadialVelocity]]
         px <- arbitrary[Option[Parallax]]
-      } yield SiderealTracking(ci, cs, ap, pv, rv, px)
+      } yield SiderealTracking(cs, ap, pv, rv, px)
     }
 
   implicit val cogSiderealTracking: Cogen[SiderealTracking] =
     Cogen[
       (
-        Option[CatalogId],
         Coordinates,
         Epoch,
         Option[ProperMotion],
@@ -41,8 +38,8 @@ trait ArbSiderealTracking {
         Option[Parallax]
       )
     ].contramap { p =>
-        (p.catalogId, p.baseCoordinates, p.epoch, p.properMotion, p.radialVelocity, p.parallax)
-      }
+      (p.baseCoordinates, p.epoch, p.properMotion, p.radialVelocity, p.parallax)
+    }
 
 }
 

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
@@ -38,9 +38,8 @@ trait ArbTarget {
         n <- arbitrary[NonEmptyString]
         t <- arbitrary[EphemerisKey]
         b <- arbitrary[SourceProfile]
-        c <- arbitrary[Option[CatalogInfo]]
         s <- arbitrary[Option[AngularSize]]
-      } yield Target.Nonsidereal(n, t, b, c, s)
+      } yield Target.Nonsidereal(n, t, b, s)
     }
 
   implicit val arbTarget: Arbitrary[Target] = Arbitrary(
@@ -52,14 +51,14 @@ trait ArbTarget {
       .contramap(t => (t.name.value, t.tracking, t.sourceProfile, t.catalogInfo, t.angularSize))
 
   implicit val cogNonsiderealTarget: Cogen[Target.Nonsidereal] =
-    Cogen[(String, EphemerisKey, SourceProfile, Option[CatalogInfo], Option[AngularSize])]
-      .contramap(t => (t.name.value, t.ephemerisKey, t.sourceProfile, t.catalogInfo, t.angularSize))
+    Cogen[(String, EphemerisKey, SourceProfile, Option[AngularSize])]
+      .contramap(t => (t.name.value, t.ephemerisKey, t.sourceProfile, t.angularSize))
 
   implicit val cogTarget: Cogen[Target] =
     Cogen[Either[Target.Sidereal, Target.Nonsidereal]]
       .contramap {
-        case t @ Target.Sidereal(_, _, _, _, _)    => t.asLeft
-        case t @ Target.Nonsidereal(_, _, _, _, _) => t.asRight
+        case t @ Target.Sidereal(_, _, _, _, _) => t.asLeft
+        case t @ Target.Nonsidereal(_, _, _, _) => t.asRight
       }
 }
 

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
@@ -19,6 +19,7 @@ trait ArbTarget {
   import ArbAngularSize._
   import ArbEnumerated._
   import ArbSourceProfile._
+  import ArbCatalogInfo._
 
   implicit val ArbSiderealTarget: Arbitrary[Target.Sidereal] =
     Arbitrary {
@@ -26,8 +27,9 @@ trait ArbTarget {
         n <- arbitrary[NonEmptyString]
         t <- arbitrary[SiderealTracking]
         b <- arbitrary[SourceProfile]
+        c <- arbitrary[Option[CatalogInfo]]
         s <- arbitrary[Option[AngularSize]]
-      } yield Target.Sidereal(n, t, b, s)
+      } yield Target.Sidereal(n, t, b, c, s)
     }
 
   implicit val arbNonsiderealTarget: Arbitrary[Target.Nonsidereal] =
@@ -36,8 +38,9 @@ trait ArbTarget {
         n <- arbitrary[NonEmptyString]
         t <- arbitrary[EphemerisKey]
         b <- arbitrary[SourceProfile]
+        c <- arbitrary[Option[CatalogInfo]]
         s <- arbitrary[Option[AngularSize]]
-      } yield Target.Nonsidereal(n, t, b, s)
+      } yield Target.Nonsidereal(n, t, b, c, s)
     }
 
   implicit val arbTarget: Arbitrary[Target] = Arbitrary(
@@ -45,18 +48,18 @@ trait ArbTarget {
   )
 
   implicit val cogSiderealTarget: Cogen[Target.Sidereal] =
-    Cogen[(String, SiderealTracking, SourceProfile)]
-      .contramap(t => (t.name.value, t.tracking, t.sourceProfile))
+    Cogen[(String, SiderealTracking, SourceProfile, Option[CatalogInfo], Option[AngularSize])]
+      .contramap(t => (t.name.value, t.tracking, t.sourceProfile, t.catalogInfo, t.angularSize))
 
   implicit val cogNonsiderealTarget: Cogen[Target.Nonsidereal] =
-    Cogen[(String, EphemerisKey, SourceProfile)]
-      .contramap(t => (t.name.value, t.ephemerisKey, t.sourceProfile))
+    Cogen[(String, EphemerisKey, SourceProfile, Option[CatalogInfo], Option[AngularSize])]
+      .contramap(t => (t.name.value, t.ephemerisKey, t.sourceProfile, t.catalogInfo, t.angularSize))
 
   implicit val cogTarget: Cogen[Target] =
     Cogen[Either[Target.Sidereal, Target.Nonsidereal]]
       .contramap {
-        case t @ Target.Sidereal(_, _, _, _)    => t.asLeft
-        case t @ Target.Nonsidereal(_, _, _, _) => t.asRight
+        case t @ Target.Sidereal(_, _, _, _, _)    => t.asLeft
+        case t @ Target.Nonsidereal(_, _, _, _, _) => t.asRight
       }
 }
 

--- a/modules/tests/jvm/src/test/scala/edu/gemini/skycalc/ImprovedSkyCalcTest.scala
+++ b/modules/tests/jvm/src/test/scala/edu/gemini/skycalc/ImprovedSkyCalcTest.scala
@@ -3,12 +3,12 @@
 
 package edu.gemini.skycalc
 
+import edu.gemini.skycalc.ImprovedSkyCalcMethods._
+import jsky.coords.WorldCoords
+
 import java.time.Instant
 import java.time.ZonedDateTime
-
-import edu.gemini.skycalc.ImprovedSkyCalcMethods._
 import java.{ util => ju }
-import jsky.coords.WorldCoords
 
 /**
   * This class exists purely for testing purposes.

--- a/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/ImprovedSkyCalcSuiteJVM.scala
+++ b/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/ImprovedSkyCalcSuiteJVM.scala
@@ -3,21 +3,21 @@
 
 package lucuma.core.math.skycalc
 
-import munit.ScalaCheckSuite
-import org.scalacheck.Prop._
-
+import com.fortysevendeg.scalacheck.datetime.GenDateTime.genDateTimeWithinRange
+import com.fortysevendeg.scalacheck.datetime.instances.jdk8._
 import edu.gemini.skycalc.ImprovedSkyCalcTest
+import jsky.coords.WorldCoords
 import lucuma.core.math.Coordinates
+import lucuma.core.math.Place
 import lucuma.core.math.arb.ArbCoordinates._
 import lucuma.core.math.arb.ArbPlace._
-import com.fortysevendeg.scalacheck.datetime.instances.jdk8._
-import com.fortysevendeg.scalacheck.datetime.GenDateTime.genDateTimeWithinRange
-import java.time._
-import lucuma.core.math.Place
-import jsky.coords.WorldCoords
-import java.{ util => ju }
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop._
 import org.scalacheck.{ Test => ScalaCheckTest }
 import org.scalactic.Tolerance
+
+import java.time._
+import java.{ util => ju }
 
 final class ImprovedSkyCalcSuiteJVM extends ScalaCheckSuite with Tolerance {
 

--- a/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/TwilightCalcSuiteJVM.scala
+++ b/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/TwilightCalcSuiteJVM.scala
@@ -3,22 +3,22 @@
 
 package lucuma.core.math.skycalc
 
-import munit.ScalaCheckSuite
-import org.scalacheck.Prop._
-
 import cats._
 import cats.syntax.all._
-import lucuma.core.math.skycalc.TwilightCalc
-import java.time.Instant
-import java.time.LocalDate
+import edu.gemini.skycalc.TwilightBoundedNightTest
+import lucuma.core.arb.ArbTime
 import lucuma.core.enum.Site
 import lucuma.core.enum.TwilightType
-import lucuma.core.arb.ArbTime
-import lucuma.core.util.arb.ArbEnumerated
-import edu.gemini.skycalc.TwilightBoundedNightTest
-import org.scalactic.Tolerance
+import lucuma.core.math.skycalc.TwilightCalc
 import lucuma.core.optics.Spire
+import lucuma.core.util.arb.ArbEnumerated
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop._
+import org.scalactic.Tolerance
 import org.typelevel.cats.time._
+
+import java.time.Instant
+import java.time.LocalDate
 
 final class TwilightCalcSuiteJVM extends ScalaCheckSuite with Tolerance {
   import ArbEnumerated._

--- a/modules/tests/shared/src/test/scala/lucuma/core/data/EnumZipperSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/data/EnumZipperSuite.scala
@@ -5,12 +5,13 @@ package lucuma
 package core
 package data
 
+import cats.kernel.laws.discipline.EqTests
 import cats.syntax.all._
 import lucuma.core.enum.StepType
 import lucuma.core.enum.StepType._
 import lucuma.core.util.arb.ArbEnumerated._
+
 import arb.ArbEnumZipper._
-import cats.kernel.laws.discipline.EqTests
 
 final class EnumZipperSuite extends munit.DisciplineSuite {
   test("withFocus on focus") {

--- a/modules/tests/shared/src/test/scala/lucuma/core/data/ZipperSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/data/ZipperSuite.scala
@@ -5,13 +5,14 @@ package lucuma
 package core
 package data
 
-import cats.syntax.all._
 import cats.data.NonEmptyList
 import cats.kernel.laws.discipline.EqTests
-import cats.laws.discipline.{ FunctorTests, TraverseTests }
+import cats.laws.discipline.FunctorTests
+import cats.laws.discipline.TraverseTests
 import cats.laws.discipline.arbitrary._
-import monocle.law.discipline.TraversalTests
+import cats.syntax.all._
 import lucuma.core.data.arb.ArbZipper._
+import monocle.law.discipline.TraversalTests
 import org.scalacheck.Prop._
 
 /**

--- a/modules/tests/shared/src/test/scala/lucuma/core/enum/EnumeratedSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enum/EnumeratedSuite.scala
@@ -3,11 +3,12 @@
 
 package lucuma.core.enum
 
-import munit._
-import monocle.law.discipline.PrismTests
+import cats.kernel.laws.discipline.OrderTests
 import lucuma.core.util.Enumerated
 import lucuma.core.util.arb.ArbEnumerated._
-import cats.kernel.laws.discipline.OrderTests
+import monocle.law.discipline.PrismTests
+import munit._
+
 import scala.reflect.ClassTag
 
 final class EnumeratedSuite extends DisciplineSuite {

--- a/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
@@ -4,14 +4,15 @@
 package lucuma.core.geom
 
 import cats.syntax.all._
-import lucuma.core.math.{ Angle, Offset }
+import lucuma.core.geom.arb._
 import lucuma.core.geom.syntax.all._
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
 import lucuma.core.math.arb._
 import lucuma.core.math.syntax.int._
-import lucuma.core.geom.arb._
-import org.scalacheck._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
+import org.scalacheck._
 
 final class ShapeExpressionSuite extends munit.DisciplineSuite {
   implicit val interpreter: ShapeInterpreter =

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/AngleSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/AngleSuite.scala
@@ -3,9 +3,11 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Order, Show }
-import cats.syntax.all._
+import cats.Eq
+import cats.Order
+import cats.Show
 import cats.kernel.laws.discipline._
+import cats.syntax.all._
 import lucuma.core.math.arb._
 import lucuma.core.optics.laws.discipline._
 import monocle.law.discipline._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ApparentRadialVelocitySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ApparentRadialVelocitySuite.scala
@@ -3,18 +3,18 @@
 
 package lucuma.core.math
 
-import java.math.MathContext
-
 import cats._
 import cats.kernel.laws.discipline._
 import coulomb._
 import coulomb.si._
-import lucuma.core.math.arb._
 import lucuma.core.math.Constants.SpeedOfLight
+import lucuma.core.math.arb._
 import lucuma.core.math.units._
 import lucuma.core.optics.laws.discipline.WedgeTests
 import monocle.law.discipline.IsoTests
 import org.scalacheck.Prop._
+
+import java.math.MathContext
 
 final class ApparentRadialVelocitySuite extends munit.DisciplineSuite {
   import ArbApparentRadialVelocity._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessUnitsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessUnitsSuite.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.math
+
+import munit.DisciplineSuite
+import lucuma.core.math.BrightnessUnits
+import lucuma.core.util.laws.EnumeratedTests
+import lucuma.core.math.dimensional.GroupedUnitType
+import lucuma.core.util.arb.ArbEnumerated
+
+final class BrightnessUnitsSuite extends DisciplineSuite {
+  import ArbEnumerated._
+  import BrightnessUnits._
+
+  checkAll(
+    "GroupedUnitType[Brightness[Integrated]]",
+    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+  )
+  checkAll(
+    "GroupedUnitType[Brightness[Surface]]",
+    EnumeratedTests[GroupedUnitType[Brightness[Surface]]].enumerated
+  )
+  checkAll(
+    "GroupedUnitType[LineFlux[Integrated]]",
+    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+  )
+  checkAll(
+    "GroupedUnitType[LineFlux[Surface]]",
+    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+  )
+  checkAll(
+    "GroupedUnitType[FluxDensityContinuum[Integrated]]",
+    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+  )
+  checkAll(
+    "GroupedUnitType[FluxDensityContinuum[Surface]]",
+    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+  )
+
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessUnitsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessUnitsSuite.scala
@@ -3,11 +3,11 @@
 
 package lucuma.core.math
 
-import munit.DisciplineSuite
 import lucuma.core.math.BrightnessUnits
-import lucuma.core.util.laws.EnumeratedTests
 import lucuma.core.math.dimensional.GroupedUnitType
 import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.laws.EnumeratedTests
+import munit.DisciplineSuite
 
 final class BrightnessUnitsSuite extends DisciplineSuite {
   import ArbEnumerated._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessValueSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessValueSuite.scala
@@ -3,7 +3,9 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Order, Show }
+import cats.Eq
+import cats.Order
+import cats.Show
 import cats.kernel.laws.discipline._
 import lucuma.core.math.arb._
 import lucuma.core.optics.laws.discipline.FormatTests

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/CoordinatesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/CoordinatesSuite.scala
@@ -3,10 +3,11 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
-import lucuma.core.optics.laws.discipline._
 import lucuma.core.math.arb._
+import lucuma.core.optics.laws.discipline._
 import monocle.law.discipline._
 import org.scalacheck.Prop._
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/DeclinationSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/DeclinationSuite.scala
@@ -3,9 +3,10 @@
 
 package lucuma.core.math
 
-import cats.syntax.all._
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
+import cats.syntax.all._
 import lucuma.core.math.arb._
 import lucuma.core.optics.laws.discipline._
 import monocle.law.discipline._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/EpochSpec.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/EpochSpec.scala
@@ -3,19 +3,21 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.implicits._
 import cats.kernel.laws.discipline._
 import eu.timepit.refined.auto._
-import lucuma.core.math.arb._
-import lucuma.core.optics.laws.discipline._
-import java.time.LocalDateTime
 import lucuma.core.arb.ArbTime
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import lucuma.core.math.arb._
 import lucuma.core.math.parser.EpochParsers._
+import lucuma.core.optics.laws.discipline._
 import lucuma.core.syntax.parser._
 import monocle.law.discipline.PrismTests
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+import java.time.LocalDateTime
 
 final class EpochSuite extends munit.DisciplineSuite {
   import ArbEpoch._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/HourAngleSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/HourAngleSuite.scala
@@ -3,7 +3,8 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
 import lucuma.core.math.arb._
 import lucuma.core.optics.laws.discipline._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalGens.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalGens.scala
@@ -5,6 +5,7 @@ package lucuma.core.math
 
 import cats.Eq
 import cats.syntax.all._
+import lucuma.core.arb.ArbTime
 import lucuma.core.optics.Spire
 import lucuma.core.syntax.boundedInterval._
 import lucuma.core.syntax.time._
@@ -25,6 +26,8 @@ import java.time.Duration
 import java.time.Instant
 
 trait IntervalGens {
+  import ArbTime._
+
   private val MaxDelta: Long = Duration.ofMinutes(10).toNanos
 
   def buildInterval(start: Int, end: Int): Bounded[Instant] =

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalGens.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalGens.scala
@@ -3,26 +3,26 @@
 
 package lucuma.core.math
 
-import cats.syntax.all._
 import cats.Eq
-import java.time.Duration
-import java.time.Instant
-import org.scalacheck.Gen
-import org.scalacheck.Gen.Choose
-import org.scalacheck.Arbitrary._
-import lucuma.core.syntax.time._
-import lucuma.core.arb.ArbTime._
-import org.typelevel.cats.time._
-import spire.math.Bounded
+import cats.syntax.all._
 import lucuma.core.optics.Spire
 import lucuma.core.syntax.boundedInterval._
-import spire.math.extras.interval.IntervalSeq
+import lucuma.core.syntax.time._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
+import org.scalacheck.Gen.Choose
+import org.typelevel.cats.time._
+import spire.math.Bounded
 import spire.math.Interval
+import spire.math.extras.interval.IntervalSeq
+import spire.math.interval.Closed
 import spire.math.interval.EmptyBound
+import spire.math.interval.Open
 import spire.math.interval.Unbound
 import spire.math.interval.ValueBound
-import spire.math.interval.Closed
-import spire.math.interval.Open
+
+import java.time.Duration
+import java.time.Instant
 
 trait IntervalGens {
   private val MaxDelta: Long = Duration.ofMinutes(10).toNanos

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalSuite.scala
@@ -3,25 +3,26 @@
 
 package lucuma.core.math
 
+import cats.Order._
 import cats.syntax.all._
+import lucuma.core.arb.ArbTime
+import lucuma.core.instances.boundedInterval._
+import lucuma.core.math.arb._
+import lucuma.core.optics.Spire
+import lucuma.core.optics.laws.discipline.FormatTests
+import lucuma.core.optics.laws.discipline.SplitEpiTests
+import lucuma.core.syntax.boundedInterval._
+import lucuma.core.syntax.time._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
+import org.scalacheck.Prop._
+import org.typelevel.cats.time._
+import spire.math.Bounded
+
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalTime
 import java.time.ZoneId
-import org.scalacheck.Gen
-import org.scalacheck.Arbitrary._
-import org.scalacheck.Prop._
-import lucuma.core.math.arb._
-import org.typelevel.cats.time._
-import lucuma.core.optics.laws.discipline.FormatTests
-import lucuma.core.arb.ArbTime
-import spire.math.Bounded
-import lucuma.core.syntax.boundedInterval._
-import lucuma.core.syntax.time._
-import lucuma.core.optics.Spire
-import java.time.Duration
-import cats.Order._
-import lucuma.core.optics.laws.discipline.SplitEpiTests
-import lucuma.core.instances.boundedInterval._
 
 final class IntervalSuite extends munit.DisciplineSuite with IntervalGens {
   import ArbInterval._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/JulianDateSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/JulianDateSuite.scala
@@ -3,19 +3,19 @@
 
 package lucuma.core.math
 
-import cats.syntax.all._
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
-
-import lucuma.core.math.arb._
-
-import java.time.LocalDateTime
-import java.time.Instant
-import org.scalacheck.Gen._
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import cats.syntax.all._
 import lucuma.core.arb.ArbTime
+import lucuma.core.math.arb._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen._
+import org.scalacheck.Prop._
 import org.typelevel.cats.time._
+
+import java.time.Instant
+import java.time.LocalDateTime
 
 final class JulianDateSuute extends munit.DisciplineSuite {
   import ArbJulianDate._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetPSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetPSuite.scala
@@ -3,10 +3,11 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
-import lucuma.core.optics.laws.discipline._
 import lucuma.core.math.arb._
+import lucuma.core.optics.laws.discipline._
 import monocle.law.discipline._
 import org.scalacheck.Prop._
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetQSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetQSuite.scala
@@ -3,10 +3,11 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
-import lucuma.core.optics.laws.discipline._
 import lucuma.core.math.arb._
+import lucuma.core.optics.laws.discipline._
 import monocle.law.discipline._
 import org.scalacheck.Prop._
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetSuite.scala
@@ -3,11 +3,12 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
 import lucuma.core.math.arb._
-import lucuma.core.optics.laws.discipline.SplitMonoTests
 import lucuma.core.math.syntax.int._
+import lucuma.core.optics.laws.discipline.SplitMonoTests
 import monocle.law.discipline._
 import org.scalacheck.Prop._
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/PlaceSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/PlaceSuite.scala
@@ -3,19 +3,19 @@
 
 package lucuma.core.math
 
+import cats.Show
+import cats.kernel.laws.discipline.EqTests
+import coulomb.cats.implicits._
+import coulomb.scalacheck.ArbQuantity
+import eu.timepit.refined.auto._
+import eu.timepit.refined.cats._
+import eu.timepit.refined.scalacheck.numeric._
+import lucuma.core.arb.ArbTime
+import lucuma.core.arb._
+import lucuma.core.math.arb._
+import monocle.law.discipline._
 import munit.DisciplineSuite
 import org.scalacheck.Prop._
-import cats.Show
-import coulomb.scalacheck.ArbQuantity
-import coulomb.cats.implicits._
-import eu.timepit.refined.auto._
-import eu.timepit.refined.scalacheck.numeric._
-import eu.timepit.refined.cats._
-import lucuma.core.math.arb._
-import lucuma.core.arb._
-import lucuma.core.arb.ArbTime
-import monocle.law.discipline._
-import cats.kernel.laws.discipline.EqTests
 import org.typelevel.cats.time._
 
 final class PlaceSuite extends DisciplineSuite {

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/RadialVelocitySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/RadialVelocitySuite.scala
@@ -5,10 +5,10 @@ package lucuma.core.math
 
 import cats._
 import lucuma.core.math.arb._
+import lucuma.core.optics.laws.discipline.FormatTests
 import monocle.law.discipline._
 import munit.DisciplineSuite
 import org.scalacheck.Prop._
-import lucuma.core.optics.laws.discipline.FormatTests
 
 final class RadialVelocitySuite extends DisciplineSuite {
   import ArbRadialVelocity._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/RedshiftSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/RedshiftSuite.scala
@@ -3,17 +3,17 @@
 
 package lucuma.core.math
 
-import java.math.MathContext
-
 import cats._
 import cats.kernel.laws.discipline._
 import coulomb._
 import coulomb.si._
+import lucuma.core.math.Constants.SpeedOfLight
 import lucuma.core.math.arb._
 import lucuma.core.math.units._
-import lucuma.core.math.Constants.SpeedOfLight
-import org.scalacheck.Prop._
 import monocle.law.discipline.IsoTests
+import org.scalacheck.Prop._
+
+import java.math.MathContext
 
 final class RedshiftSuite extends munit.DisciplineSuite {
   import ArbRedshift._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/RightAscensionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/RightAscensionSuite.scala
@@ -3,7 +3,9 @@
 
 package lucuma.core.math
 
-import cats.{ Eq, Order, Show }
+import cats.Eq
+import cats.Order
+import cats.Show
 import cats.kernel.laws.discipline._
 import lucuma.core.math.arb._
 import lucuma.core.optics.laws.discipline._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/UnitsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/UnitsSuite.scala
@@ -4,13 +4,13 @@
 package lucuma.core.math
 
 import coulomb._
+import coulomb.mks._
 import coulomb.si.Meter
 import lucuma.core.math.units._
 import munit.FunSuite
+import spire.implicits._
 import spire.math.Rational
 import spire.math.SafeLong
-import spire.implicits._
-import coulomb.mks._
 
 final class UnitsSuite extends FunSuite {
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/WavelengthSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/WavelengthSuite.scala
@@ -3,21 +3,23 @@
 
 package lucuma.core.math
 
-import cats.{Eq, Order, Show}
-import cats.syntax.all._
+import cats.Eq
+import cats.Order
+import cats.Show
 import cats.kernel.laws.discipline._
+import cats.syntax.all._
 import coulomb.Quantity
-import lucuma.core.math.arb._
-import lucuma.core.math.units._
-import monocle.law.discipline._
 import coulomb.refined._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.math.arb._
+import lucuma.core.math.units._
 import lucuma.core.optics.Format
 import lucuma.core.optics.laws.discipline.FormatTests
+import monocle.law.discipline._
 import org.scalacheck.Prop._
 import spire.math.Rational
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/GroupedUnitQtySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/GroupedUnitQtySuite.scala
@@ -4,10 +4,10 @@
 package lucuma.core.math.dimensional
 
 import cats.kernel.laws.discipline._
-import monocle.law.discipline._
 import lucuma.core.math.BrightnessUnits._
-import lucuma.core.util.arb.ArbEnumerated._
 import lucuma.core.math.dimensional.arb.ArbQty._
+import lucuma.core.util.arb.ArbEnumerated._
+import monocle.law.discipline._
 
 class GroupedUnitQtySuite extends munit.DisciplineSuite {
   // Laws

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/parser/MiscParsersSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/parser/MiscParsersSuite.scala
@@ -3,10 +3,12 @@
 
 package lucuma.core.math.parser
 
-import atto._, Atto._
+import atto._
 import lucuma.core.math.Index
 import lucuma.core.parser.MiscParsers.index
 import org.scalacheck.Prop._
+
+import Atto._
 
 final class MiscParsersSuite extends munit.DisciplineSuite {
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/ImprovedSkyCalcSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/ImprovedSkyCalcSuite.scala
@@ -3,12 +3,12 @@
 
 package lucuma.core.math.skycalc
 
+import lucuma.core.enum.Site
+import lucuma.core.math.Coordinates
 import munit.FunSuite
+import org.scalactic.Tolerance
 
 import java.time._
-import lucuma.core.math.Coordinates
-import lucuma.core.enum.Site
-import org.scalactic.Tolerance
 
 // This is just a basic case, mostly to test linking in JS.
 // Property based testing is in ImprovedSkyCalcSpecJVM, where output

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/TwilightCalcSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/TwilightCalcSuite.scala
@@ -3,11 +3,12 @@
 
 package lucuma.core.math.skycalc
 
-import munit.FunSuite
 import lucuma.core.enum.Site
 import lucuma.core.enum.TwilightType
-import java.time.LocalDate
+import munit.FunSuite
 import org.scalactic.Tolerance
+
+import java.time.LocalDate
 
 final class TwilightCalcSuite extends FunSuite with Tolerance {
   private val Date = LocalDate.of(2000, 1, 1)

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/ConstraintSolverSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/ConstraintSolverSuite.scala
@@ -4,15 +4,16 @@
 package lucuma.core.math.skycalc
 package solver
 
-import java.time.Duration
+import lucuma.core.enum.Site.GN
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.HourAngle
 import lucuma.core.math.IntervalGens
 import lucuma.core.math.skycalc.SkyCalcResults
-import lucuma.core.enum.Site.GN
-import spire.math.extras.interval.IntervalSeq
 import org.typelevel.cats.time._
+import spire.math.extras.interval.IntervalSeq
+
+import java.time.Duration
 
 /**
  * This is not meant to test the underlying SkyCalc implementations, we assume that this is all working,

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/SampleRounderSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/SampleRounderSuite.scala
@@ -4,17 +4,18 @@
 package lucuma.core.math.skycalc.solver
 
 import cats.Eq
+import cats.laws.discipline.InvariantSemigroupalTests
 import cats.syntax.all._
-import java.time.Duration
-import java.time.Instant
+import lucuma.core.arb.ArbTime
+import lucuma.core.syntax.time._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Prop
 import org.scalacheck.Prop._
-import lucuma.core.arb.ArbTime
-import lucuma.core.syntax.time._
 import org.typelevel.cats.time._
-import cats.laws.discipline.InvariantSemigroupalTests
+
+import java.time.Duration
+import java.time.Instant
 
 final class SampleRounderSuite extends munit.DisciplineSuite {
   import ArbTime._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/SamplesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/SamplesSuite.scala
@@ -5,26 +5,27 @@ package lucuma.core.math.skycalc.solver
 
 import cats.Eq
 import cats.Eval
-import cats.syntax.all._
-import java.time.Duration
-import scala.collection.immutable.TreeMap
-import spire.math.Bounded
-import lucuma.core.math.IntervalGens
-import lucuma.core.math.skycalc.solver.Samples.Bracket
-import lucuma.core.syntax.time._
-import org.scalacheck.Gen._
-import org.scalacheck.Arbitrary._
-import org.scalacheck.Prop._
-import lucuma.core.math.arb._
+import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline.FunctorTests
 import cats.laws.discipline.MonoidKTests
-import cats.kernel.laws.discipline.EqTests
-import monocle.law.discipline.IsoTests
-import lucuma.core.arb._
+import cats.syntax.all._
 import lucuma.core.arb.ArbEval
 import lucuma.core.arb.ArbTime
+import lucuma.core.arb._
+import lucuma.core.math.IntervalGens
+import lucuma.core.math.arb._
+import lucuma.core.math.skycalc.solver.Samples.Bracket
+import lucuma.core.syntax.time._
+import monocle.law.discipline.IsoTests
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen._
+import org.scalacheck.Prop._
 import org.typelevel.cats.time._
+import spire.math.Bounded
+
+import java.time.Duration
 import java.time.Instant
+import scala.collection.immutable.TreeMap
 
 final class SamplesSuite extends munit.DisciplineSuite with IntervalGens {
   import ArbEval._

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/SolverSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/SolverSuite.scala
@@ -4,13 +4,14 @@
 package lucuma.core.math.skycalc.solver
 
 import cats.syntax.all._
-import java.time.Instant
-import java.time.Duration
-import spire.math.extras.interval.IntervalSeq
 import lucuma.core.math.IntervalGens
-import lucuma.core.math.skycalc.solver.SolverStrategy._
 import lucuma.core.math.skycalc.solver.RoundStrategy._
+import lucuma.core.math.skycalc.solver.SolverStrategy._
 import org.typelevel.cats.time._
+import spire.math.extras.interval.IntervalSeq
+
+import java.time.Duration
+import java.time.Instant
 
 final class SolverSuite extends munit.DisciplineSuite with IntervalGens {
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/TargetSamplesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/TargetSamplesSuite.scala
@@ -3,20 +3,21 @@
 
 package lucuma.core.math.skycalc.solver
 
+import cats.Order._
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.RightAscension
+import lucuma.core.math.skycalc._
+import lucuma.core.math.skycalc.solver.RoundStrategy._
+import lucuma.core.syntax.boundedInterval._
+import org.typelevel.cats.time._
+import spire.math.Bounded
+
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZonedDateTime
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Declination
-import spire.math.Bounded
-import lucuma.core.syntax.boundedInterval._
-import lucuma.core.math.RightAscension
-import lucuma.core.math.skycalc._
-import java.time.Duration
-import lucuma.core.math.skycalc.solver.RoundStrategy._
 import scala.math.abs
-import org.typelevel.cats.time._
-import cats.Order._
 
 /**
  * Compare some random values with results from http://catserver.ing.iac.es/staralt/index.php

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
@@ -3,19 +3,19 @@
 
 package lucuma.core.model
 
-import cats.syntax.all._
 import cats.kernel.laws.discipline._
+import cats.syntax.all._
+import lucuma.core.enum.Band
 import lucuma.core.math.BrightnessUnits
+import lucuma.core.math.BrightnessValue
 import lucuma.core.math.arb.ArbBrightnessValue
+import lucuma.core.math.dimensional._
 import lucuma.core.math.dimensional.arb.ArbQty
+import lucuma.core.math.units._
 import lucuma.core.model.arb._
 import lucuma.core.util.arb.ArbEnumerated
 import monocle.law.discipline.LensTests
 import munit._
-import lucuma.core.math.BrightnessValue
-import lucuma.core.math.dimensional._
-import lucuma.core.math.units._
-import lucuma.core.enum.Band
 
 final class BandBrightnessSuite extends DisciplineSuite {
   import ArbBandBrightness._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
@@ -2,6 +2,8 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package lucuma.core.model
+
+import cats.syntax.all._
 import cats.kernel.laws.discipline._
 import lucuma.core.math.BrightnessUnits
 import lucuma.core.math.arb.ArbBrightnessValue
@@ -10,6 +12,10 @@ import lucuma.core.model.arb._
 import lucuma.core.util.arb.ArbEnumerated
 import monocle.law.discipline.LensTests
 import munit._
+import lucuma.core.math.BrightnessValue
+import lucuma.core.math.dimensional._
+import lucuma.core.math.units._
+import lucuma.core.enum.Band
 
 final class BandBrightnessSuite extends DisciplineSuite {
   import ArbBandBrightness._
@@ -17,6 +23,55 @@ final class BandBrightnessSuite extends DisciplineSuite {
   import BrightnessUnits._
   import ArbBrightnessValue._
   import ArbQty._
+
+  def checkValues[T, U](
+    b:           Option[BandBrightness[T]]
+  )(scaledValue: Int, band: Band, scaledError: Option[Int])(implicit
+    unit:        UnitOfMeasure[U]
+  ): Unit = {
+    assertEquals(b.map(_.quantity.value.scaledValue), scaledValue.some)
+    assertEquals(b.map(_.quantity.unit.ungrouped), unit.some)
+    assertEquals(b.map(_.band), band.some)
+    assertEquals(b.flatMap(_.error.map(_.scaledValue)), scaledError)
+  }
+
+  // Full constructors
+  val b1 = BandBrightness(
+    GroupedUnitOfMeasure[Brightness[Integrated], VegaMagnitude]
+      .withValue(BrightnessValue.fromDouble(10.0)),
+    Band.R
+  )
+  checkValues[Integrated, VegaMagnitude](b1.some)(10000, Band.R, None)
+
+  val b2 = BandBrightness(
+    GroupedUnitOfMeasure[Brightness[Integrated], VegaMagnitude]
+      .withValue(BrightnessValue.fromDouble(10.0)),
+    Band.R,
+    BrightnessValue.fromDouble(2.0)
+  )
+  checkValues[Integrated, VegaMagnitude](b2.some)(10000, Band.R, 2000.some)
+
+  // Convenience constructors
+  val b3 = BandBrightness[Surface, ABMagnitudePerArcsec2](BrightnessValue.fromDouble(10.0), Band.R)
+  checkValues[Surface, ABMagnitudePerArcsec2](b3)(10000, Band.R, None)
+
+  val b4 = BandBrightness[Surface, ABMagnitudePerArcsec2](
+    BrightnessValue.fromDouble(10.0),
+    Band.R,
+    BrightnessValue.fromDouble(2.0)
+  )
+  checkValues[Surface, ABMagnitudePerArcsec2](b4)(10000, Band.R, 2000.some)
+
+  // Default units
+  val b5 = BandBrightness[Integrated](BrightnessValue.fromDouble(10.0), Band.R)
+  checkValues[Integrated, VegaMagnitude](b5.some)(10000, Band.R, None)
+
+  val b6 = BandBrightness[Integrated](
+    BrightnessValue.fromDouble(10.0),
+    Band.R,
+    BrightnessValue.fromDouble(2.0)
+  )
+  checkValues[Integrated, VegaMagnitude](b6.some)(10000, Band.R, 2000.some)
 
   // Laws
   checkAll(

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
@@ -3,13 +3,13 @@
 
 package lucuma.core.model
 import cats.kernel.laws.discipline._
-import lucuma.core.model.arb._
-import munit._
 import lucuma.core.math.BrightnessUnits
-import lucuma.core.util.arb.ArbEnumerated
-import monocle.law.discipline.LensTests
 import lucuma.core.math.arb.ArbBrightnessValue
 import lucuma.core.math.dimensional.arb.ArbQty
+import lucuma.core.model.arb._
+import lucuma.core.util.arb.ArbEnumerated
+import monocle.law.discipline.LensTests
+import munit._
 
 final class BandBrightnessSuite extends DisciplineSuite {
   import ArbBandBrightness._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/CatalogInfoSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/CatalogInfoSuite.scala
@@ -4,14 +4,25 @@
 package lucuma.core.model
 
 import cats.kernel.laws.discipline._
+import eu.timepit.refined.cats._
+import eu.timepit.refined.scalacheck.string._
+import lucuma.core.arb._
 import lucuma.core.model.arb._
+import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.arb._
+import monocle.law.discipline.LensTests
 import munit._
 
 final class CatalogInfoSuite extends DisciplineSuite {
+  import ArbEnumerated._
+  import ArbGid._
   import ArbCatalogInfo._
 
   // Laws
   checkAll("Order[CatalogInfo]", OrderTests[CatalogInfo].order)
 
   // Optics
+  checkAll("CatalogInfo.catalog", LensTests(CatalogInfo.catalog))
+  checkAll("CatalogInfo.id", LensTests(CatalogInfo.id))
+  checkAll("CatalogInfo.objectType", LensTests(CatalogInfo.objectType))
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/CatalogInfoSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/CatalogInfoSuite.scala
@@ -7,9 +7,11 @@ import cats.kernel.laws.discipline._
 import lucuma.core.model.arb._
 import munit._
 
-final class CatalogIdSuite extends DisciplineSuite {
-  import ArbCatalogId._
+final class CatalogInfoSuite extends DisciplineSuite {
+  import ArbCatalogInfo._
 
   // Laws
-  checkAll("Order[CatalogId]", OrderTests[CatalogId].order)
+  checkAll("Order[CatalogInfo]", OrderTests[CatalogInfo].order)
+
+  // Optics
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/EmissionLineSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/EmissionLineSuite.scala
@@ -3,19 +3,19 @@
 
 package lucuma.core.model
 
-import cats.kernel.laws.discipline._
-import eu.timepit.refined.cats._
-import munit._
-import lucuma.core.util.arb.ArbEnumerated
-import lucuma.core.math.BrightnessUnits._
-import lucuma.core.model.arb.ArbEmissionLine
-import monocle.law.discipline.LensTests
-import lucuma.core.math.arb.ArbWavelength
-import lucuma.core.math.arb.ArbRefined
-import lucuma.core.math.dimensional.arb.ArbQty
-import coulomb.scalacheck.ArbQuantity
-import coulomb.cats.implicits._
 import cats.implicits._
+import cats.kernel.laws.discipline._
+import coulomb.cats.implicits._
+import coulomb.scalacheck.ArbQuantity
+import eu.timepit.refined.cats._
+import lucuma.core.math.BrightnessUnits._
+import lucuma.core.math.arb.ArbRefined
+import lucuma.core.math.arb.ArbWavelength
+import lucuma.core.math.dimensional.arb.ArbQty
+import lucuma.core.model.arb.ArbEmissionLine
+import lucuma.core.util.arb.ArbEnumerated
+import monocle.law.discipline.LensTests
+import munit._
 
 final class EmissionLineSuite extends DisciplineSuite {
   import ArbEnumerated._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/EphemerisCoordinatesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/EphemerisCoordinatesSuite.scala
@@ -3,16 +3,21 @@
 
 package lucuma.core.model
 
-import lucuma.core.model.arb.ArbEphemeris
-import lucuma.core.math.{ Angle, Offset }
-import lucuma.core.math.arb.{ ArbCoordinates, ArbDeclination, ArbOffset, ArbRightAscension }
-
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import lucuma.core.math.arb.ArbCoordinates
+import lucuma.core.math.arb.ArbDeclination
+import lucuma.core.math.arb.ArbOffset
+import lucuma.core.math.arb.ArbRightAscension
+import lucuma.core.model.arb.ArbEphemeris
 import monocle.law.discipline._
-import org.scalacheck.{ Arbitrary, Gen }
-import org.scalacheck.Prop._
 import munit._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Prop._
 
 final class EphemerisCoordinatesSuite extends DisciplineSuite {
   import ArbCoordinates._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/EphemerisKeySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/EphemerisKeySuite.scala
@@ -3,14 +3,14 @@
 
 package lucuma.core.model
 
-import lucuma.core.model.arb._
-import lucuma.core.util.arb._
-
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
 import io.circe.testing.CodecTests
 import io.circe.testing.instances._
+import lucuma.core.model.arb._
 import lucuma.core.optics.laws.discipline._
+import lucuma.core.util.arb._
 import munit._
 import org.scalacheck.Prop._
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/GaussianSourceSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/GaussianSourceSuite.scala
@@ -4,8 +4,8 @@
 package lucuma.core.model
 
 import cats.kernel.laws.discipline._
-import munit._
 import lucuma.core.optics.laws.discipline.SplitMonoTests
+import munit._
 
 class GaussianSourceSuite extends DisciplineSuite {
   import lucuma.core.model.arb.ArbGaussianSource._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/IdsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/IdsSuite.scala
@@ -3,9 +3,9 @@
 
 package lucuma.core.model
 
-import munit.DisciplineSuite
 import lucuma.core.util.arb._
 import lucuma.core.util.laws.GidTests
+import munit.DisciplineSuite
 
 final class IdsSuite extends DisciplineSuite {
   import ArbGid._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/LocalObservingNightSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/LocalObservingNightSuite.scala
@@ -3,15 +3,16 @@
 
 package gem.math
 
-import munit._
-import org.scalacheck.Prop._
-import cats.{ Eq, Show }
-import lucuma.core.model.LocalObservingNight
+import cats.Eq
+import cats.Show
+import cats.kernel.laws.discipline._
 import lucuma.core.arb.ArbTime._
+import lucuma.core.model.LocalObservingNight
 import lucuma.core.model.arb.ArbObservingNight._
 import lucuma.core.util.arb.ArbEnumerated._
-import cats.kernel.laws.discipline._
 import monocle.law.discipline._
+import munit._
+import org.scalacheck.Prop._
 import org.typelevel.cats.time._
 
 final class LocalObservingNightSuite extends DisciplineSuite {

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/ObservingNightSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/ObservingNightSuite.scala
@@ -3,17 +3,19 @@
 
 package lucuma.core.model
 
-import munit._
-import org.scalacheck.Prop._
-import cats.{ Eq, Show }
-import java.time._
-import lucuma.core.enum.Site
+import cats.Eq
+import cats.Show
+import cats.kernel.laws.discipline._
 import lucuma.core.arb.ArbTime._
+import lucuma.core.enum.Site
 import lucuma.core.model.arb.ArbObservingNight._
 import lucuma.core.util.arb.ArbEnumerated._
-import cats.kernel.laws.discipline._
 import monocle.law.discipline._
+import munit._
+import org.scalacheck.Prop._
 import org.typelevel.cats.time._
+
+import java.time._
 
 final class ObservingNightSuite extends DisciplineSuite {
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/OrcidIdProfile.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/OrcidIdProfile.scala
@@ -3,10 +3,9 @@
 
 package lucuma.core.model
 
-import lucuma.core.model.arb._
-
-import munit._
 import cats.kernel.laws.discipline.EqTests
+import lucuma.core.model.arb._
+import munit._
 
 final class OrcidProfileSuite extends DisciplineSuite {
   import ArbOrcidProfile._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/OrcidIdSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/OrcidIdSuite.scala
@@ -3,13 +3,12 @@
 
 package lucuma.core.model
 
-import lucuma.core.model.arb._
-
-import munit._
 import cats.implicits._
 import cats.kernel.laws.discipline.EqTests
 import io.circe.testing.CodecTests
 import io.circe.testing.instances.arbitraryJson
+import lucuma.core.model.arb._
+import munit._
 import org.scalacheck.Prop
 
 final class OrcidIdSuite extends DisciplineSuite {

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/RoleSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/RoleSuite.scala
@@ -3,11 +3,11 @@
 
 package lucuma.core.model
 
-import lucuma.core.util.arb._
-import lucuma.core.model.arb._
-import munit._
-import lucuma.core.util.laws.GidTests
 import cats.kernel.laws.discipline.EqTests
+import lucuma.core.model.arb._
+import lucuma.core.util.arb._
+import lucuma.core.util.laws.GidTests
+import munit._
 
 final class RoleSuite extends DisciplineSuite {
   import ArbGid._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SemesterSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SemesterSuite.scala
@@ -3,16 +3,20 @@
 
 package lucuma.core.model
 
-import cats.{ Eq, Show }
-import java.time.{ Year, ZoneId }
-import lucuma.core.enum.{ Half, Site }
-import lucuma.core.util.arb.ArbEnumerated._
-import lucuma.core.arb.ArbTime._
-import lucuma.core.model.arb.ArbSemester._
-import java.time.format.DateTimeFormatter
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
-import org.typelevel.cats.time._
+import lucuma.core.arb.ArbTime._
+import lucuma.core.enum.Half
+import lucuma.core.enum.Site
+import lucuma.core.model.arb.ArbSemester._
+import lucuma.core.util.arb.ArbEnumerated._
 import org.scalacheck.Prop._
+import org.typelevel.cats.time._
+
+import java.time.Year
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 final class SemesterSuite extends munit.DisciplineSuite {
   // Laws

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
@@ -11,7 +11,6 @@ import munit.DisciplineSuite
 import org.scalacheck.Prop.forAll
 
 final class SiderealTrackingSuite extends DisciplineSuite {
-  import ArbCatalogId._
   import ArbParallax._
   import ArbCoordinates._
   import ArbEpoch._
@@ -22,7 +21,6 @@ final class SiderealTrackingSuite extends DisciplineSuite {
   // Laws
   checkAll("SiderealTracking", OrderTests[SiderealTracking].order)
   checkAll("SiderealTracking.baseCoordinates", LensTests(SiderealTracking.baseCoordinates))
-  checkAll("SiderealTracking.catalogId", LensTests(SiderealTracking.catalogId))
   checkAll("SiderealTracking.epoch", LensTests(SiderealTracking.epoch))
   checkAll("SiderealTracking.properMotion", LensTests(SiderealTracking.properMotion))
   checkAll("SiderealTracking.radialVelocity", LensTests(SiderealTracking.radialVelocity))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
@@ -4,15 +4,15 @@
 package lucuma.core.model
 
 import cats.kernel.laws.discipline._
-import lucuma.core.model.arb._
-import monocle.law.discipline._
-import munit._
-import lucuma.core.util.arb.ArbEnumerated
+import eu.timepit.refined.cats._
 import lucuma.core.enum.Band
 import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbRefined
 import lucuma.core.math.dimensional.arb.ArbQty
-import eu.timepit.refined.cats._
+import lucuma.core.model.arb._
+import lucuma.core.util.arb.ArbEnumerated
+import monocle.law.discipline._
+import munit._
 
 final class SourceProfileSuite extends DisciplineSuite {
   import ArbSourceProfile._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
@@ -4,15 +4,15 @@
 package lucuma.core.model
 
 import cats.kernel.laws.discipline._
-import lucuma.core.model.arb._
-import monocle.law.discipline._
-import munit._
-import lucuma.core.util.arb.ArbEnumerated
+import eu.timepit.refined.cats._
 import lucuma.core.enum.Band
 import lucuma.core.math.BrightnessUnits
 import lucuma.core.math.arb.ArbRefined
 import lucuma.core.math.dimensional.arb.ArbQty
-import eu.timepit.refined.cats._
+import lucuma.core.model.arb._
+import lucuma.core.util.arb.ArbEnumerated
+import monocle.law.discipline._
+import munit._
 
 final class SpectralDefinitionSuite extends DisciplineSuite {
   import ArbUnnormalizedSED._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -30,7 +30,7 @@ final class TargetSuite extends DisciplineSuite {
   import ArbRadialVelocity._
   import ArbGid._
   import ArbEpoch._
-  import ArbCatalogId._
+  import ArbCatalogInfo._
   import Target._
   import ArbEmissionLine._
   import ArbSpectralDefinition._
@@ -39,6 +39,7 @@ final class TargetSuite extends DisciplineSuite {
   import ArbBandBrightness._
   import ArbRefined._
   import ArbQty._
+  import ArbAngularSize._
 
   // Laws for Target.Sidereal
   checkAll("Eq[Target.Sidereal]", EqTests[Target.Sidereal].eqv)
@@ -52,7 +53,16 @@ final class TargetSuite extends DisciplineSuite {
   )
   checkAll("Target.Sidereal.name", LensTests(Target.Sidereal.name))
   checkAll("Target.Sidereal.tracking", LensTests(Target.Sidereal.tracking))
-  checkAll("Target.Sidereal.properMotion", OptionalTests(Target.Sidereal.properMotion))
+  checkAll("Target.Sidereal.parallax", LensTests(Target.Sidereal.parallax))
+  checkAll("Target.Sidereal.radialVelocity", LensTests(Target.Sidereal.radialVelocity))
+  checkAll("Target.Sidereal.baseCoordinates", LensTests(Target.Sidereal.baseCoordinates))
+  checkAll("Target.Sidereal.baseRA", LensTests(Target.Sidereal.baseRA))
+  checkAll("Target.Sidereal.baseDec", LensTests(Target.Sidereal.baseDec))
+  checkAll("Target.Sidereal.catalogInfo", LensTests(Target.Sidereal.catalogInfo))
+  checkAll("Target.Sidereal.epoch", LensTests(Target.Sidereal.epoch))
+  checkAll("Target.Sidereal.properMotion", LensTests(Target.Sidereal.properMotion))
+  checkAll("Target.Sidereal.properMotionRA", OptionalTests(Target.Sidereal.properMotionRA))
+  checkAll("Target.Sidereal.properMotionDec", OptionalTests(Target.Sidereal.properMotionDec))
   checkAll("Target.Sidereal.sourceProfile", LensTests(Target.Sidereal.sourceProfile))
   checkAll(
     "Target.Sidereal.integratedSpectralDefinition",
@@ -150,16 +160,8 @@ final class TargetSuite extends DisciplineSuite {
     "Target.Sidereal.surfaceFluxDensityContinuum",
     OptionalTests(Target.Sidereal.surfaceFluxDensityContinuum)
   )
-  checkAll("Target.Sidereal.parallax", LensTests(Target.Sidereal.parallax))
-  checkAll("Target.Sidereal.radialVelocity", LensTests(Target.Sidereal.radialVelocity))
-  checkAll("Target.Sidereal.baseCoordinates", LensTests(Target.Sidereal.baseCoordinates))
-  checkAll("Target.Sidereal.baseRA", LensTests(Target.Sidereal.baseRA))
-  checkAll("Target.Sidereal.baseDec", LensTests(Target.Sidereal.baseDec))
-  checkAll("Target.Sidereal.catalogId", LensTests(Target.Sidereal.catalogId))
-  checkAll("Target.Sidereal.epoch", LensTests(Target.Sidereal.epoch))
-  checkAll("Target.Sidereal.properMotion", LensTests(Target.Sidereal.properMotion))
-  checkAll("Target.Sidereal.properMotionRA", OptionalTests(Target.Sidereal.properMotionRA))
-  checkAll("Target.Sidereal.properMotionDec", OptionalTests(Target.Sidereal.properMotionDec))
+  checkAll("Target.Sidereal.catalogInfo", LensTests(Target.Sidereal.catalogInfo))
+  checkAll("Target.Sidereal.angularSize", LensTests(Target.Sidereal.angularSize))
 
   // Laws for Target.Nonsidereal
   checkAll("Eq[Target.Nonsidereal]", EqTests[Target.Nonsidereal].eqv)
@@ -270,6 +272,8 @@ final class TargetSuite extends DisciplineSuite {
     "Target.Nonsidereal.surfaceFluxDensityContinuum",
     OptionalTests(Target.Nonsidereal.surfaceFluxDensityContinuum)
   )
+  checkAll("Target.Nonsidereal.catalogInfo", LensTests(Target.Nonsidereal.catalogInfo))
+  checkAll("Target.Nonsidereal.angularSize", LensTests(Target.Nonsidereal.angularSize))
 
   // Laws for Target
   checkAll("Target.Id", GidTests[Target.Id].gid)
@@ -279,7 +283,6 @@ final class TargetSuite extends DisciplineSuite {
   checkAll("Target.sidereal", PrismTests(Target.sidereal))
   checkAll("Target.nonsidereal", PrismTests(Target.nonsidereal))
   checkAll("Target.name", LensTests(Target.name))
-  checkAll("Target.properMotion", OptionalTests(Target.properMotion))
   checkAll("Target.ephemerisKey", OptionalTests(Target.ephemerisKey))
   checkAll("Target.sourceProfile", LensTests(Target.sourceProfile))
   checkAll(
@@ -378,16 +381,17 @@ final class TargetSuite extends DisciplineSuite {
     "Target.surfaceFluxDensityContinuum",
     OptionalTests(Target.surfaceFluxDensityContinuum)
   )
-
   checkAll("Target.siderealTracking", OptionalTests(Target.siderealTracking))
   checkAll("Target.parallax", OptionalTests(Target.parallax))
   checkAll("Target.radialVelocity", OptionalTests(Target.radialVelocity))
   checkAll("Target.baseCoordinates", OptionalTests(Target.baseCoordinates))
   checkAll("Target.baseRA", OptionalTests(Target.baseRA))
   checkAll("Target.baseDec", OptionalTests(Target.baseDec))
-  checkAll("Target.catalogId", OptionalTests(Target.catalogId))
+  checkAll("Target.catalogInfo", OptionalTests(Target.catalogInfo))
   checkAll("Target.epoch", OptionalTests(Target.epoch))
   checkAll("Target.properMotion", OptionalTests(Target.properMotion))
   checkAll("Target.properMotionRA", OptionalTests(Target.properMotionRA))
   checkAll("Target.properMotionDec", OptionalTests(Target.properMotionDec))
+  checkAll("Target.catalogInfo", LensTests(Target.catalogInfo))
+  checkAll("Target.angularSize", LensTests(Target.angularSize))
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -272,7 +272,6 @@ final class TargetSuite extends DisciplineSuite {
     "Target.Nonsidereal.surfaceFluxDensityContinuum",
     OptionalTests(Target.Nonsidereal.surfaceFluxDensityContinuum)
   )
-  checkAll("Target.Nonsidereal.catalogInfo", LensTests(Target.Nonsidereal.catalogInfo))
   checkAll("Target.Nonsidereal.angularSize", LensTests(Target.Nonsidereal.angularSize))
 
   // Laws for Target
@@ -392,6 +391,6 @@ final class TargetSuite extends DisciplineSuite {
   checkAll("Target.properMotion", OptionalTests(Target.properMotion))
   checkAll("Target.properMotionRA", OptionalTests(Target.properMotionRA))
   checkAll("Target.properMotionDec", OptionalTests(Target.properMotionDec))
-  checkAll("Target.catalogInfo", LensTests(Target.catalogInfo))
+  checkAll("Target.catalogInfo", OptionalTests(Target.catalogInfo))
   checkAll("Target.angularSize", LensTests(Target.angularSize))
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -7,14 +7,14 @@ import cats.kernel.laws.discipline._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.scalacheck.string._
 import lucuma.core.arb._
+import lucuma.core.enum.Band
 import lucuma.core.math.arb._
+import lucuma.core.math.dimensional.arb.ArbQty
 import lucuma.core.model.arb._
 import lucuma.core.util.arb._
 import lucuma.core.util.laws.GidTests
 import monocle.law.discipline._
-import lucuma.core.math.dimensional.arb.ArbQty
 import munit._
-import lucuma.core.enum.Band
 
 final class TargetSuite extends DisciplineSuite {
   import ArbTarget._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TwilightBoundedNightSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TwilightBoundedNightSuite.scala
@@ -3,18 +3,20 @@
 
 package lucuma.core.model
 
-import munit._
-import org.scalacheck.Prop._
+import cats.Eq
+import cats.Show
+import cats.kernel.laws.discipline._
 import cats.syntax.all._
-import cats.{ Eq, Show }
-import java.time._
+import lucuma.core.arb.ArbTime._
 import lucuma.core.enum.Site
 import lucuma.core.enum.TwilightType
-import lucuma.core.arb.ArbTime._
 import lucuma.core.model.arb.ArbTwilightBoundedNight._
 import lucuma.core.util.arb.ArbEnumerated._
-import cats.kernel.laws.discipline._
+import munit._
+import org.scalacheck.Prop._
 import org.typelevel.cats.time._
+
+import java.time._
 
 final class TwilightBoundedNightSuite extends DisciplineSuite {
   checkAll("TwilightBoundedNight", OrderTests[TwilightBoundedNight].order)

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/UnnormalizedSpectralEnergyDistributionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/UnnormalizedSpectralEnergyDistributionSuite.scala
@@ -4,15 +4,15 @@
 package lucuma.core.model
 
 import cats.kernel.laws.discipline._
-import lucuma.core.model.arb._
-import munit._
-import lucuma.core.math.arb.ArbRefined
-import lucuma.core.util.arb.ArbEnumerated
-import monocle.law.discipline.LensTests
+import coulomb.cats.implicits._
 import coulomb.scalacheck.ArbQuantity
 import eu.timepit.refined.cats._
+import lucuma.core.math.arb.ArbRefined
+import lucuma.core.model.arb._
+import lucuma.core.util.arb.ArbEnumerated
+import monocle.law.discipline.LensTests
 import monocle.law.discipline.PrismTests
-import coulomb.cats.implicits._
+import munit._
 
 final class UnnormalizedSpectralEnergyDistributionSuite extends DisciplineSuite {
   import UnnormalizedSED._

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/UserSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/UserSuite.scala
@@ -3,11 +3,11 @@
 
 package lucuma.core.model
 
+import cats.kernel.laws.discipline.EqTests
 import lucuma.core.model.arb._
 import lucuma.core.util.arb._
 import lucuma.core.util.laws.GidTests
 import munit._
-import cats.kernel.laws.discipline.EqTests
 
 final class UserSuite extends DisciplineSuite {
   import ArbGid._

--- a/modules/tests/shared/src/test/scala/lucuma/core/optics/SpireOpticsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/optics/SpireOpticsSuite.scala
@@ -4,11 +4,11 @@
 package lucuma.core.optics
 
 import lucuma.core.optics.Spire._
-import spire.laws.arb._
 import lucuma.core.optics.laws.discipline.FormatTests
 import lucuma.core.optics.laws.discipline.SplitEpiTests
-import org.scalacheck.Arbitrary._
 import monocle.law.discipline.IsoTests
+import org.scalacheck.Arbitrary._
+import spire.laws.arb._
 
 final class SpireOpticsSuite extends munit.DisciplineSuite {
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampSuite.scala
@@ -3,21 +3,19 @@
 
 package lucuma.core.util
 
-import lucuma.core.util.Timestamp
-import lucuma.core.util.arb.ArbTimestamp._
+import cats.kernel.laws.discipline._
 import lucuma.core.arb.ArbTime._
 import lucuma.core.optics.laws.discipline._
-import cats.kernel.laws.discipline._
+import lucuma.core.util.Timestamp
+import lucuma.core.util.arb.ArbTimestamp._
+import munit._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Prop._
 import org.typelevel.cats.time._
 
-import java.time.ZonedDateTime
 import java.time.ZoneOffset.UTC
-
-import org.scalacheck.Prop._
-import org.scalacheck.Gen
-import org.scalacheck.Arbitrary
-
-import munit._
+import java.time.ZonedDateTime
 
 final class TimestampSuite extends DisciplineSuite {
 


### PR DESCRIPTION
- `CatalogId` renamed to `CatalogInfo`.
- Moved `CatalogInfo` to `Target`.
- Added `objectType`, so that we can store and show the object type retrieved from the catalog. Users may find this helpful when determining the profile and SED of targets.

Also, organize imports in tests.