### PR TITLE
Measure + Units ~show~/display, test suit for Units, minor renamings

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
@@ -176,8 +176,8 @@ object BrightnessUnits {
     enumTaggedUnit[FluxDensityContinuum[Surface]](FluxDensityContinuum.Surface.all)
 
   /**
-   * Typeclass providing a conversion between a `UnitType` tagged with `T` to a corresponding
-   * `UnitType` tagged with `T0`.
+   * Typeclass providing a conversion between a `Units` tagged with `T` to a corresponding `Units`
+   * tagged with `T0`.
    *
    * This is used to convert between `Integrated` <-> `Surface` units.
    */
@@ -231,7 +231,7 @@ object BrightnessUnits {
 
   implicit class TaggedUnitOps[T](val units: Units Of T) extends AnyVal {
 
-    /** Convert `T`-tagged `UnitType` to a `T0`-tagged one. */
+    /** Convert `T`-tagged `Units` to a `T0`-tagged ones. */
     def toTag[T0](implicit conv: TagConverter[T, T0]): Units Of T0 =
       conv.convert(units)
   }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/measure.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/measure.scala
@@ -39,10 +39,8 @@ object Measure {
   implicit def eqTaggedMeasure[N: Eq, T]: Eq[Measure[N] Of T] =
     Eq.by(x => (x.value, x.units, x.error))
 
-  // TODO TEST
   implicit def showMeasure[N]: Show[Measure[N]] = Show.fromToString
 
-  // TODO TEST
   implicit def displayMeasure[N]: Display[Measure[N]] =
     Display.by(
       m => s"${m.value}${m.errStr} ${m.units.abbv}",

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/measure.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/measure.scala
@@ -6,11 +6,10 @@ package lucuma.core.math.dimensional
 import cats.Eq
 import cats.syntax.option._
 import coulomb._
+import lucuma.core.util.Display
 import monocle.Focus
 import monocle.Lens
 import shapeless.tag
-import _root_.cats.Show
-import lucuma.core.util.Display
 
 /**
  * A magnitude of type `N` and a runtime representation of a physical unit.
@@ -38,8 +37,6 @@ object Measure {
 
   implicit def eqTaggedMeasure[N: Eq, T]: Eq[Measure[N] Of T] =
     Eq.by(x => (x.value, x.units, x.error))
-
-  implicit def showMeasure[N]: Show[Measure[N]] = Show.fromToString
 
   implicit def displayMeasure[N]: Display[Measure[N]] =
     Display.by(

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
@@ -12,6 +12,7 @@ import lucuma.core.util.TypeString
 import shapeless.tag
 
 import java.util.Objects
+import cats.Show
 
 /**
  * Runtime representation of a physical unit. Wraps:
@@ -56,18 +57,20 @@ trait Units { self =>
 }
 
 object Units {
-  implicit val eqUnitType: Eq[Units] = Eq.fromUniversalEquals
+  implicit val eqUnits: Eq[Units] = Eq.fromUniversalEquals
 
-  implicit def displayUnitType: Display[Units] = Display.by(_.abbv, _.name)
+  implicit val showUnits: Show[Units] = Show.fromToString
 
-  implicit class TaggedUnitTypeOps[T](val unitType: Units Of T) extends AnyVal {
+  implicit val displayUnits: Display[Units] = Display.by(_.abbv, _.name)
+
+  implicit class TaggedUnitsOps[T](val units: Units Of T) extends AnyVal {
 
     /**
      * Create a `Measure` with the specified value, keeping the runtime represantation of the units,
      * propagating the unit tag into the `Measure`.
      */
     def withValueTagged[N](value: N, error: Option[N] = none): Measure[N] Of T = {
-      val tagged = tag[T](Measure[N](value, unitType, error))
+      val tagged = tag[T](Measure[N](value, units, error))
       tagged
     }
   }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
@@ -12,7 +12,6 @@ import lucuma.core.util.TypeString
 import shapeless.tag
 
 import java.util.Objects
-import cats.Show
 
 /**
  * Runtime representation of a physical unit. Wraps:
@@ -58,8 +57,6 @@ trait Units { self =>
 
 object Units {
   implicit val eqUnits: Eq[Units] = Eq.fromUniversalEquals
-
-  implicit val showUnits: Show[Units] = Show.fromToString
 
   implicit val displayUnits: Display[Units] = Display.by(_.abbv, _.name)
 

--- a/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbMeasure.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbMeasure.scala
@@ -3,23 +3,12 @@
 
 package lucuma.core.math.dimensional.arb
 
-import coulomb.Unitless
 import lucuma.core.math.dimensional._
 import org.scalacheck.Arbitrary._
 import org.scalacheck._
 
 trait ArbMeasure {
-  implicit val arbUnitType: Arbitrary[Units] =
-    Arbitrary {
-      for {
-        name <- arbitrary[String]
-        abbv <- arbitrary[String]
-        tag  <- arbitrary[String]
-      } yield UnitOfMeasure[Unitless](name, abbv, tag)
-    }
-
-  implicit val cogenUnitType: Cogen[Units] =
-    Cogen[(String, String)].contramap(x => (x.name, x.abbv))
+  import ArbUnits._
 
   implicit def arbMeasure[N: Arbitrary]: Arbitrary[Measure[N]] =
     Arbitrary {
@@ -33,7 +22,7 @@ trait ArbMeasure {
   implicit def cogenMeasure[N: Cogen]: Cogen[Measure[N]] =
     Cogen[(N, Units, Option[N])].contramap(m => (m.value, m.units, m.error))
 
-  implicit def arbTaggedUnitMeasure[N: Arbitrary, Tag](implicit
+  implicit def arbTaggedMeasure[N: Arbitrary, Tag](implicit
     arbUnit: Arbitrary[Units Of Tag]
   ): Arbitrary[Measure[N] Of Tag] =
     Arbitrary {
@@ -44,7 +33,7 @@ trait ArbMeasure {
       } yield u.withValueTagged(n, e)
     }
 
-  implicit def cogenTaggedUnitMeasure[N: Cogen, Tag]: Cogen[Measure[N] Of Tag] =
+  implicit def cogenTaggedMeasure[N: Cogen, Tag]: Cogen[Measure[N] Of Tag] =
     Cogen[(N, Units, Option[N])].contramap(m => (m.value, m.units, m.error))
 }
 

--- a/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbUnits.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/dimensional/arb/ArbUnits.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.math.dimensional.arb
+
+import coulomb.Unitless
+import lucuma.core.math.dimensional._
+import org.scalacheck.Arbitrary._
+import org.scalacheck._
+
+trait ArbUnits {
+  implicit val arbUnits: Arbitrary[Units] =
+    Arbitrary {
+      for {
+        name       <- arbitrary[String]
+        abbv       <- arbitrary[String]
+        serialized <- arbitrary[String]
+      } yield UnitOfMeasure[Unitless](name, abbv, serialized)
+    }
+
+  implicit val cogenUnits: Cogen[Units] =
+    Cogen[(String, String, String)].contramap(x => (x.name, x.abbv, x.serialized))
+}
+
+object ArbUnits extends ArbUnits

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/MeasureSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/MeasureSuite.scala
@@ -4,7 +4,6 @@
 package lucuma.core.math.dimensional
 
 import cats.Eq
-import cats.Show
 import cats.kernel.laws.discipline._
 import cats.syntax.all._
 import lucuma.core.math.BrightnessUnits._
@@ -28,12 +27,6 @@ class MeasureSuite extends munit.DisciplineSuite {
   test("Equality must be natural") {
     forAll { (a: Measure[BigDecimal], b: Measure[BigDecimal]) =>
       assertEquals(a.equals(b), Eq[Measure[BigDecimal]].eqv(a, b))
-    }
-  }
-
-  test("Show must be natural") {
-    forAll { (a: Measure[BigDecimal]) =>
-      assertEquals(a.toString, Show[Measure[BigDecimal]].show(a))
     }
   }
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/MeasureSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/MeasureSuite.scala
@@ -3,15 +3,20 @@
 
 package lucuma.core.math.dimensional
 
+import cats.Eq
+import cats.Show
 import cats.kernel.laws.discipline._
 import cats.syntax.all._
 import lucuma.core.math.BrightnessUnits._
 import lucuma.core.math.dimensional.arb.ArbMeasure
+import lucuma.core.math.dimensional.arb.ArbUnits
 import lucuma.core.util.arb.ArbEnumerated._
 import monocle.law.discipline._
+import org.scalacheck.Prop._
 
 class MeasureSuite extends munit.DisciplineSuite {
   import ArbMeasure._
+  import ArbUnits._
 
   // Laws
   checkAll("Measure[BigDecimal]", EqTests[Measure[BigDecimal]].eqv)
@@ -19,6 +24,18 @@ class MeasureSuite extends munit.DisciplineSuite {
     "Measure[BigDecimal] Of Brightness[Integrated]",
     EqTests[Measure[BigDecimal] Of Brightness[Integrated]].eqv
   )
+
+  test("Equality must be natural") {
+    forAll { (a: Measure[BigDecimal], b: Measure[BigDecimal]) =>
+      assertEquals(a.equals(b), Eq[Measure[BigDecimal]].eqv(a, b))
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Measure[BigDecimal]) =>
+      assertEquals(a.toString, Show[Measure[BigDecimal]].show(a))
+    }
+  }
 
   // Optics
   checkAll("Measure[BigDecimal].value", LensTests(Measure.value[BigDecimal]))

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/UnitSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/UnitSuite.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.math.dimensional
+
+import cats.Eq
+import cats.Show
+import cats.kernel.laws.discipline._
+import lucuma.core.math.BrightnessUnits._
+import lucuma.core.math.dimensional.arb.ArbUnits
+import lucuma.core.util.arb.ArbEnumerated._
+import org.scalacheck.Prop._
+
+class UnitSuite extends munit.DisciplineSuite {
+  import ArbUnits._
+
+  // Laws
+  checkAll("Units", EqTests[Units].eqv)
+  checkAll(
+    "Units Of Brightness[Integrated]",
+    EqTests[Units Of Brightness[Integrated]].eqv
+  )
+
+  test("Equality must be natural") {
+    forAll { (a: Units, b: Units) =>
+      assertEquals(a.equals(b), Eq[Units].eqv(a, b))
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Units) =>
+      assertEquals(a.toString, Show[Units].show(a))
+    }
+  }
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/UnitSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/UnitSuite.scala
@@ -4,7 +4,6 @@
 package lucuma.core.math.dimensional
 
 import cats.Eq
-import cats.Show
 import cats.kernel.laws.discipline._
 import lucuma.core.math.BrightnessUnits._
 import lucuma.core.math.dimensional.arb.ArbUnits
@@ -24,12 +23,6 @@ class UnitSuite extends munit.DisciplineSuite {
   test("Equality must be natural") {
     forAll { (a: Units, b: Units) =>
       assertEquals(a.equals(b), Eq[Units].eqv(a, b))
-    }
-  }
-
-  test("Show must be natural") {
-    forAll { (a: Units) =>
-      assertEquals(a.toString, Show[Units].show(a))
     }
   }
 }


### PR DESCRIPTION
- Add `Display[Measure]`, `Show[Measure]` and `Show[Units]`.
- Add `UnitTest`.
- Minor renamings that were pending (`Units` was previously called `UnitType`).