### PR TITLE
Use 'normal' tag

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/CoolStarTemperature.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/CoolStarTemperature.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.core.enum
+package lucuma.core.`enum`
 
 import coulomb._
 import coulomb.refined._
@@ -25,7 +25,7 @@ object CoolStarTemperature {
     case object T1000K extends CoolStarTemperature("1000K", BigDecimal(1000).withRefinedUnit[Positive, Kelvin])
     case object T1200K extends CoolStarTemperature("1200K", BigDecimal(1200).withRefinedUnit[Positive, Kelvin])
     case object T1400K extends CoolStarTemperature("1400K", BigDecimal(1400).withRefinedUnit[Positive, Kelvin])
-    case object T1600K extends CoolStarTemperature("1600K",BigDecimal(1600).withRefinedUnit[Positive, Kelvin])
+    case object T1600K extends CoolStarTemperature("1600K", BigDecimal(1600).withRefinedUnit[Positive, Kelvin])
     case object T1800K extends CoolStarTemperature("1800K", BigDecimal(1800).withRefinedUnit[Positive, Kelvin])
     case object T2000K extends CoolStarTemperature("2000K", BigDecimal(2000).withRefinedUnit[Positive, Kelvin])
     case object T2200K extends CoolStarTemperature("2200K", BigDecimal(2200).withRefinedUnit[Positive, Kelvin])
@@ -34,7 +34,7 @@ object CoolStarTemperature {
     case object T2800K extends CoolStarTemperature("2800K", BigDecimal(2800).withRefinedUnit[Positive, Kelvin])
 
   implicit val enumCoolStarTemperature: Enumerated[CoolStarTemperature] =
-    Enumerated.from(T400K, T600K, T800K, T900K, T1000K, T1200K, T1400K, T1600K, T1800K, T2000K, T2200K, T2400K, T2600K, T2800K).withTag(_.name)
+    Enumerated.of(T400K, T600K, T800K, T900K, T1000K, T1200K, T1400K, T1600K, T1800K, T2000K, T2200K, T2400K, T2600K, T2800K)
 
   implicit val displayCoolstarTemperature: Display[CoolStarTemperature] =
     Display.byShortName(_.name)


### PR DESCRIPTION
Might we use the "normal" tag for `CoolStarTemperature`?  GraphQL enums cannot start with a number so we'd need to define them with a leading `T`.  That's fine, but then the `Decoder` defined in `Enumerated`, which looks for the tag, doesn't work for reading inputs.  It sees, for example, `T400_K` but that doesn't match the (screaming snake) tag `400_K`.  We can overcome that with a custom `Decoder` but maybe the "normal" tag is okay?

On the other hand, perhaps relying upon the `Enumerated` decoder is too fragile though?  Discuss. 