### PR TITLE
Remove UC band

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/Band.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/Band.scala
@@ -167,16 +167,6 @@ object Band {
       )
 
   /** @group Constructors */
-  case object Uc
-      extends BandWithDefaultUnits[VegaMagnitude, VegaMagnitudePerArcsec2](
-        "Uc",
-        "UC",
-        "UCAC",
-        Wavelength(610000),
-        63.withRefinedUnit[Positive, Nanometer]
-      )
-
-  /** @group Constructors */
   case object R
       extends BandWithDefaultUnits[VegaMagnitude, VegaMagnitudePerArcsec2](
         "R",
@@ -288,7 +278,7 @@ object Band {
 
   /** All members of Band, in canonical order. */
   val all: List[Band] =
-    List(SloanU, SloanG, SloanR, SloanI, SloanZ, U, B, V, Uc, R, I, Y, J, H, K, L, M, N, Q, Ap)
+    List(SloanU, SloanG, SloanR, SloanI, SloanZ, U, B, V, R, I, Y, J, H, K, L, M, N, Q, Ap)
 
   /** Select the member of Band with the given tag, if any. */
   def fromTag(s: String): Option[Band] =


### PR DESCRIPTION
After some discussions with science it was suggested we could drop UC.
ITC cannot handle UC and it is only relevant to the UCAC catalog while we'll be using GAIA in GPP