### PR TITLE
Serialized form for units. BandBrightness constructors.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: olafurpg/setup-scala@v13
       - uses: olafurpg/setup-gpg@v3
       - name: Publish
-        run: sbt ci-release
+        run: sbt -v -J-Xmx6g -J-Xss4m ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           java-version: adoptium@17
       - name: Run compile
-        run: sbt headerCheck +compile +test +doc
+        run: sbt -v -J-Xmx6g -J-Xss4m headerCheck +compile +test +doc

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/CoolStarTemperature.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/CoolStarTemperature.scala
@@ -4,8 +4,8 @@
 package lucuma.core.enum
 
 import coulomb._
-import coulomb.si.Kelvin
 import coulomb.refined._
+import coulomb.si.Kelvin
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.util.Display

--- a/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
@@ -152,7 +152,7 @@ object BrightnessUnits {
   private def enumTaggedUnit[T](
     allList: NonEmptyList[Units Of T]
   ): Enumerated[Units Of T] =
-    Enumerated.fromNEL(allList).withTag(_.abbv)
+    Enumerated.fromNEL(allList).withTag(_.serialized)
 
   implicit val enumBrightnessIntegrated: Enumerated[Units Of Brightness[Integrated]] =
     enumTaggedUnit[Brightness[Integrated]](Brightness.Integrated.all)

--- a/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessValue.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessValue.scala
@@ -5,11 +5,11 @@ package lucuma.core.math
 
 import cats.Order
 import cats.Show
-import lucuma.core.optics.{Format, SplitEpi}
+import lucuma.core.optics.Format
+import lucuma.core.optics.SplitEpi
 import spire.math.Rational
 
 import java.math.RoundingMode
-
 import scala.math.rint
 import scala.util.Try
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/coulomb.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/coulomb.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.math.dimensional
+
+import coulomb.UnitTypeName
+import coulomb.define.BaseUnit
+import coulomb.define.DerivedUnit
+import coulomb.unitops.UnitString
+import lucuma.core.syntax.string._
+import lucuma.core.util.TypeString
+import spire.math.Rational
+
+object BaseUnitDef {
+
+  /** Convenience method to create a coulomb `BaseUnit` and `TypeString` in one go. */
+  def apply[U](name: String = "", abbv: String = "", serialized: String = "")(implicit
+    ut:              UnitTypeName[U]
+  ): BaseUnit[U] with TypeString[U] = {
+    val base = BaseUnit[U](name, abbv)
+
+    val _serialized = if (serialized != "") serialized else base.name.toScreamingSnakeCase
+
+    new BaseUnit[U](base.name, base.abbv) with TypeString[U] {
+      override val serialized: String = _serialized
+    }
+  }
+}
+
+object DerivedUnitDef {
+
+  /** Convenience method to create a coulomb `DerivedUnit` and `TypeString` in one go. */
+  def apply[U, D](
+    coef:        Rational = Rational(1),
+    name:        String = "",
+    abbv:        String = "",
+    serialized:  String
+  )(implicit ut: UnitTypeName[U]): DerivedUnit[U, D] with TypeString[U] = {
+    val base = DerivedUnit[U, D](coef, name, abbv)
+
+    val _serialized = if (serialized != "") serialized else base.name.toScreamingSnakeCase
+
+    new DerivedUnit[U, D](base.coef, base.name, base.abbv) with TypeString[U] {
+      override val serialized: String = _serialized
+    }
+  }
+}
+
+/** Convenience class to create a coulomb `UnitString` and `TypeString` in one go. */
+
+final case class UnitStringDef[U](full: String, abbv: String, serialized: String)
+    extends UnitString[U]
+    with TypeString[U]
+
+object UnitStringDef {
+
+  /** Convenience method to create a coulomb `UnitString` and `TypeString` in one go. */
+  def apply[U](abbv: String, serialized: String): UnitStringDef[U] =
+    UnitStringDef[U](abbv, abbv, serialized)
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/coulomb.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/coulomb.scala
@@ -34,7 +34,7 @@ object DerivedUnitDef {
     coef:        Rational = Rational(1),
     name:        String = "",
     abbv:        String = "",
-    serialized:  String
+    serialized:  String = ""
   )(implicit ut: UnitTypeName[U]): DerivedUnit[U, D] with TypeString[U] = {
     val base = DerivedUnit[U, D](coef, name, abbv)
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
@@ -45,7 +45,7 @@ trait Units { self =>
   def withValue[N](value: N): Measure[N] = Measure[N](value, self)
 
   override def equals(obj: Any): Boolean = obj match {
-    case that: Units => name == that.name && abbv == that.abbv
+    case that: Units => name == that.name && abbv == that.abbv && serialized == that.serialized
     case _           => false
   }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import coulomb.unitops.UnitString
 import lucuma.core.util.Display
 import lucuma.core.util.Tag
+import lucuma.core.util.TypeString
 import shapeless.tag
 
 import java.util.Objects
@@ -22,11 +23,21 @@ import java.util.Objects
 trait Units { self =>
   type Type
 
-  /** the full name of a unit, e.g. "meter" */
+  /** The full name of a unit, e.g. "squared meter" */
   def name: String
 
-  /** the abbreviation of a unit, e.g. "m" for "meter" */
+  /** The abbreviation of a unit, e.g. "m²" for "squared meter" */
   def abbv: String
+
+  /**
+   * The serialized form of a unit, e.g. "METER_2" for "squared meter"
+   *
+   * May be particularly useful in limited-charset codecs.
+   *
+   * The name `tag` was intentinally avoided to prevent confusion with the type-tags used in
+   * `TaggedUnit` or `Units Of T`.
+   */
+  def serialized: String
 
   /**
    * Create a `Measure` with the specified value, keeping the runtime represantation of the units.
@@ -38,7 +49,7 @@ trait Units { self =>
     case _           => false
   }
 
-  override def hashCode: Int = Objects.hash(name, abbv)
+  override def hashCode: Int = Objects.hash(name, abbv, serialized)
 
   override def toString: String = abbv
 }
@@ -67,19 +78,20 @@ object Units {
  * Can be automatically derived if there's an implicit `BaseUnit[U]` or `DerivedUnit[U, _]` in
  * scope.
  */
-trait UnitOfMeasure[U] extends Units {
+final case class UnitOfMeasure[U](name: String, abbv: String, serialized: String) extends Units {
   type Type = U
+
+  def withSerialized(serialized: String): UnitOfMeasure[U] = copy(serialized = serialized)
 }
 
 object UnitOfMeasure {
   def apply[U: UnitOfMeasure]: UnitOfMeasure[U] = implicitly[UnitOfMeasure[U]]
 
-  implicit def unitOfMeasureFromUnitString[U](implicit ev: UnitString[U]): UnitOfMeasure[U] =
-    new UnitOfMeasure[U] {
-      override type Type = U
-      override val name = ev.full
-      override val abbv = ev.abbv
-    }
+  implicit def unitOfMeasureFromUnitString[U](implicit
+    ev: UnitString[U],
+    s:  TypeString[U]
+  ): UnitOfMeasure[U] =
+    UnitOfMeasure(ev.full, ev.abbv, s.serialized)
 
   implicit def eqUnitOfMeasure[U]: Eq[UnitOfMeasure[U]] = Eq.fromUniversalEquals
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/units.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/units.scala
@@ -10,7 +10,6 @@ import coulomb.mks._
 import coulomb.si._
 import coulomb.siprefix._
 import coulomb.time._
-import coulomb.unitops.UnitString
 import coulomb.unitops._
 import eu.timepit.refined._
 import eu.timepit.refined.auto._
@@ -56,23 +55,24 @@ trait units {
   // Integrated Brightness units
   type VegaMagnitude
   implicit val defineVegaMagnitude =
-    BaseUnit[VegaMagnitude](name = "Vega magnitude", abbv = "Vega mag")
+    BaseUnitDef[VegaMagnitude]("Vega magnitude", "Vega mag", "VEGA_MAGNITUDE")
 
   type ABMagnitude
   implicit val defineABMagnitude =
-    BaseUnit[ABMagnitude](name = "AB magnitude", abbv = "AB mag")
+    BaseUnitDef[ABMagnitude]("AB magnitude", "AB mag", "AB_MAGNITUDE")
 
   private val JanskysPerWattMeter2Hertz: SafeLong = SafeLong(10).pow(26)
   type Jansky
   implicit val defineJansky                       =
-    DerivedUnit[Jansky, Watt %/ ((Meter %^ 2) %* (Hertz %^ -1))](
+    DerivedUnitDef[Jansky, Watt %/ ((Meter %^ 2) %* (Hertz %^ -1))](
       Rational(1, JanskysPerWattMeter2Hertz),
-      abbv = "Jy"
+      abbv = "Jy",
+      serialized = "JANSKY"
     )
 
   type WattsPerMeter2Micrometer = Watt %/ ((Meter %^ 2) %* Micrometer)
-  implicit val strWattsPerMeter2Micrometer: UnitString[WattsPerMeter2Micrometer] =
-    UnitString[WattsPerMeter2Micrometer]("W/m²/µm")
+  implicit val strWattsPerMeter2Micrometer =
+    UnitStringDef[WattsPerMeter2Micrometer]("W/m²/µm", "W_PER_M_SQUARED_PER_UM")
 
   private val ErgsPerJoule: SafeLong = SafeLong(10).pow(7)
   type Erg
@@ -80,58 +80,68 @@ trait units {
     DerivedUnit[Erg, Joule](Rational(1, ErgsPerJoule), abbv = "erg")
 
   type ErgsPerSecondCentimeter2Angstrom = Erg %/ (Second %* (Centimeter %^ 2) %* Angstrom)
-  implicit val strErgsPerSecondCentimeter2Angstrom: UnitString[ErgsPerSecondCentimeter2Angstrom] =
-    UnitString[ErgsPerSecondCentimeter2Angstrom]("erg/s/cm²/Å")
+  implicit val strErgsPerSecondCentimeter2Angstrom =
+    UnitStringDef[ErgsPerSecondCentimeter2Angstrom]("erg/s/cm²/Å", "ERG_PER_S_PER_CM_SQUARED_PER_A")
 
   type ErgsPerSecondCentimeter2Hertz = Erg %/ (Second %* (Centimeter %^ 2) %* Hertz)
-  implicit val strErgsPerSecondCentimeter2Hertz: UnitString[ErgsPerSecondCentimeter2Hertz] =
-    UnitString[ErgsPerSecondCentimeter2Hertz]("erg/s/cm²/Hz")
+  implicit val strErgsPerSecondCentimeter2Hertz =
+    UnitStringDef[ErgsPerSecondCentimeter2Hertz]("erg/s/cm²/Hz", "ERG_PER_S_PER_CM_SQUARED_PER_HZ")
 
   // Surface Brightness units
   type VegaMagnitudePerArcsec2 = VegaMagnitude %/ (ArcSecond %^ 2)
-  implicit val strVegaMagnitudePerArcsec2: UnitString[VegaMagnitudePerArcsec2] =
-    UnitString[VegaMagnitudePerArcsec2]("Vega mag/arcsec²")
+  implicit val strVegaMagnitudePerArcsec2 =
+    UnitStringDef[VegaMagnitudePerArcsec2]("Vega mag/arcsec²", "VEGA_MAG_PER_ARCSEC_SQUARED")
 
   type ABMagnitudePerArcsec2 = ABMagnitude %/ (ArcSecond %^ 2)
-  implicit val strABMagnitudePerArcsec2: UnitString[ABMagnitudePerArcsec2] =
-    UnitString[ABMagnitudePerArcsec2]("AB mag/arcsec²")
+  implicit val strABMagnitudePerArcsec2 =
+    UnitStringDef[ABMagnitudePerArcsec2]("AB mag/arcsec²", "AB_MAG_PER_ARCSEC_SQUARED")
 
   type JanskyPerArcsec2 = Jansky %/ (ArcSecond %^ 2)
-  implicit val strJanskyPerArcsec2: UnitString[JanskyPerArcsec2] =
-    UnitString[JanskyPerArcsec2]("Jy/arcsec²")
+  implicit val strJanskyPerArcsec2 =
+    UnitStringDef[JanskyPerArcsec2]("Jy/arcsec²", "JY_PER_ARCSEC_SQUARED")
 
   type WattsPerMeter2MicrometerArcsec2 = WattsPerMeter2Micrometer %/ (ArcSecond %^ 2)
-  implicit val strWattsPerMeter2MicrometerArcsec2: UnitString[WattsPerMeter2MicrometerArcsec2] =
-    UnitString[WattsPerMeter2MicrometerArcsec2]("W/m²/µm/arcsec²")
+  implicit val strWattsPerMeter2MicrometerArcsec2 =
+    UnitStringDef[WattsPerMeter2MicrometerArcsec2](
+      "W/m²/µm/arcsec²",
+      "W_PER_M_SQUARED_PER_UM_PER_ARCSEC_SQUARED"
+    )
 
   type ErgsPerSecondCentimeter2AngstromArcsec2 =
     ErgsPerSecondCentimeter2Angstrom %/ (ArcSecond %^ 2)
-  implicit val strErgsPerSecondCentimeter2AngstromArcsec2
-    : UnitString[ErgsPerSecondCentimeter2AngstromArcsec2] =
-    UnitString[ErgsPerSecondCentimeter2AngstromArcsec2]("erg/s/cm²/Å/arcsec²")
+  implicit val strErgsPerSecondCentimeter2AngstromArcsec2 =
+    UnitStringDef[ErgsPerSecondCentimeter2AngstromArcsec2](
+      "erg/s/cm²/Å/arcsec²",
+      "ERG_PER_S_PER_CM_SQUARED_PER_A_PER_ARCSEC_SQUARED"
+    )
 
   type ErgsPerSecondCentimeter2HertzArcsec2 = ErgsPerSecondCentimeter2Hertz %/ (ArcSecond %^ 2)
-  implicit val strErgsPerSecondCentimeter2HertzArcsec2
-    : UnitString[ErgsPerSecondCentimeter2HertzArcsec2] =
-    UnitString[ErgsPerSecondCentimeter2HertzArcsec2]("erg/s/cm²/Hz/arcsec²")
+  implicit val strErgsPerSecondCentimeter2HertzArcsec2 =
+    UnitStringDef[ErgsPerSecondCentimeter2HertzArcsec2](
+      "erg/s/cm²/Hz/arcsec²",
+      "ERG_PER_S_PER_CM_SQUARED_PER_HZ_PER_ARCSEC_SQUARED"
+    )
 
   // Integrated Line Flux units
   type WattsPerMeter2 = Watt %/ (Meter %^ 2)
-  implicit val strWattsPerMeter2: UnitString[WattsPerMeter2] =
-    UnitString[WattsPerMeter2]("W/m²")
+  implicit val strWattsPerMeter2 =
+    UnitStringDef[WattsPerMeter2]("W/m²", "W_PER_M_SQUARED")
 
   type ErgsPerSecondCentimeter2 = Erg %/ (Second %* (Centimeter %^ 2))
-  implicit val strErgsPerSecondCentimeter2: UnitString[ErgsPerSecondCentimeter2] =
-    UnitString[ErgsPerSecondCentimeter2]("erg/s/cm²")
+  implicit val strErgsPerSecondCentimeter2 =
+    UnitStringDef[ErgsPerSecondCentimeter2]("erg/s/cm²", "ERG_PER_S_PER_CM_SQUARED")
 
   // Surface Line Flux units
   type WattsPerMeter2Arcsec2 = WattsPerMeter2 %/ (ArcSecond %^ 2)
-  implicit val strWattsPerMeter2Arcsec2: UnitString[WattsPerMeter2Arcsec2] =
-    UnitString[WattsPerMeter2Arcsec2]("W/m²/arcsec²")
+  implicit val strWattsPerMeter2Arcsec2 =
+    UnitStringDef[WattsPerMeter2Arcsec2]("W/m²/arcsec²", "W_PER_M_SQUARED_PER_ARCSEC_SQUARED")
 
   type ErgsPerSecondCentimeter2Arcsec2 = ErgsPerSecondCentimeter2 %/ (ArcSecond %^ 2)
-  implicit val strErgsPerSecondCentimeter2Arcsec2: UnitString[ErgsPerSecondCentimeter2Arcsec2] =
-    UnitString[ErgsPerSecondCentimeter2Arcsec2]("erg/s/cm²/arcsec²")
+  implicit val strErgsPerSecondCentimeter2Arcsec2 =
+    UnitStringDef[ErgsPerSecondCentimeter2Arcsec2](
+      "erg/s/cm²/arcsec²",
+      "ERG_PER_S_PER_CM_SQUARED_PER_ARCSEC_SQUARED"
+    )
 
   // PosInt can be converted to Rational exactly
   implicit def rationalPosIntConverter[U1, U2](implicit

--- a/modules/core/shared/src/main/scala/lucuma/core/model/BandBrightness.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/BandBrightness.scala
@@ -79,26 +79,26 @@ object BandBrightness {
     new BandBrightness(quantity, band, error.some)
 
   /** Secondary constructor using type units. */
-  def apply[T, U](value: BrightnessValue, band: Band, error: Option[BrightnessValue])(implicit
-    tagged:              TaggedUnit[U, Brightness[T]]
-  ): BandBrightness[T] =
-    new BandBrightness(tagged.unit.withValueTagged(value), band, error)
+  def apply[U]: UnitsApplied[U] = new UnitsApplied[U]
 
-  /** Secondary constructor using type units and no error. */
-  def apply[T, U](value: BrightnessValue, band: Band)(implicit
-    tagged:              TaggedUnit[U, Brightness[T]]
-  ): BandBrightness[T] =
-    apply[T, U](value, band, none)
+  protected class UnitsApplied[U] {
+    def apply[T](value: BrightnessValue, band: Band, error: Option[BrightnessValue])(implicit
+      tagged:           TaggedUnit[U, Brightness[T]]
+    ): BandBrightness[T] =
+      new BandBrightness(tagged.unit.withValueTagged(value), band, error)
 
-  /** Secondary constructor with error and using type units. */
-  def apply[T, U](value: BrightnessValue, band: Band, error: BrightnessValue)(implicit
-    tagged:              TaggedUnit[U, Brightness[T]]
-  ): BandBrightness[T] =
-    apply[T, U](value, band, error.some)
+    def apply[T](value: BrightnessValue, band: Band)(implicit
+      tagged:           TaggedUnit[U, Brightness[T]]
+    ): BandBrightness[T] = apply(value, band, none)
+
+    def apply[T](value: BrightnessValue, band: Band, error: BrightnessValue)(implicit
+      tagged:           TaggedUnit[U, Brightness[T]]
+    ): BandBrightness[T] = apply(value, band, error.some)
+  }
 
   /** Secondary constructor using default units for the band. */
-  def apply[T] = new GroupApplied[T]
-  protected class GroupApplied[T] {
+  def withDefaultUnits[T] = new BrightnessTypeApplied[T]
+  protected class BrightnessTypeApplied[T] {
 
     /** Secondary constructor using default units for the band. */
     def apply(

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TypeString.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TypeString.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+/**
+ * Type class defining a custom serialized representation of type `T`.
+ */
+trait TypeString[T] {
+  def serialized: String
+}

--- a/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbMeasure.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbMeasure.scala
@@ -12,13 +12,10 @@ trait ArbMeasure {
   implicit val arbUnitType: Arbitrary[Units] =
     Arbitrary {
       for {
-        _name <- arbitrary[String]
-        _abbv <- arbitrary[String]
-      } yield new Units {
-        type Type = Unitless
-        val name = _name
-        val abbv = _abbv
-      }
+        name <- arbitrary[String]
+        abbv <- arbitrary[String]
+        tag  <- arbitrary[String]
+      } yield UnitOfMeasure[Unitless](name, abbv, tag)
     }
 
   implicit val cogenUnitType: Cogen[Units] =

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessUnitsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BrightnessUnitsSuite.scala
@@ -8,6 +8,7 @@ import lucuma.core.math.dimensional._
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.laws.EnumeratedTests
 import munit.DisciplineSuite
+import lucuma.core.util.Enumerated
 
 final class BrightnessUnitsSuite extends DisciplineSuite {
   import ArbEnumerated._
@@ -38,6 +39,15 @@ final class BrightnessUnitsSuite extends DisciplineSuite {
     "Units Of [FluxDensityContinuum[Surface]]",
     EnumeratedTests[Units Of FluxDensityContinuum[Surface]].enumerated
   )
+
+  // Serialization
+  test("Serialization (via Enumerated tag)") {
+    val enum1 = implicitly[Enumerated[Units Of FluxDensityContinuum[Integrated]]]
+    assertEquals(
+      enum1.all.map(enum1.tag),
+      List("W_PER_M_SQUARED_PER_UM", "ERG_PER_S_PER_CM_SQUARED_PER_A")
+    )
+  }
 
   // Tag Conversions
   test("Tag conversion Brightness[Integrated] -> Brightness[Surface]") {

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/BandBrightnessSuite.scala
@@ -61,31 +61,31 @@ final class BandBrightnessSuite extends DisciplineSuite {
   )
 
   // Convenience constructors
-  val b3 = BandBrightness[Surface, ABMagnitudePerArcsec2](BrightnessValue.fromDouble(10.0), Band.R)
+  val b3 = BandBrightness[ABMagnitudePerArcsec2](BrightnessValue.fromDouble(10.0), Band.R)
   checkValues[Surface, ABMagnitudePerArcsec2](
     "Type-parametrized units without error"
   )(b3)(10000, Band.R, None)
 
-  val b4 = BandBrightness[Surface, ABMagnitudePerArcsec2](
+  val b4 = BandBrightness[ABMagnitude](
     BrightnessValue.fromDouble(10.0),
     Band.R,
     BrightnessValue.fromDouble(2.0)
   )
-  checkValues[Surface, ABMagnitudePerArcsec2]("Type-parametrized units with error")(b4)(
+  checkValues[Integrated, ABMagnitude]("Type-parametrized units with error")(b4)(
     10000,
     Band.R,
     2000.some
   )
 
   // Default units
-  val b5 = BandBrightness[Integrated](BrightnessValue.fromDouble(10.0), Band.R)
+  val b5 = BandBrightness.withDefaultUnits[Integrated](BrightnessValue.fromDouble(10.0), Band.R)
   checkValues[Integrated, VegaMagnitude]("Default band units without error")(b5)(
     10000,
     Band.R,
     None
   )
 
-  val b6 = BandBrightness[Surface](
+  val b6 = BandBrightness.withDefaultUnits[Surface](
     BrightnessValue.fromDouble(10.0),
     Band.SloanR,
     BrightnessValue.fromDouble(2.0)

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
@@ -37,7 +37,7 @@ final class SourceProfileSuite extends DisciplineSuite {
   // Conversions
   val sd1Integrated: SpectralDefinition[Integrated] = {
     val b: BandBrightness[Integrated] =
-      BandBrightness[Integrated](BrightnessValue.fromDouble(10.0), Band.R)
+      BandBrightness.withDefaultUnits[Integrated](BrightnessValue.fromDouble(10.0), Band.R)
 
     SpectralDefinition.BandNormalized(
       UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
@@ -47,7 +47,7 @@ final class SourceProfileSuite extends DisciplineSuite {
 
   val sd1Surface: SpectralDefinition[Surface] = {
     val b: BandBrightness[Surface] =
-      BandBrightness[Surface](BrightnessValue.fromDouble(10.0), Band.R)
+      BandBrightness.withDefaultUnits[Surface](BrightnessValue.fromDouble(10.0), Band.R)
 
     SpectralDefinition.BandNormalized(
       UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
@@ -34,7 +34,7 @@ final class SpectralDefinitionSuite extends DisciplineSuite {
   // Brightness type conversions
   val sd1Integrated: SpectralDefinition[Integrated] = {
     val b: BandBrightness[Integrated] =
-      BandBrightness[Integrated](BrightnessValue.fromDouble(10.0), Band.R)
+      BandBrightness.withDefaultUnits[Integrated](BrightnessValue.fromDouble(10.0), Band.R)
 
     SpectralDefinition.BandNormalized(
       UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
@@ -44,7 +44,7 @@ final class SpectralDefinitionSuite extends DisciplineSuite {
 
   val sd1Surface: SpectralDefinition[Surface] = {
     val b: BandBrightness[Surface] =
-      BandBrightness[Surface](BrightnessValue.fromDouble(10.0), Band.R)
+      BandBrightness.withDefaultUnits[Surface](BrightnessValue.fromDouble(10.0), Band.R)
 
     SpectralDefinition.BandNormalized(
       UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),


### PR DESCRIPTION
This PR addresses 2 issues:
- Keep in one place serialized forms of runtime units.
  - We can't use units abbreviations as GraphQL `enum` members due to the constrained charset.
  - Therefore we add a `serialized` property to `Units`.
  - Convenience constructors are added to create `coulomb` type instances together with the `serialized` string.
  - `Enumerated` instances of brightness tagged units now use `serialized` as `tag` instead of `abbv`.
- Constructors of `BandBrightness` where the units were specified as a type still required another type parameter for the brightness type (`Integrated`, `Surface`) even when it could be inferred.
  - Now, it's inferred:
    - Before: `BandBrightness[Integrated, ABMagnitude](BrightnessValue.fromDouble(10.0), Band.R)`
    - After: `BandBrightness[ABMagnitude](BrightnessValue.fromDouble(10.0), Band.R)`
  - Previous `BandBrightness[T]` constructor for brightness type `T` was used to infer default units for the band. It's now renamed explicitly to `BandBrightness.withDefaultUnits[T]`:
    - Before: `BandBrightness[Integrated](BrightnessValue.fromDouble(10.0), Band.R)`
    - After: `BandBrightness.withDefaultUnits[Integrated](BrightnessValue.fromDouble(10.0), Band.R)`
    - 
Also, more heap and stack is given to CI `sbt` runs. This is an attempt to solve compilation issues in CI.