### PR TITLE
make GMOS disperser enumerated all values lazy

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enum/GmosNorthDisperser.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/GmosNorthDisperser.scala
@@ -42,7 +42,7 @@ object GmosNorthDisperser {
   /** @group Constructors */ case object R150_G5308  extends GmosNorthDisperser("R150_G5308",  "R150",  "R150_G5308",   150, pmToDispersion(193), false)
 
   /** All members of GmosNorthDisperser, in canonical order. */
-  val all: List[GmosNorthDisperser] =
+  lazy val all: List[GmosNorthDisperser] =
     List(B1200_G5301, R831_G5302, B600_G5303, B600_G5307, R600_G5304, B480_G5309, R400_G5305, R150_G5306, R150_G5308)
 
   /** Select the member of GmosNorthDisperser with the given tag, if any. */

--- a/modules/core/shared/src/main/scala/lucuma/core/enum/GmosSouthDisperser.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enum/GmosSouthDisperser.scala
@@ -40,7 +40,7 @@ object GmosSouthDisperser {
   /** @group Constructors */ case object R150_G5326  extends GmosSouthDisperser("R150_G5326",  "R150",  "R150_G5326",   150, pmToDispersion(193), false)
 
   /** All members of GmosSouthDisperser, in canonical order. */
-  val all: List[GmosSouthDisperser] =
+  lazy val all: List[GmosSouthDisperser] =
     List(B1200_G5321, R831_G5322, B600_G5323, R600_G5324, B480_G5327, R400_G5325, R150_G5326)
 
   /** Select the member of GmosSouthDisperser with the given tag, if any. */


### PR DESCRIPTION
I cannot explain why, but unless the `GmosSouthDisperser.all` value is `lazy`, accessing it yields a `null` value where `B600_G5323` should be (at least in `tmp-api` test cases).