### PR TITLE
baseRa and baseDec optics in SiderealTracking

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
@@ -228,6 +228,14 @@ trait SiderealTrackingOptics {
     Focus[SiderealTracking](_.baseCoordinates)
 
   /** @group Optics */
+  val baseRa: Lens[SiderealTracking, RightAscension] =
+    baseCoordinates.andThen(Coordinates.rightAscension)
+
+  /** @group Optics */
+  val baseDec: Lens[SiderealTracking, Declination] =
+    baseCoordinates.andThen(Coordinates.declination)
+
+  /** @group Optics */
   val epoch: Lens[SiderealTracking, Epoch] =
     Focus[SiderealTracking](_.epoch)
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -143,11 +143,11 @@ object Target extends WithId('t') with TargetOptics {
 
     /** @group Optics */
     val baseRA: Lens[Sidereal, RightAscension] =
-      baseCoordinates.andThen(Coordinates.rightAscension)
+      tracking.andThen(SiderealTracking.baseRa)
 
     /** @group Optics */
     val baseDec: Lens[Sidereal, Declination] =
-      baseCoordinates.andThen(Coordinates.declination)
+      tracking.andThen(SiderealTracking.baseDec)
 
     /** @group Optics */
     val epoch: Lens[Sidereal, Epoch] =
@@ -537,11 +537,11 @@ trait TargetOptics { this: Target.type =>
 
   /** @group Optics */
   val baseRA: Optional[Target, RightAscension] =
-    baseCoordinates.andThen(Coordinates.rightAscension)
+    siderealTracking.andThen(SiderealTracking.baseRa)
 
   /** @group Optics */
   val baseDec: Optional[Target, Declination] =
-    baseCoordinates.andThen(Coordinates.declination)
+    siderealTracking.andThen(SiderealTracking.baseDec)
 
   /** @group Optics */
   val epoch: Optional[Target, Epoch] =

--- a/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/ImprovedSkyCalcSuiteJVM.scala
+++ b/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/ImprovedSkyCalcSuiteJVM.scala
@@ -11,13 +11,14 @@ import lucuma.core.math.Coordinates
 import lucuma.core.math.Place
 import lucuma.core.math.arb.ArbCoordinates._
 import lucuma.core.math.arb.ArbPlace._
+import lucuma.core.tests.ScalaCheckFlaky
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop._
-import org.scalacheck.{ Test => ScalaCheckTest }
+import org.scalacheck.{Test => ScalaCheckTest}
 import org.scalactic.Tolerance
 
 import java.time._
-import java.{ util => ju }
+import java.{util => ju}
 
 final class ImprovedSkyCalcSuiteJVM extends ScalaCheckSuite with Tolerance {
 
@@ -33,7 +34,7 @@ final class ImprovedSkyCalcSuiteJVM extends ScalaCheckSuite with Tolerance {
   )
   private val zdtRange = Duration.ofDays(Period.ofYears(1000).getDays.toLong)
 
-  test("Arbitrary sky calculations") {
+  test("Arbitrary sky calculations".tag(ScalaCheckFlaky)) {
     forAll { place: Place =>
       // This SkyCalc should be thread safe, but Java's isn't.
       val calc = ImprovedSkyCalc(place)

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
@@ -11,16 +11,20 @@ import munit.DisciplineSuite
 import org.scalacheck.Prop.forAll
 
 final class SiderealTrackingSuite extends DisciplineSuite {
-  import ArbParallax._
   import ArbCoordinates._
+  import ArbDeclination._
   import ArbEpoch._
+  import ArbParallax._
   import ArbProperMotion._
+  import ArbRightAscension._
   import ArbSiderealTracking._
   import ArbRadialVelocity._
 
   // Laws
   checkAll("SiderealTracking", OrderTests[SiderealTracking].order)
   checkAll("SiderealTracking.baseCoordinates", LensTests(SiderealTracking.baseCoordinates))
+  checkAll("SiderealTracking.baseRa", LensTests(SiderealTracking.baseRa))
+  checkAll("SiderealTracking.baseDec", LensTests(SiderealTracking.baseDec))
   checkAll("SiderealTracking.epoch", LensTests(SiderealTracking.epoch))
   checkAll("SiderealTracking.properMotion", LensTests(SiderealTracking.properMotion))
   checkAll("SiderealTracking.radialVelocity", LensTests(SiderealTracking.radialVelocity))


### PR DESCRIPTION
Very minor update to `SiderealTracking` to add `baseRa` and `baseDec`.  When working directly with a `SiderealTracking` these are useful and otherwise have to be typed in.