### PR TITLE
Display tagged Units and Measure.

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/dimensional/unit.scala
@@ -60,6 +60,9 @@ object Units {
 
   implicit val displayUnits: Display[Units] = Display.by(_.abbv, _.name)
 
+  implicit def displayTaggedUnits[T]: Display[Units Of T] =
+    Display[Units].narrow
+
   implicit class TaggedUnitsOps[T](val units: Units Of T) extends AnyVal {
 
     /**

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/MeasureSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/MeasureSuite.scala
@@ -35,10 +35,10 @@ class MeasureSuite extends munit.DisciplineSuite {
     import lucuma.core.math.units._
     import lucuma.core.syntax.display._
 
-    assertEquals(
-      UnitOfMeasure[ABMagnitude].withValue(BrightnessValue.fromDouble(1.235)).shortName,
-      "1.235 AB mag"
-    )
+    val m = UnitOfMeasure[ABMagnitude].withValue(BrightnessValue.fromDouble(1.235))
+
+    assertEquals(m.shortName, "1.235 AB mag")
+    assertEquals(m.withError(BrightnessValue.fromDouble(0.005)).shortName, "1.235 ± 0.005 AB mag")
   }
 
   // Optics

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/UnitSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/UnitSuite.scala
@@ -8,6 +8,7 @@ import cats.kernel.laws.discipline._
 import lucuma.core.math.BrightnessUnits._
 import lucuma.core.math.dimensional.arb.ArbUnits
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.syntax.display._
 import org.scalacheck.Prop._
 
 class UnitSuite extends munit.DisciplineSuite {
@@ -23,6 +24,20 @@ class UnitSuite extends munit.DisciplineSuite {
   test("Equality must be natural") {
     forAll { (a: Units, b: Units) =>
       assertEquals(a.equals(b), Eq[Units].eqv(a, b))
+    }
+  }
+
+  test("Display[Units]") {
+    forAll { u: Units =>
+      assertEquals(u.longName, u.name)
+      assertEquals(u.shortName, u.abbv)
+    }
+  }
+
+  test("Display[Units Of Brightness[Integrated]]") {
+    forAll { u: Units Of Brightness[Integrated] =>
+      assertEquals(u.longName, u.name)
+      assertEquals(u.shortName, u.abbv)
     }
   }
 }


### PR DESCRIPTION
- `Display[Measure[N]]`:
  - Derive instance from `Display[N]`
- `Display[Units Of T]` and `Display[Measure[N] Of T]`:
  - Support these tagged variants.