### PR TITLE
Add trigonometric functions to angle

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Angle.scala
@@ -13,6 +13,7 @@ import lucuma.core.optics._
 import lucuma.core.syntax.parser._
 import monocle.Iso
 import monocle.Prism
+import scala.math
 
 /**
  * Exact angles represented as integral microarcseconds. These values form a commutative group over
@@ -136,6 +137,21 @@ sealed class Angle protected (val toMicroarcseconds: Long) {
    */
   def offsetInQ: Offset =
     Offset(Offset.P.Zero, q)
+
+  /**
+   * Trigonometric sine of the angle.
+   */
+  def sin: Double = math.sin(toDoubleRadians)
+
+  /**
+   * Trigonometric cosine of the angle.
+   */
+  def cos: Double = math.cos(toDoubleRadians)
+
+  /**
+   * Trigonometric tangent of the angle.
+   */
+  def tan: Double = math.tan(toDoubleRadians)
 
   /** String representation of this Angle, for debugging purposes only. */
   override def toString: String = {

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/AngleSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/AngleSuite.scala
@@ -172,4 +172,13 @@ final class AngleSuite extends munit.DisciplineSuite {
       assert(a === b || a.flip === b)
     }
   }
+
+  test("Trigonometric functions") {
+    forAll { (a: Angle) =>
+      // Trivial checks
+      assertEquals(a.sin, scala.math.sin(a.toDoubleRadians))
+      assertEquals(a.cos, scala.math.cos(a.toDoubleRadians))
+      assertEquals(a.tan, scala.math.tan(a.toDoubleRadians))
+    }
+  }
 }


### PR DESCRIPTION
The rationale for this change is to remove a step where you need to look exactly what units needs the param when you call sine/cos/tan