### PR TITLE
disable parallel compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import sbtcrossproject.CrossType
 
+Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)
+
 lazy val attoVersion           = "0.9.5"
 lazy val catsVersion           = "2.7.0"
 lazy val kindProjectorVersion  = "0.13.2"


### PR DESCRIPTION
This seems to stabilize the build and eliminate the crashes documented at https://github.com/tpolecat/lucuma-core-crashes, at the cost of increased build time. See also https://github.com/scala/bug/issues/10682 for discussion.