### PR TITLE
Tagged unit types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val refinedVersion        = "0.9.28"
 lazy val catsTimeVersion       = "0.5.0"
 lazy val circeVersion          = "0.14.1"
 lazy val catsScalacheckVersion = "0.3.1"
+// lazy val shapelessVersion      = ""
 
 inThisBuild(
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val refinedVersion        = "0.9.28"
 lazy val catsTimeVersion       = "0.5.0"
 lazy val circeVersion          = "0.14.1"
 lazy val catsScalacheckVersion = "0.3.1"
-// lazy val shapelessVersion      = ""
+lazy val shapelessVersion      = "2.3.3"
 
 inThisBuild(
   Seq(
@@ -58,7 +58,8 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "eu.timepit"     %%% "refined-cats"               % refinedVersion,
       "org.typelevel"  %%% "cats-time"                  % catsTimeVersion,
       "io.circe"       %%% "circe-core"                 % circeVersion,
-      "io.circe"       %%% "circe-refined"              % circeVersion
+      "io.circe"       %%% "circe-refined"              % circeVersion,
+      "com.chuusai"    %%% "shapeless"                  % shapelessVersion
     )
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/Band.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/Band.scala
@@ -20,6 +20,7 @@ import lucuma.core.math.units._
 import lucuma.core.util.Enumerated
 import spire.std.any._
 import spire.syntax.all._
+import shapeless.tag.@@
 
 /**
  * Enumerated type for wavelength band.
@@ -47,14 +48,10 @@ sealed abstract class Band(
 }
 
 trait BandDefaultUnit {
-  trait DefaultUnit[B, T] {
-    val unit: GroupedUnitType[Brightness[T]]
-  }
-  object DefaultUnit      {
-    def apply[B, T, U](implicit ev: UnitOfMeasure[U]) =
-      new DefaultUnit[B, T] {
-        val unit: GroupedUnitType[Brightness[T]] = ev.groupedIn[Brightness[T]]
-      }
+  class DefaultUnit[B, T](val unit: UnitType @@ Brightness[T])
+  object DefaultUnit {
+    def apply[B, T, U](implicit tagged: IsTaggedUnit[U, Brightness[T]]) =
+      new DefaultUnit[B, T](tagged.unit)
   }
 }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/Band.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/Band.scala
@@ -18,9 +18,9 @@ import lucuma.core.math.dimensional._
 import lucuma.core.math.units.Nanometer
 import lucuma.core.math.units._
 import lucuma.core.util.Enumerated
+import shapeless.tag.@@
 import spire.std.any._
 import spire.syntax.all._
-import shapeless.tag.@@
 
 /**
  * Enumerated type for wavelength band.

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/Band.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/Band.scala
@@ -50,6 +50,7 @@ sealed abstract class Band(
 trait BandDefaultUnit {
   class DefaultUnit[B, T](val unit: UnitType @@ Brightness[T])
   object DefaultUnit {
+    // Declare `U` as the default unit for band `B` and brightness type `T` (Integrated or Surface).
     def apply[B, T, U](implicit tagged: IsTaggedUnit[U, Brightness[T]]) =
       new DefaultUnit[B, T](tagged.unit)
   }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
@@ -9,6 +9,8 @@ import cats.data.NonEmptyList
 import lucuma.core.math.dimensional._
 import lucuma.core.math.units._
 import lucuma.core.util.Enumerated
+import shapeless.tag
+import shapeless.tag.@@
 
 object BrightnessUnits {
   type Integrated
@@ -18,103 +20,167 @@ object BrightnessUnits {
   trait LineFlux[+T]
   trait FluxDensityContinuum[+T]
 
+  // TODO This is general, move somewhere else
+
+  trait IsTagged[T, U] {
+    def apply(t: T): T @@ U = tag[U](t)
+  }
+
+  class IsTaggedUnit[U, Tag](implicit ev: UnitOfMeasure[U])
+      extends IsTagged[UnitOfMeasure[U], Tag] {
+    def unit: UnitOfMeasure[U] @@ Tag = tag[Tag](ev)
+  }
+
+  // Brightness Integrated
+  implicit object VegaMagnitudeIsIntegratedBrightnessUnit
+      extends IsTaggedUnit[VegaMagnitude, Brightness[Integrated]]
+  implicit object ABMagnitudeIsIntegratedBrightnessUnit
+      extends IsTaggedUnit[ABMagnitude, Brightness[Integrated]]
+  implicit object JanskyIsIntegratedBrightnessUnit
+      extends IsTaggedUnit[Jansky, Brightness[Integrated]]
+  implicit object WattsPerMeter2MicrometerIsIntegratedBrightnessUnit
+      extends IsTaggedUnit[WattsPerMeter2Micrometer, Brightness[Integrated]]
+  implicit object ErgsPerSecondCentimeter2AngstromIsIntegratedBrightnessUnit
+      extends IsTaggedUnit[ErgsPerSecondCentimeter2Angstrom, Brightness[Integrated]]
+  implicit object ErgsPerSecondCentimeter2HertzIsIntegratedBrightnessUnit
+      extends IsTaggedUnit[ErgsPerSecondCentimeter2Hertz, Brightness[Integrated]]
+
+  // Brightness Surface
+  implicit object VegaMagnitudePerArcsec2IsSurfaceBrightnessUnit
+      extends IsTaggedUnit[VegaMagnitudePerArcsec2, Brightness[Surface]]
+  implicit object ABMagnitudePerArcsec2IsSurfaceBrightnessUnit
+      extends IsTaggedUnit[ABMagnitudePerArcsec2, Brightness[Surface]]
+  implicit object JanskyPerArcsec2IsSurfaceBrightnessUnit
+      extends IsTaggedUnit[JanskyPerArcsec2, Brightness[Surface]]
+  implicit object WattsPerMeter2MicrometerArcsec2IsSurfaceBrightnessUnit
+      extends IsTaggedUnit[WattsPerMeter2MicrometerArcsec2, Brightness[Surface]]
+  implicit object ErgsPerSecondCentimeter2AngstromArcsec2IsSurfaceBrightnessUnit
+      extends IsTaggedUnit[ErgsPerSecondCentimeter2AngstromArcsec2, Brightness[Surface]]
+  implicit object ErgsPerSecondCentimeter2HertzArcsec2IsSurfaceBrightnessUnit
+      extends IsTaggedUnit[ErgsPerSecondCentimeter2HertzArcsec2, Brightness[Surface]]
+
+  // Line Flux Integrated
+  implicit object WattsPerMeter2IsIntegratedLineFluxUnit
+      extends IsTaggedUnit[WattsPerMeter2, LineFlux[Integrated]]
+  implicit object ErgsPerSecondCentimeter2IsIntegratedLineFluxUnit
+      extends IsTaggedUnit[ErgsPerSecondCentimeter2, LineFlux[Integrated]]
+
+  // Line Flux Surface
+  implicit object WattsPerMeter2Arcsec2IsSurfaceLineFluxUnit
+      extends IsTaggedUnit[WattsPerMeter2Arcsec2, LineFlux[Surface]]
+  implicit object ErgsPerSecondCentimeter2Arcsec2IsSurfaceLineFluxUnit
+      extends IsTaggedUnit[ErgsPerSecondCentimeter2Arcsec2, LineFlux[Surface]]
+
+  // Flux Density Continuum Integrated
+  implicit object WattsPerMeter2MicrometerIsIntegratedFluxDensityContinuumUnit
+      extends IsTaggedUnit[WattsPerMeter2Micrometer, FluxDensityContinuum[Integrated]]
+  implicit object ErgsPerSecondCentimeter2AngstromIsIntegratedFluxDensityContinuumUnit
+      extends IsTaggedUnit[ErgsPerSecondCentimeter2Angstrom, FluxDensityContinuum[Integrated]]
+
+  // Flux Density Continuum Surface
+  implicit object WattsPerMeter2MicrometerArcsec2IsSurfaceFluxDensityContinuumUnit
+      extends IsTaggedUnit[WattsPerMeter2MicrometerArcsec2, FluxDensityContinuum[Surface]]
+  implicit object ErgsPerSecondCentimeter2AngstromArcsec2IsSurfaceFluxDensityContinuumUnit
+      extends IsTaggedUnit[ErgsPerSecondCentimeter2AngstromArcsec2, FluxDensityContinuum[Surface]]
+
   object Brightness {
     object Integrated {
-      val all: NonEmptyList[GroupedUnitType[Brightness[Integrated]]] =
+
+      val all: NonEmptyList[UnitType @@ Brightness[Integrated]] =
         NonEmptyList
           .of(
-            UnitOfMeasure[VegaMagnitude],
-            UnitOfMeasure[ABMagnitude],
-            UnitOfMeasure[Jansky],
-            UnitOfMeasure[WattsPerMeter2Micrometer],
-            UnitOfMeasure[ErgsPerSecondCentimeter2Angstrom],
-            UnitOfMeasure[ErgsPerSecondCentimeter2Hertz]
+            VegaMagnitudeIsIntegratedBrightnessUnit,
+            ABMagnitudeIsIntegratedBrightnessUnit,
+            JanskyIsIntegratedBrightnessUnit,
+            WattsPerMeter2MicrometerIsIntegratedBrightnessUnit,
+            ErgsPerSecondCentimeter2AngstromIsIntegratedBrightnessUnit,
+            ErgsPerSecondCentimeter2HertzIsIntegratedBrightnessUnit
           )
-          .map(_.groupedIn[Brightness[Integrated]])
+          .map(_.unit)
     }
 
     object Surface {
-      val all: NonEmptyList[GroupedUnitType[Brightness[Surface]]] =
+      val all: NonEmptyList[UnitType @@ Brightness[Surface]] =
         NonEmptyList
           .of(
-            UnitOfMeasure[VegaMagnitudePerArcsec2],
-            UnitOfMeasure[ABMagnitudePerArcsec2],
-            UnitOfMeasure[JanskyPerArcsec2],
-            UnitOfMeasure[WattsPerMeter2MicrometerArcsec2],
-            UnitOfMeasure[ErgsPerSecondCentimeter2AngstromArcsec2],
-            UnitOfMeasure[ErgsPerSecondCentimeter2HertzArcsec2]
+            VegaMagnitudePerArcsec2IsSurfaceBrightnessUnit,
+            ABMagnitudePerArcsec2IsSurfaceBrightnessUnit,
+            JanskyPerArcsec2IsSurfaceBrightnessUnit,
+            WattsPerMeter2MicrometerArcsec2IsSurfaceBrightnessUnit,
+            ErgsPerSecondCentimeter2AngstromArcsec2IsSurfaceBrightnessUnit,
+            ErgsPerSecondCentimeter2HertzArcsec2IsSurfaceBrightnessUnit
           )
-          .map(_.groupedIn[Brightness[Surface]])
+          .map(_.unit)
     }
   }
 
   object LineFlux {
     object Integrated {
-      val all: NonEmptyList[GroupedUnitType[LineFlux[Integrated]]] =
+      val all: NonEmptyList[UnitType @@ LineFlux[Integrated]] =
         NonEmptyList
           .of(
-            UnitOfMeasure[WattsPerMeter2],
-            UnitOfMeasure[ErgsPerSecondCentimeter2]
+            WattsPerMeter2IsIntegratedLineFluxUnit,
+            ErgsPerSecondCentimeter2IsIntegratedLineFluxUnit
           )
-          .map(_.groupedIn[LineFlux[Integrated]])
+          .map(_.unit)
     }
 
     object Surface {
-      val all: NonEmptyList[GroupedUnitType[LineFlux[Surface]]] =
+      val all: NonEmptyList[UnitType @@ LineFlux[Surface]] =
         NonEmptyList
           .of(
-            UnitOfMeasure[WattsPerMeter2Arcsec2],
-            UnitOfMeasure[ErgsPerSecondCentimeter2Arcsec2]
+            WattsPerMeter2Arcsec2IsSurfaceLineFluxUnit,
+            ErgsPerSecondCentimeter2Arcsec2IsSurfaceLineFluxUnit
           )
-          .map(_.groupedIn[LineFlux[Surface]])
+          .map(_.unit)
     }
   }
 
   object FluxDensityContinuum {
     object Integrated {
-      val all: NonEmptyList[GroupedUnitType[FluxDensityContinuum[Integrated]]] =
+      val all: NonEmptyList[UnitType @@ FluxDensityContinuum[Integrated]] =
         NonEmptyList
           .of(
-            UnitOfMeasure[WattsPerMeter2Micrometer],
-            UnitOfMeasure[ErgsPerSecondCentimeter2Angstrom]
+            WattsPerMeter2MicrometerIsIntegratedFluxDensityContinuumUnit,
+            ErgsPerSecondCentimeter2AngstromIsIntegratedFluxDensityContinuumUnit
           )
-          .map(_.groupedIn[FluxDensityContinuum[Integrated]])
+          .map(_.unit)
     }
 
     object Surface {
-      val all: NonEmptyList[GroupedUnitType[FluxDensityContinuum[Surface]]] =
+      val all: NonEmptyList[UnitType @@ FluxDensityContinuum[Surface]] =
         NonEmptyList
           .of(
-            UnitOfMeasure[WattsPerMeter2MicrometerArcsec2],
-            UnitOfMeasure[ErgsPerSecondCentimeter2AngstromArcsec2]
+            WattsPerMeter2MicrometerArcsec2IsSurfaceFluxDensityContinuumUnit,
+            ErgsPerSecondCentimeter2AngstromArcsec2IsSurfaceFluxDensityContinuumUnit
           )
-          .map(_.groupedIn[FluxDensityContinuum[Surface]])
+          .map(_.unit)
     }
 
   }
 
-  private def enumGroupedUnitType[UG](
-    allList: NonEmptyList[GroupedUnitType[UG]]
-  ): Enumerated[GroupedUnitType[UG]] =
+  private def enumTaggedUnit[Tag](
+    allList: NonEmptyList[UnitType @@ Tag]
+  ): Enumerated[UnitType @@ Tag] =
     Enumerated.fromNEL(allList).withTag(_.abbv)
 
-  implicit val enumBrightnessIntegrated: Enumerated[GroupedUnitType[Brightness[Integrated]]] =
-    enumGroupedUnitType[Brightness[Integrated]](Brightness.Integrated.all)
+  implicit val enumBrightnessIntegrated: Enumerated[UnitType @@ Brightness[Integrated]] =
+    enumTaggedUnit[Brightness[Integrated]](Brightness.Integrated.all)
 
-  implicit val enumBrightnessSurface: Enumerated[GroupedUnitType[Brightness[Surface]]] =
-    enumGroupedUnitType[Brightness[Surface]](Brightness.Surface.all)
+  implicit val enumBrightnessSurface: Enumerated[UnitType @@ Brightness[Surface]] =
+    enumTaggedUnit[Brightness[Surface]](Brightness.Surface.all)
 
-  implicit val enumLineFluxIntegrated: Enumerated[GroupedUnitType[LineFlux[Integrated]]] =
-    enumGroupedUnitType[LineFlux[Integrated]](LineFlux.Integrated.all)
+  implicit val enumLineFluxIntegrated: Enumerated[UnitType @@ LineFlux[Integrated]] =
+    enumTaggedUnit[LineFlux[Integrated]](LineFlux.Integrated.all)
 
-  implicit val enumLineFluxSurface: Enumerated[GroupedUnitType[LineFlux[Surface]]] =
-    enumGroupedUnitType[LineFlux[Surface]](LineFlux.Surface.all)
+  implicit val enumLineFluxSurface: Enumerated[UnitType @@ LineFlux[Surface]] =
+    enumTaggedUnit[LineFlux[Surface]](LineFlux.Surface.all)
 
   implicit val enumFluxDensityContinuumIntegrated
-    : Enumerated[GroupedUnitType[FluxDensityContinuum[Integrated]]] =
-    enumGroupedUnitType[FluxDensityContinuum[Integrated]](FluxDensityContinuum.Integrated.all)
+    : Enumerated[UnitType @@ FluxDensityContinuum[Integrated]] =
+    enumTaggedUnit[FluxDensityContinuum[Integrated]](FluxDensityContinuum.Integrated.all)
 
   implicit val enumFluxDensityContinuumSurface
-    : Enumerated[GroupedUnitType[FluxDensityContinuum[Surface]]] =
-    enumGroupedUnitType[FluxDensityContinuum[Surface]](FluxDensityContinuum.Surface.all)
+    : Enumerated[UnitType @@ FluxDensityContinuum[Surface]] =
+    enumTaggedUnit[FluxDensityContinuum[Surface]](FluxDensityContinuum.Surface.all)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
@@ -9,7 +9,6 @@ import cats.data.NonEmptyList
 import lucuma.core.math.dimensional._
 import lucuma.core.math.units._
 import lucuma.core.util.Enumerated
-import shapeless.tag
 import shapeless.tag.@@
 
 object BrightnessUnits {
@@ -19,17 +18,6 @@ object BrightnessUnits {
   trait Brightness[+T]
   trait LineFlux[+T]
   trait FluxDensityContinuum[+T]
-
-  // TODO This is general, move somewhere else
-
-  trait IsTagged[T, U] {
-    def apply(t: T): T @@ U = tag[U](t)
-  }
-
-  class IsTaggedUnit[U, Tag](implicit ev: UnitOfMeasure[U])
-      extends IsTagged[UnitOfMeasure[U], Tag] {
-    def unit: UnitOfMeasure[U] @@ Tag = tag[Tag](ev)
-  }
 
   // Brightness Integrated
   implicit object VegaMagnitudeIsIntegratedBrightnessUnit

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/package.scala
@@ -3,7 +3,10 @@
 
 package lucuma.core.math
 
+import coulomb.Quantity
 import coulomb.unitops.UnitString
+import shapeless.tag
+import shapeless.tag.@@
 
 package object dimensional {
 
@@ -23,5 +26,12 @@ package object dimensional {
      */
     def apply[U](abbreviation: String): UnitString[U] =
       apply(abbreviation, abbreviation)
+  }
+
+  implicit class QuantityOps[N, U](quantity: Quantity[N, U]) {
+    def toQty(implicit unit: UnitOfMeasure[U]): Qty[N] = Qty(quantity.value, unit)
+
+    def toQtyT[Tag](implicit unit: UnitOfMeasure[U]): Qty[N] @@ Tag =
+      tag[Tag](Qty(quantity.value, unit))
   }
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/package.scala
@@ -29,8 +29,15 @@ package object dimensional {
   }
 
   implicit class QuantityOps[N, U](quantity: Quantity[N, U]) {
+
+    /**
+     * Convert a coulomb `Quantity` to a `Qty` with runtime unit representation.
+     */
     def toQty(implicit unit: UnitOfMeasure[U]): Qty[N] = Qty(quantity.value, unit)
 
+    /**
+     * Convert a coulomb `Quantity` to a `Qty` with runtime unit representation and tag `Tag`.
+     */
     def toQtyT[Tag](implicit unit: UnitOfMeasure[U]): Qty[N] @@ Tag =
       tag[Tag](Qty(quantity.value, unit))
   }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/quantity.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/quantity.scala
@@ -26,13 +26,17 @@ object Qty {
 
   implicit def eqTaggedQty[N: Eq, Tag]: Eq[Qty[N] @@ Tag] = Eq.by(x => (x.value, x.unit))
 
+  /** @group Optics */
   def value[N]: Lens[Qty[N], N] = Focus[Qty[N]](_.value)
 
+  /** @group Optics */
   def valueT[N, Tag]: Lens[Qty[N] @@ Tag, N] =
     Lens[Qty[N] @@ Tag, N](_.value)(v => q => tag[Tag](value.replace(v)(q)))
 
+  /** @group Optics */
   def unit[N]: Lens[Qty[N], UnitType] = Focus[Qty[N]](_.unit)
 
+  /** @group Optics */
   def unitT[N, Tag]: Lens[Qty[N] @@ Tag, UnitType @@ Tag] =
     Lens[Qty[N] @@ Tag, UnitType @@ Tag](q => tag[Tag](q.unit))(v =>
       q => tag[Tag](unit.replace(v)(q))

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
@@ -29,6 +29,7 @@ trait UnitType { self =>
   /** the abbreviation of a unit, e.g. "m" for "meter" */
   def abbv: String
 
+  /** Create a `Qty` with the specified value, keeping the runtime represantation of the units. */
   def withValue[N](value: N): Qty[N] = Qty[N](value, self)
 
   override def equals(obj: Any): Boolean = obj match {
@@ -47,6 +48,11 @@ object UnitType {
   implicit def displayUnitType: Display[UnitType] = Display.by(_.abbv, _.name)
 
   implicit class TaggedUnitTypeOps[Tag](val unitType: UnitType @@ Tag) extends AnyVal {
+
+    /**
+     * Create a `Qty` with the specified value, keeping the runtime represantation of the units,
+     * propagating the unit tag into the `Qty`.
+     */
     def withValueT[N](value: N): Qty[N] @@ Tag =
       tag[Tag](Qty[N](value, unitType))
   }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
@@ -6,6 +6,7 @@ package lucuma.core.math.dimensional
 import cats.Eq
 import coulomb.unitops.UnitString
 import lucuma.core.util.Display
+import lucuma.core.util.IsTagged
 import shapeless.tag
 import shapeless.tag.@@
 
@@ -28,10 +29,7 @@ trait UnitType { self =>
   /** the abbreviation of a unit, e.g. "m" for "meter" */
   def abbv: String
 
-  def withValue[N](_value: N): Qty[N] = new Qty[N] {
-    val value = _value
-    val unit  = self
-  }
+  def withValue[N](value: N): Qty[N] = Qty[N](value, self)
 
   override def equals(obj: Any): Boolean = obj match {
     case that: UnitType => name == that.name && abbv == that.abbv
@@ -49,11 +47,8 @@ object UnitType {
   implicit def displayUnitType: Display[UnitType] = Display.by(_.abbv, _.name)
 
   implicit class TaggedUnitTypeOps[Tag](val unitType: UnitType @@ Tag) extends AnyVal {
-    def withValueT[N](_value: N): Qty[N] @@ Tag =
-      tag[Tag](new Qty[N] {
-        val value = _value
-        val unit  = unitType
-      })
+    def withValueT[N](value: N): Qty[N] @@ Tag =
+      tag[Tag](Qty[N](value, unitType))
   }
 }
 
@@ -78,4 +73,11 @@ object UnitOfMeasure {
     }
 
   implicit def eqUnitOfMeasure[U]: Eq[UnitOfMeasure[U]] = Eq.fromUniversalEquals
+}
+
+/**
+ * Type class placing a tag `Tag` on a unit of measure.
+ */
+class IsTaggedUnit[U, Tag](implicit ev: UnitOfMeasure[U]) extends IsTagged[UnitOfMeasure[U], Tag] {
+  def unit: UnitOfMeasure[U] @@ Tag = tag[Tag](ev)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/BandBrightness.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/BandBrightness.scala
@@ -55,6 +55,7 @@ object BandBrightness {
   ): BandBrightness[T] =
     new BandBrightness(quantity, band, none)
 
+  /** Secondary constructor with error. */
   def apply[T](
     quantity: Qty[BrightnessValue] @@ Brightness[T],
     band:     Band,
@@ -62,40 +63,44 @@ object BandBrightness {
   ): BandBrightness[T] =
     new BandBrightness(quantity, band, error.some)
 
+  /** Secondary constructor using type units. */
   def apply[T, U](value: BrightnessValue, band: Band, error: Option[BrightnessValue])(implicit
     tagged:              IsTaggedUnit[U, Brightness[T]]
   ): BandBrightness[T] =
     new BandBrightness(tagged.unit.withValueT(value), band, error)
 
-  // def apply[T, U](value: BrightnessValue, band: Band, error: BrightnessValue)(implicit
-  //   enumerated:          Enumerated[GroupedUnitType[Brightness[T]]],
-  //   unit:                UnitOfMeasure[U]
-  // ): Option[BandBrightness[T]] =
-  //   apply[T, U](value, band, error.some)
+  /** Secondary constructor using type units and no error. */
+  def apply[T, U](value: BrightnessValue, band: Band)(implicit
+    tagged:              IsTaggedUnit[U, Brightness[T]]
+  ): BandBrightness[T] =
+    apply[T, U](value, band, none)
 
-  // def apply[T, U](value: BrightnessValue, band: Band)(implicit
-  //   enumerated:          Enumerated[GroupedUnitType[Brightness[T]]],
-  //   unit:                UnitOfMeasure[U]
-  // ): Option[BandBrightness[T]] =
-  //   apply[T, U](value, band, none)
+  /** Secondary constructor with error and using type units. */
+  def apply[T, U](value: BrightnessValue, band: Band, error: BrightnessValue)(implicit
+    tagged:              IsTaggedUnit[U, Brightness[T]]
+  ): BandBrightness[T] =
+    apply[T, U](value, band, error.some)
 
   // /** Secondary constructor using default units for the band. */
-  // def apply[T] = new GroupApplied[T]
-  // protected class GroupApplied[T] {
-  //   def apply[B <: Band](value: BrightnessValue, band: B, error: Option[BrightnessValue])(implicit
-  //     ev:                       Band.DefaultUnit[B, T]
-  //   ): BandBrightness[T] =
-  //     new BandBrightness(ev.unit.withValue(value), band, error)
+  def apply[T] = new GroupApplied[T]
+  protected class GroupApplied[T] {
+    // /** Secondary constructor using default units for the band. */
+    def apply[B <: Band](value: BrightnessValue, band: B, error: Option[BrightnessValue])(implicit
+      ev:                       Band.DefaultUnit[B, T]
+    ): BandBrightness[T] =
+      new BandBrightness(ev.unit.withValueT(value), band, error)
 
-  //   def apply[B <: Band](value: BrightnessValue, band: B)(implicit
-  //     ev:                       Band.DefaultUnit[B, T]
-  //   ): BandBrightness[T] =
-  //     apply(value, band, none)
+    // /** Secondary constructor using default units for the band and no error. */
+    def apply[B <: Band](value: BrightnessValue, band: B)(implicit
+      ev:                       Band.DefaultUnit[B, T]
+    ): BandBrightness[T] =
+      apply(value, band, none)
 
-  //   def apply[B <: Band](value: BrightnessValue, band: B, error: BrightnessValue)(implicit
-  //     ev:                       Band.DefaultUnit[B, T]
-  //   ): BandBrightness[T] = apply(value, band, error.some)
-  // }
+    // /** Secondary constructor with error and using default units for the band. */
+    def apply[B <: Band](value: BrightnessValue, band: B, error: BrightnessValue)(implicit
+      ev:                       Band.DefaultUnit[B, T]
+    ): BandBrightness[T] = apply(value, band, error.some)
+  }
 
   implicit def bandBrightnessOrder[T](implicit
     unitOrder: Order[UnitType @@ Brightness[T]]

--- a/modules/core/shared/src/main/scala/lucuma/core/model/BandBrightness.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/BandBrightness.scala
@@ -34,17 +34,23 @@ final case class BandBrightness[T](
 }
 
 object BandBrightness {
+
+  /** @group Optics */
   def quantity[T]: Lens[BandBrightness[T], Qty[BrightnessValue] @@ Brightness[T]] =
     Focus[BandBrightness[T]](_.quantity)
 
+  /** @group Optics */
   def value[T]: Lens[BandBrightness[T], BrightnessValue] =
     quantity.andThen(Qty.valueT)
 
+  /** @group Optics */
   def unit[T]: Lens[BandBrightness[T], UnitType @@ Brightness[T]] =
     quantity.andThen(Qty.unitT)
 
+  /** @group Optics */
   def band[T]: Lens[BandBrightness[T], Band] = Focus[BandBrightness[T]](_.band)
 
+  /** @group Optics */
   def error[T]: Lens[BandBrightness[T], Option[BrightnessValue]] =
     Focus[BandBrightness[T]](_.error)
 
@@ -81,34 +87,36 @@ object BandBrightness {
   ): BandBrightness[T] =
     apply[T, U](value, band, error.some)
 
-  // /** Secondary constructor using default units for the band. */
+  /** Secondary constructor using default units for the band. */
   def apply[T] = new GroupApplied[T]
   protected class GroupApplied[T] {
-    // /** Secondary constructor using default units for the band. */
+
+    /** Secondary constructor using default units for the band. */
     def apply[B <: Band](value: BrightnessValue, band: B, error: Option[BrightnessValue])(implicit
       ev:                       Band.DefaultUnit[B, T]
     ): BandBrightness[T] =
       new BandBrightness(ev.unit.withValueT(value), band, error)
 
-    // /** Secondary constructor using default units for the band and no error. */
+    /** Secondary constructor using default units for the band and no error. */
     def apply[B <: Band](value: BrightnessValue, band: B)(implicit
       ev:                       Band.DefaultUnit[B, T]
     ): BandBrightness[T] =
       apply(value, band, none)
 
-    // /** Secondary constructor with error and using default units for the band. */
+    /** Secondary constructor with error and using default units for the band. */
     def apply[B <: Band](value: BrightnessValue, band: B, error: BrightnessValue)(implicit
       ev:                       Band.DefaultUnit[B, T]
     ): BandBrightness[T] = apply(value, band, error.some)
   }
 
+  /** group Typeclass Instances */
   implicit def bandBrightnessOrder[T](implicit
     unitOrder: Order[UnitType @@ Brightness[T]]
   ): Order[BandBrightness[T]] =
     Order.by(m => (Qty.unitT.get(m.quantity), m.band.tag, Qty.value.get(m.quantity), m.error))
 
   /** group Typeclass Instances */
-  implicit def TargetBrightnessShow[T]: Show[BandBrightness[T]] =
+  implicit def bandBrightnessShow[T]: Show[BandBrightness[T]] =
     Show.fromToString
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/EmissionLine.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/EmissionLine.scala
@@ -15,11 +15,12 @@ import lucuma.core.math.dimensional._
 import lucuma.core.math.units._
 import monocle.Focus
 import monocle.Lens
+import shapeless.tag.@@
 
-final case class EmissionLine[+T](
+final case class EmissionLine[T](
   wavelength: Wavelength,
   lineWidth:  Quantity[PosBigDecimal, KilometersPerSecond],
-  lineFlux:   GroupedUnitQty[PosBigDecimal, LineFlux[T]]
+  lineFlux:   Qty[PosBigDecimal] @@ LineFlux[T]
 )
 
 object EmissionLine {
@@ -35,6 +36,6 @@ object EmissionLine {
     Focus[EmissionLine[T]](_.lineWidth)
 
   /** @group Optics */
-  def lineFlux[T]: Lens[EmissionLine[T], GroupedUnitQty[PosBigDecimal, LineFlux[T]]] =
+  def lineFlux[T]: Lens[EmissionLine[T], Qty[PosBigDecimal] @@ LineFlux[T]] =
     Focus[EmissionLine[T]](_.lineFlux)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SourceProfile.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SourceProfile.scala
@@ -9,13 +9,14 @@ import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.enum.Band
 import lucuma.core.math.BrightnessUnits._
 import lucuma.core.math.Wavelength
-import lucuma.core.math.dimensional.GroupedUnitQty
+import lucuma.core.math.dimensional.Qty
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
 import monocle.Prism
 import monocle.Traversal
 import monocle.macros.GenPrism
+import shapeless.tag.@@
 
 import scala.collection.immutable.SortedMap
 
@@ -202,12 +203,12 @@ object SourceProfile {
   /** @group Optics */
   val integratedFluxDensityContinuum: Optional[
     SourceProfile,
-    GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[Integrated]]
+    Qty[PosBigDecimal] @@ FluxDensityContinuum[Integrated]
   ] = integratedSpectralDefinition.andThen(SpectralDefinition.fluxDensityContinuum[Integrated])
 
   /** @group Optics */
   val surfaceFluxDensityContinuum: Optional[
     SourceProfile,
-    GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[Surface]]
+    Qty[PosBigDecimal] @@ FluxDensityContinuum[Surface]
   ] = surfaceSpectralDefinition.andThen(SpectralDefinition.fluxDensityContinuum[Surface])
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SpectralDefinition.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SpectralDefinition.scala
@@ -10,13 +10,14 @@ import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.enum.Band
 import lucuma.core.math.BrightnessUnits._
 import lucuma.core.math.Wavelength
-import lucuma.core.math.dimensional.GroupedUnitQty
+import lucuma.core.math.dimensional.Qty
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
 import monocle.Prism
 import monocle.Traversal
 import monocle.macros.GenPrism
+import shapeless.tag.@@
 
 import scala.collection.immutable.SortedMap
 
@@ -56,7 +57,7 @@ object SpectralDefinition {
   // TODO Check if BigDecimal [parse from/toString to] "5e-19".
   final case class EmissionLines[T](
     lines:                SortedMap[Wavelength, EmissionLine[T]],
-    fluxDensityContinuum: GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[T]]
+    fluxDensityContinuum: Qty[PosBigDecimal] @@ FluxDensityContinuum[T]
   ) extends SpectralDefinition[T] {
     lazy val wavelengths: List[Wavelength] = lines.keys.toList
   }
@@ -80,7 +81,7 @@ object SpectralDefinition {
     /** @group Optics */
     def fluxDensityContinuum[T]: Lens[
       EmissionLines[T],
-      GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[T]]
+      Qty[PosBigDecimal] @@ FluxDensityContinuum[T]
     ] = Focus[EmissionLines[T]](_.fluxDensityContinuum)
   }
 
@@ -131,6 +132,6 @@ object SpectralDefinition {
   /** @group Optics */
   def fluxDensityContinuum[T]: Optional[
     SpectralDefinition[T],
-    GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[T]]
+    Qty[PosBigDecimal] @@ FluxDensityContinuum[T]
   ] = emissionLines.andThen(EmissionLines.fluxDensityContinuum[T])
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -12,13 +12,14 @@ import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enum.Band
 import lucuma.core.math.BrightnessUnits._
 import lucuma.core.math._
-import lucuma.core.math.dimensional.GroupedUnitQty
+import lucuma.core.math.dimensional.Qty
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
 import monocle.Prism
 import monocle.Traversal
 import monocle.macros.GenPrism
+import shapeless.tag.@@
 
 import scala.collection.immutable.SortedMap
 
@@ -265,13 +266,13 @@ object Target extends WithId('t') with TargetOptics {
     /** @group Optics */
     val integratedFluxDensityContinuum: Optional[
       Sidereal,
-      GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[Integrated]]
+      Qty[PosBigDecimal] @@ FluxDensityContinuum[Integrated]
     ] = sourceProfile.andThen(SourceProfile.integratedFluxDensityContinuum)
 
     /** @group Optics */
     val surfaceFluxDensityContinuum: Optional[
       Sidereal,
-      GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[Surface]]
+      Qty[PosBigDecimal] @@ FluxDensityContinuum[Surface]
     ] = sourceProfile.andThen(SourceProfile.surfaceFluxDensityContinuum)
 
     /** @group Optics */
@@ -390,13 +391,13 @@ object Target extends WithId('t') with TargetOptics {
     /** @group Optics */
     val integratedFluxDensityContinuum: Optional[
       Nonsidereal,
-      GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[Integrated]]
+      Qty[PosBigDecimal] @@ FluxDensityContinuum[Integrated]
     ] = sourceProfile.andThen(SourceProfile.integratedFluxDensityContinuum)
 
     /** @group Optics */
     val surfaceFluxDensityContinuum: Optional[
       Nonsidereal,
-      GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[Surface]]
+      Qty[PosBigDecimal] @@ FluxDensityContinuum[Surface]
     ] = sourceProfile.andThen(SourceProfile.surfaceFluxDensityContinuum)
 
     /** @group Optics */
@@ -526,13 +527,13 @@ trait TargetOptics { this: Target.type =>
   /** @group Optics */
   val integratedFluxDensityContinuum: Optional[
     Target,
-    GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[Integrated]]
+    Qty[PosBigDecimal] @@ FluxDensityContinuum[Integrated]
   ] = sourceProfile.andThen(SourceProfile.integratedFluxDensityContinuum)
 
   /** @group Optics */
   val surfaceFluxDensityContinuum: Optional[
     Target,
-    GroupedUnitQty[PosBigDecimal, FluxDensityContinuum[Surface]]
+    Qty[PosBigDecimal] @@ FluxDensityContinuum[Surface]
   ] = sourceProfile.andThen(SourceProfile.surfaceFluxDensityContinuum)
 
   /** @group Optics */

--- a/modules/core/shared/src/main/scala/lucuma/core/util/IsTagged.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/IsTagged.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import shapeless.tag
+import shapeless.tag.@@
+
+/**
+ * Type class placing a tag `U` on type `T`. Helps produce tagged instances of `T`.
+ */
+trait IsTagged[T, U] {
+  def apply(t: T): T @@ U = tag[U](t)
+}

--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbRefined.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbRefined.scala
@@ -3,20 +3,24 @@
 
 package lucuma.core.math.arb
 
-import cats.syntax.all._
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 
 trait ArbRefined {
-  private val BigDecimalZero: BigDecimal = BigDecimal(0)
+  private val BigDecimalZero: BigDecimal      = BigDecimal(0)
+  private val PosBigDecimalOne: PosBigDecimal = PosBigDecimal(BigDecimal(1))
 
   // Refined does not derive this arbitrary. Generally deriving `Arbitrary` instances for `Pos`
   // numbers requires instances of `Adjacent` and `Max`, which don't exist for `BigDecimal`.
   implicit val arbPosBigDecimal: Arbitrary[PosBigDecimal] =
     Arbitrary(
-      arbitrary[BigDecimal].suchThat(_ =!= BigDecimalZero).map(x => PosBigDecimal.unsafeFrom(x.abs))
+      arbitrary[BigDecimal]
+        .map {
+          case BigDecimalZero => PosBigDecimalOne
+          case x              => PosBigDecimal.unsafeFrom(x.abs)
+        }
     )
 
   implicit val cogenPosBigDecimal: Cogen[PosBigDecimal] =

--- a/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbQty.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbQty.scala
@@ -3,7 +3,6 @@
 
 package lucuma.core.math.dimensional.arb
 
-// import coulomb.define.UnitDefinition
 import coulomb.Unitless
 import lucuma.core.math.dimensional._
 import org.scalacheck.Arbitrary._

--- a/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbQty.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbQty.scala
@@ -4,22 +4,34 @@
 package lucuma.core.math.dimensional.arb
 
 // import coulomb.define.UnitDefinition
+import coulomb.Unitless
 import lucuma.core.math.dimensional._
 import org.scalacheck.Arbitrary._
 import org.scalacheck._
 import shapeless.tag.@@
 
 trait ArbQty {
+  implicit val arbUnitType: Arbitrary[UnitType] =
+    Arbitrary {
+      for {
+        _name <- arbitrary[String]
+        _abbv <- arbitrary[String]
+      } yield new UnitType {
+        type Type = Unitless
+        val name = _name
+        val abbv = _abbv
+      }
+    }
+
   implicit val cogenUnitType: Cogen[UnitType] =
     Cogen[(String, String)].contramap(x => (x.name, x.abbv))
 
-  implicit def arbQty[N: Arbitrary, U](implicit
-    unit: UnitOfMeasure[U]
-  ): Arbitrary[Qty[N]] =
+  implicit def arbQty[N: Arbitrary]: Arbitrary[Qty[N]] =
     Arbitrary {
       for {
         n <- arbitrary[N]
-      } yield unit.withValue(n)
+        u <- arbitrary[UnitType]
+      } yield u.withValue(n)
     }
 
   implicit def cogenQty[N: Cogen]: Cogen[Qty[N]] =
@@ -35,10 +47,8 @@ trait ArbQty {
       } yield u.withValueT(n)
     }
 
-  // implicit def cogenTaggedUnitQty[N: Cogen, Tag](implicit
-  //   cogenUnit: Cogen[UnitType @@ Tag]
-  // ): Cogen[UnitType @@ Tag] =
-  //   Cogen[(N, UnitType @@ Tag)].contramap(q => (q.value, q.unit))
+  implicit def cogenTaggedUnitQty[N: Cogen, Tag]: Cogen[Qty[N] @@ Tag] =
+    Cogen[(N, UnitType)].contramap(q => (q.value, q.unit))
 }
 
 object ArbQty extends ArbQty

--- a/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbQty.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbQty.scala
@@ -7,6 +7,7 @@ package lucuma.core.math.dimensional.arb
 import lucuma.core.math.dimensional._
 import org.scalacheck.Arbitrary._
 import org.scalacheck._
+import shapeless.tag.@@
 
 trait ArbQty {
   implicit val cogenUnitType: Cogen[UnitType] =
@@ -24,20 +25,20 @@ trait ArbQty {
   implicit def cogenQty[N: Cogen]: Cogen[Qty[N]] =
     Cogen[(N, UnitType)].contramap(q => (q.value, q.unit))
 
-  implicit def arbGroupedUnitQty[N: Arbitrary, UG](implicit
-    arbUnit: Arbitrary[GroupedUnitType[UG]]
-  ): Arbitrary[GroupedUnitQty[N, UG]] =
+  implicit def arbTaggedUnitQty[N: Arbitrary, Tag](implicit
+    arbUnit: Arbitrary[UnitType @@ Tag]
+  ): Arbitrary[Qty[N] @@ Tag] =
     Arbitrary {
       for {
         n <- arbitrary[N]
-        u <- arbitrary[GroupedUnitType[UG]]
-      } yield u.withValue(n)
+        u <- arbitrary[UnitType @@ Tag]
+      } yield u.withValueT(n)
     }
 
-  implicit def cogenGroupedUnitQty[N: Cogen, UG](implicit
-    cogenUnit: Cogen[GroupedUnitType[UG]]
-  ): Cogen[GroupedUnitQty[N, UG]] =
-    Cogen[(N, GroupedUnitType[UG])].contramap(q => (q.value, q.unit))
+  // implicit def cogenTaggedUnitQty[N: Cogen, Tag](implicit
+  //   cogenUnit: Cogen[UnitType @@ Tag]
+  // ): Cogen[UnitType @@ Tag] =
+  //   Cogen[(N, UnitType @@ Tag)].contramap(q => (q.value, q.unit))
 }
 
 object ArbQty extends ArbQty

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbBandBrightness.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbBandBrightness.scala
@@ -14,6 +14,7 @@ import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen._
 import org.scalacheck._
+import shapeless.tag.@@
 
 trait ArbBandBrightness {
   import ArbEnumerated._
@@ -21,21 +22,19 @@ trait ArbBandBrightness {
   import ArbQty._
 
   implicit def arbBandBrightness[T](implicit
-    arbUnit: Arbitrary[GroupedUnitType[Brightness[T]]]
+    arbUnit: Arbitrary[UnitType @@ Brightness[T]]
   ): Arbitrary[BandBrightness[T]] =
     Arbitrary {
       for {
-        q <- arbitrary[GroupedUnitQty[BrightnessValue, Brightness[T]]]
+        q <- arbitrary[Qty[BrightnessValue] @@ Brightness[T]]
         b <- arbitrary[Band]
         e <- arbitrary[Option[BrightnessValue]]
       } yield BandBrightness(q, b, e)
     }
 
-  implicit def cogBandBrightness[T](implicit
-    cogenUnit: Cogen[GroupedUnitType[Brightness[T]]]
-  ): Cogen[BandBrightness[T]] =
+  implicit def cogBandBrightness[T]: Cogen[BandBrightness[T]] =
     Cogen[
-      (GroupedUnitQty[BrightnessValue, Brightness[T]], Band, Option[BrightnessValue])
+      (Qty[BrightnessValue], Band, Option[BrightnessValue])
     ].contramap(u => (u.quantity, u.band, u.error))
 }
 

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbEmissionLine.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbEmissionLine.scala
@@ -17,6 +17,7 @@ import lucuma.core.model.EmissionLine
 import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
+import shapeless.tag.@@
 
 trait ArbEmissionLine {
   import ArbEnumerated._
@@ -28,7 +29,7 @@ trait ArbEmissionLine {
   val RedWavelength: Wavelength = Wavelength.picometers.get(PosInt(620000))
 
   implicit def arbEmissionLine[T](implicit
-    arbLineFluxUnit: Arbitrary[GroupedUnitType[LineFlux[T]]]
+    arbLineFluxUnit: Arbitrary[UnitType @@ LineFlux[T]]
   ): Arbitrary[EmissionLine[T]] =
     Arbitrary {
       for {
@@ -38,15 +39,13 @@ trait ArbEmissionLine {
             20 -> arbitrary[Wavelength]
           )
         lw <- arbitrary[PosBigDecimal]
-        lf <- arbitrary[GroupedUnitQty[PosBigDecimal, LineFlux[T]]]
+        lf <- arbitrary[Qty[PosBigDecimal] @@ LineFlux[T]]
       } yield EmissionLine[T](w, lw.withUnit[KilometersPerSecond], lf)
     }
 
-  implicit def cogEmissionLine[T](implicit
-    cogenLineFluxUnit: Cogen[GroupedUnitType[LineFlux[T]]]
-  ): Cogen[EmissionLine[T]] =
+  implicit def cogEmissionLine[T]: Cogen[EmissionLine[T]] =
     Cogen[
-      (Wavelength, PosBigDecimal, GroupedUnitQty[PosBigDecimal, LineFlux[T]])
+      (Wavelength, PosBigDecimal, Qty[PosBigDecimal])
     ].contramap(x => (x.wavelength, x.lineWidth.value, x.lineFlux))
 }
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessUnitsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessUnitsSuite.scala
@@ -4,38 +4,38 @@
 package lucuma.core.math
 
 import lucuma.core.math.BrightnessUnits
-import lucuma.core.math.dimensional.GroupedUnitType
+import lucuma.core.math.dimensional.UnitType
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.laws.EnumeratedTests
 import munit.DisciplineSuite
+import shapeless.tag.@@
 
 final class BrightnessUnitsSuite extends DisciplineSuite {
   import ArbEnumerated._
   import BrightnessUnits._
 
   checkAll(
-    "GroupedUnitType[Brightness[Integrated]]",
-    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+    "UnitType @@ Brightness[Integrated]",
+    EnumeratedTests[UnitType @@ Brightness[Integrated]].enumerated
   )
   checkAll(
-    "GroupedUnitType[Brightness[Surface]]",
-    EnumeratedTests[GroupedUnitType[Brightness[Surface]]].enumerated
+    "UnitType @@ Brightness[Surface]",
+    EnumeratedTests[UnitType @@ Brightness[Surface]].enumerated
   )
   checkAll(
-    "GroupedUnitType[LineFlux[Integrated]]",
-    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+    "UnitType @@ LineFlux[Integrated]",
+    EnumeratedTests[UnitType @@ LineFlux[Integrated]].enumerated
   )
   checkAll(
-    "GroupedUnitType[LineFlux[Surface]]",
-    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+    "UnitType @@ LineFlux[Surface]",
+    EnumeratedTests[UnitType @@ LineFlux[Surface]].enumerated
   )
   checkAll(
-    "GroupedUnitType[FluxDensityContinuum[Integrated]]",
-    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+    "UnitType @@ [FluxDensityContinuum[Integrated]]",
+    EnumeratedTests[UnitType @@ FluxDensityContinuum[Integrated]].enumerated
   )
   checkAll(
-    "GroupedUnitType[FluxDensityContinuum[Surface]]",
-    EnumeratedTests[GroupedUnitType[Brightness[Integrated]]].enumerated
+    "UnitType @@ [FluxDensityContinuum[Surface]]",
+    EnumeratedTests[UnitType @@ FluxDensityContinuum[Surface]].enumerated
   )
-
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/QtySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/QtySuite.scala
@@ -9,7 +9,7 @@ import lucuma.core.math.dimensional.arb.ArbQty._
 import lucuma.core.util.arb.ArbEnumerated._
 import monocle.law.discipline._
 
-class GroupedUnitQtySuite extends munit.DisciplineSuite {
+class QtySuite extends munit.DisciplineSuite {
   // Laws
   checkAll(
     "GroupedUnitQty[BigDecimal, Brightness[Surface]]",

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/QtySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/QtySuite.scala
@@ -5,24 +5,24 @@ package lucuma.core.math.dimensional
 
 import cats.kernel.laws.discipline._
 import lucuma.core.math.BrightnessUnits._
-import lucuma.core.math.dimensional.arb.ArbQty._
+import lucuma.core.math.dimensional.arb.ArbQty
 import lucuma.core.util.arb.ArbEnumerated._
 import monocle.law.discipline._
+import shapeless.tag.@@
 
 class QtySuite extends munit.DisciplineSuite {
+  import ArbQty._
+
   // Laws
+  checkAll("Qty[BigDecimal]", EqTests[Qty[BigDecimal]].eqv)
   checkAll(
-    "GroupedUnitQty[BigDecimal, Brightness[Surface]]",
-    EqTests[GroupedUnitQty[BigDecimal, Brightness[Surface]]].eqv
+    "Qty[BigDecimal] @@ Brightness[Integrated]",
+    EqTests[Qty[BigDecimal] @@ Brightness[Integrated]].eqv
   )
 
   // Optics
-  checkAll(
-    "GroupedUnitQty[BigDecimal, Brightness[Surface]].value",
-    LensTests(GroupedUnitQty.value[BigDecimal, Brightness[Surface]])
-  )
-  checkAll(
-    "GroupedUnitQty[BigDecimal, Brightness[Surface]].unit",
-    LensTests(GroupedUnitQty.unit[BigDecimal, Brightness[Surface]])
-  )
+  checkAll("Qty[BigDecimal].value", LensTests(Qty.value[BigDecimal]))
+  checkAll("Qty[BigDecimal].valueT", LensTests(Qty.valueT[BigDecimal, Brightness[Surface]]))
+  checkAll("Qty[BigDecimal].unit", LensTests(Qty.unit[BigDecimal]))
+  checkAll("Qty[BigDecimal].unitT", LensTests(Qty.unitT[BigDecimal, Brightness[Surface]]))
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
@@ -16,6 +16,7 @@ import lucuma.core.model.arb._
 import lucuma.core.util.arb.ArbEnumerated
 import monocle.law.discipline.LensTests
 import munit._
+import coulomb._
 
 final class BandBrightnessSuite extends DisciplineSuite {
   import ArbBandBrightness._
@@ -25,31 +26,29 @@ final class BandBrightnessSuite extends DisciplineSuite {
   import ArbQty._
 
   def checkValues[T, U](
-    b:           Option[BandBrightness[T]]
+    b:           BandBrightness[T]
   )(scaledValue: Int, band: Band, scaledError: Option[Int])(implicit
     unit:        UnitOfMeasure[U]
   ): Unit = {
-    assertEquals(b.map(_.quantity.value.scaledValue), scaledValue.some)
-    assertEquals(b.map(_.quantity.unit.ungrouped), unit.some)
-    assertEquals(b.map(_.band), band.some)
-    assertEquals(b.flatMap(_.error.map(_.scaledValue)), scaledError)
+    assertEquals(b.quantity.value.scaledValue, scaledValue)
+    assertEquals(b.quantity.unit, unit)
+    assertEquals(b.band, band)
+    assertEquals(b.error.map(_.scaledValue), scaledError)
   }
 
   // Full constructors
   val b1 = BandBrightness(
-    GroupedUnitOfMeasure[Brightness[Integrated], VegaMagnitude]
-      .withValue(BrightnessValue.fromDouble(10.0)),
+    BrightnessValue.fromDouble(10.0).withUnit[VegaMagnitude].toQtyT[Brightness[Integrated]],
     Band.R
   )
-  checkValues[Integrated, VegaMagnitude](b1.some)(10000, Band.R, None)
+  checkValues[Integrated, VegaMagnitude](b1)(10000, Band.R, None)
 
   val b2 = BandBrightness(
-    GroupedUnitOfMeasure[Brightness[Integrated], VegaMagnitude]
-      .withValue(BrightnessValue.fromDouble(10.0)),
+    BrightnessValue.fromDouble(10.0).withUnit[VegaMagnitude].toQtyT[Brightness[Integrated]],
     Band.R,
     BrightnessValue.fromDouble(2.0)
   )
-  checkValues[Integrated, VegaMagnitude](b2.some)(10000, Band.R, 2000.some)
+  checkValues[Integrated, VegaMagnitude](b2)(10000, Band.R, 2000.some)
 
   // Convenience constructors
   val b3 = BandBrightness[Surface, ABMagnitudePerArcsec2](BrightnessValue.fromDouble(10.0), Band.R)
@@ -64,14 +63,14 @@ final class BandBrightnessSuite extends DisciplineSuite {
 
   // Default units
   val b5 = BandBrightness[Integrated](BrightnessValue.fromDouble(10.0), Band.R)
-  checkValues[Integrated, VegaMagnitude](b5.some)(10000, Band.R, None)
+  checkValues[Integrated, VegaMagnitude](b5)(10000, Band.R, None)
 
   val b6 = BandBrightness[Integrated](
     BrightnessValue.fromDouble(10.0),
     Band.R,
     BrightnessValue.fromDouble(2.0)
   )
-  checkValues[Integrated, VegaMagnitude](b6.some)(10000, Band.R, 2000.some)
+  checkValues[Integrated, VegaMagnitude](b6)(10000, Band.R, 2000.some)
 
   // Laws
   checkAll(


### PR DESCRIPTION
I was not happy with the concepts of `GroupedUnitType` and `GroupedUnitQty`. They were cumbersome and misleading since they didn't group anything and just type-tagged units and quantities. So, it seems that a simpler approach is to use, well, tagged types. This is what this PR does, by using tags on `UnitType` and `Qty` instead.

I think this generally makes code, eg `BandBrightness` constructors, a bit more intuitive. Also, associations between units and tags now exist at the type-level (via the `IsTaggedUnit` type class).

Notes:
- `shapeless` was already brought in transitively. I just added it explicitly to `build.sbt` now.
- Tagged types don't seem to be part of `shapeless` 3. They can be easily implemented though using intersection types, as shown here: https://contributors.scala-lang.org/t/poor-or-rich-mans-refinement-types-in-scala-3-x/4647/12.