### PR TITLE
Removable catalog info optic

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -572,8 +572,8 @@ trait TargetOptics { this: Target.type =>
     sidereal.andThen(Sidereal.properMotionDec)
 
   /** @group Optics */
-  val catalogInfo: Optional[Target, CatalogInfo] =
-    sidereal.andThen(Sidereal.catalogInfo.some)
+  val catalogInfo: Optional[Target, Option[CatalogInfo]] =
+    sidereal.andThen(Sidereal.catalogInfo)
 
   /** @group Optics */
   val angularSize: Lens[Target, Option[AngularSize]] =

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -374,7 +374,6 @@ final class TargetSuite extends DisciplineSuite {
   checkAll("Target.baseCoordinates", OptionalTests(Target.baseCoordinates))
   checkAll("Target.baseRA", OptionalTests(Target.baseRA))
   checkAll("Target.baseDec", OptionalTests(Target.baseDec))
-  checkAll("Target.catalogInfo", OptionalTests(Target.catalogInfo))
   checkAll("Target.epoch", OptionalTests(Target.epoch))
   checkAll("Target.properMotion", OptionalTests(Target.properMotion))
   checkAll("Target.properMotionRA", OptionalTests(Target.properMotionRA))


### PR DESCRIPTION
Since `catalogInfo` is optional, it should be removable via the optic (like proper motion, radial velocity, and parallax).