### PR TITLE
switch BrightnessValue.fromBigDecimal to SplitEpi

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessValue.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessValue.scala
@@ -5,10 +5,11 @@ package lucuma.core.math
 
 import cats.Order
 import cats.Show
-import lucuma.core.optics.Format
+import lucuma.core.optics.{Format, SplitEpi}
 import spire.math.Rational
 
 import java.math.RoundingMode
+
 import scala.math.rint
 import scala.util.Try
 
@@ -51,22 +52,21 @@ object BrightnessValue {
     new BrightnessValue(rint(mg * 1000).toInt)
 
   /**
-   * Format with BigDecimal
+   * SplitEpi with BigDecimal
    * @group Optics
    */
-  val fromBigDecimal: Format[BigDecimal, BrightnessValue] =
-    Format[Int, BrightnessValue](v => Some(new BrightnessValue(v)), _.scaledValue)
-      .imapA[BigDecimal](
-        n => new java.math.BigDecimal(n).movePointLeft(3),
-        d => d.underlying.movePointRight(3).setScale(0, RoundingMode.HALF_UP).intValue
-      )
+  val fromBigDecimal: SplitEpi[BigDecimal, BrightnessValue] =
+    SplitEpi[BigDecimal, BrightnessValue](
+      d => new BrightnessValue(d.underlying.movePointRight(3).setScale(0, RoundingMode.HALF_UP).intValue),
+      b => new java.math.BigDecimal(b.scaledValue).movePointLeft(3)
+    )
 
   /**
    * @group Optics
    */
   val fromString: Format[String, BrightnessValue] =
     Format[String, BigDecimal](s => Try(BigDecimal(s)).toOption, _.toString)
-      .andThen(fromBigDecimal)
+      .andThen(fromBigDecimal.asFormat)
 
   /** @group Typeclass Instances */
   implicit val BrightnessValueShow: Show[BrightnessValue] =

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessValueSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessValueSuite.scala
@@ -8,7 +8,7 @@ import cats.Order
 import cats.Show
 import cats.kernel.laws.discipline._
 import lucuma.core.math.arb._
-import lucuma.core.optics.laws.discipline.FormatTests
+import lucuma.core.optics.laws.discipline.{FormatTests, SplitEpiTests}
 import munit.DisciplineSuite
 import org.scalacheck.Prop.forAll
 
@@ -17,7 +17,7 @@ final class BrightnessValueSuite extends DisciplineSuite {
 
   // Laws
   checkAll("BrightnessValue", OrderTests[BrightnessValue].order)
-  checkAll("fromBigDecimal", FormatTests(BrightnessValue.fromBigDecimal).format)
+  checkAll("fromBigDecimal", SplitEpiTests(BrightnessValue.fromBigDecimal).splitEpi)
   checkAll("fromString", FormatTests(BrightnessValue.fromString).formatWith(stringsBrightnessValue))
 
   test("Equality must be natural") {
@@ -48,8 +48,8 @@ final class BrightnessValueSuite extends DisciplineSuite {
   }
 
   test("BrightnessValue rounding") {
-    assertEquals(BrightnessValue.fromBigDecimal.unsafeGet(BigDecimal("1.0004")).scaledValue, 1000)
-    assertEquals(BrightnessValue.fromBigDecimal.unsafeGet(BigDecimal("1.0005")).scaledValue, 1001)
+    assertEquals(BrightnessValue.fromBigDecimal.get(BigDecimal("1.0004")).scaledValue, 1000)
+    assertEquals(BrightnessValue.fromBigDecimal.get(BigDecimal("1.0005")).scaledValue, 1001)
   }
 
 }


### PR DESCRIPTION
Shouldn't `BrightnessValue.fromBigDecimal` be a `SplitEpi`?  Ignoring `BigDecimal` values that are too big for an `Int` (which we were doing before as well) it seems like you always get some `BrightnessValue` from a `BigDecimal`.  It's never optional.