### PR TITLE
HashWithOrder

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/Wavelength.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Wavelength.scala
@@ -3,22 +3,21 @@
 
 package lucuma.core.math
 
-import cats.Order
 import cats.Show
 import coulomb._
-import coulomb.cats.implicits._
 import eu.timepit.refined._
 import eu.timepit.refined.auto._
-import eu.timepit.refined.cats._
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.math.units._
 import lucuma.core.optics.Format
+import lucuma.core.util.HashWithOrder
 import monocle.Iso
 import monocle.Prism
 import spire.math.Rational
 
 import java.math.RoundingMode
+
 import scala.util.Try
 
 /**
@@ -87,8 +86,8 @@ object Wavelength {
     Show.fromToString
 
   /** @group Typeclass Instances */
-  implicit val WavelengthOrd: Order[Wavelength] =
-    Order.by(_.toPicometers)
+  implicit val HashWithOrderWavelength: HashWithOrder[Wavelength] =
+    HashWithOrder.by(_.toPicometers.value.value)
 
   /**
     * Try to build a Wavelength from a plain Int. Negatives and Zero will produce a None

--- a/modules/core/shared/src/main/scala/lucuma/core/util/HashWithOrder.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/HashWithOrder.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import cats.{Hash, Order}
+
+trait HashWithOrder[A] extends Hash[A] with Order[A]
+
+object HashWithOrder {
+
+  @inline final def apply[A](implicit ev: HashWithOrder[A]): HashWithOrder[A] =
+    ev
+
+  def by[A, B](f: A => B)(implicit H: Hash[B], O: Order[B]): HashWithOrder[A] =
+    new HashWithOrder[A] {
+      override def compare(x: A, y: A): Int =
+        O.compare(f(x), f(y))
+
+      override def hash(x: A): Int =
+        H.hash(f(x))
+    }
+
+}


### PR DESCRIPTION
This is probably a "don't do that" case (as opposed to "use `traverse`").  Nevertheless, I'm opening a PR to get the "don't do that" feedback.

I'd like to, ultimately, hash ITC inputs for the purpose of caching them.  Should we be defining `cats.Hash` instances at least for the things that will be used in this way?  If so, things for which there is also an `Order` instance should be problematic since both `Hash` and `Order` extend `Eq`.  Hence, `HashWithOrder` :-/

So, I shouldn't do this, but any advice on what I should do instead?

