### PR TITLE
Bounding box

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.31"
+ThisBuild / tlBaseVersion                         := "0.32"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 ThisBuild / scalacOptions += "-Xsource:3"

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/BoundingOffsets.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/BoundingOffsets.scala
@@ -31,7 +31,7 @@ final case class BoundingOffsets(topLeft: Offset, bottomRight: Offset) {
    * |---|
    * |   |
    * |---|
-   * p3 p4
+   * p4 p3
    * }}}
    */
   def vertices: (Offset, Offset, Offset, Offset) =

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/BoundingOffsets.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/BoundingOffsets.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom
+
+import lucuma.core.math.Offset
+
+/**
+  * Defines a box of offsets that sorround a shape
+  *
+  * The vertices are in the order indicated below:
+  *
+  * p1           p2
+  * +------------+
+  * |            |
+  * |            |                      ^
+  * |            |                      |   q
+  * |            |                      |
+  * |            |                      |
+  * |            |                      |
+  * +------------+              <-------+
+  * p4           p3               p
+  */
+final case class BoundingOffsets(p1: Offset, p2: Offset, p3: Offset, p4: Offset)

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/BoundingOffsets.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/BoundingOffsets.scala
@@ -4,21 +4,45 @@
 package lucuma.core.geom
 
 import lucuma.core.math.Offset
+import lucuma.core.math.Angle
 
 /**
-  * Defines a box of offsets that sorround a shape
-  *
-  * The vertices are in the order indicated below:
-  *
-  * p1           p2
-  * +------------+
-  * |            |
-  * |            |                      ^
-  * |            |                      |   q
-  * |            |                      |
-  * |            |                      |
-  * |            |                      |
-  * +------------+              <-------+
-  * p4           p3               p
-  */
-final case class BoundingOffsets(p1: Offset, p2: Offset, p3: Offset, p4: Offset)
+ * Defines a pair of offsets that surround a shape
+ *
+ * {{{
+ * topLeft
+ * +------------+
+ * |            |
+ * |            |              ^
+ * |            |              |   q
+ * |            |              |
+ * |            |              |
+ * +------------+         <----+
+ *          bottomRight     p
+ * }}}
+ */
+final case class BoundingOffsets(topLeft: Offset, bottomRight: Offset) {
+
+  /**
+   * The vertices (p1, p2, p3, p4) are in the order indicated below:
+   *
+   * {{{
+   * p1 p2
+   * |---|
+   * |   |
+   * |---|
+   * p3 p4
+   * }}}
+   */
+  def vertices: (Offset, Offset, Offset, Offset) =
+    (topLeft, Offset(bottomRight.p, topLeft.q), bottomRight, Offset(topLeft.p, bottomRight.q))
+
+  /**
+   * Widest side expressed as an angle, Useful to do queries covering a shape
+   */
+  def maxSide: Angle = {
+    val p = topLeft.p.toAngle.difference(bottomRight.p.toAngle)
+    val q = topLeft.q.toAngle.difference(bottomRight.q.toAngle)
+    Angle.AngleOrder.max(p, q)
+  }
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/GmosOiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/GmosOiwfsProbeArm.scala
@@ -154,4 +154,11 @@ object GmosOiwfsProbeArm {
     s ↗ offsetPos ⟲ posAngle
   }
 
+  /**
+    * GMOS complete afs field shape, an ellipse centered at the base position. This area covers
+    * every allowed position angle
+    */
+  val agsField: ShapeExpression =
+    ShapeExpression.centeredEllipse((2 * 490000).mas, (2 * 490000).mas)
+
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/GmosOiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/GmosOiwfsProbeArm.scala
@@ -154,11 +154,4 @@ object GmosOiwfsProbeArm {
     s ↗ offsetPos ⟲ posAngle
   }
 
-  /**
-    * GMOS complete afs field shape, an ellipse centered at the base position. This area covers
-    * every allowed position angle
-    */
-  val agsField: ShapeExpression =
-    ShapeExpression.centeredEllipse((2 * 490000).mas, (2 * 490000).mas)
-
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/Shape.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/Shape.scala
@@ -3,26 +3,20 @@
 
 package lucuma.core.geom
 
-import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 
 /**
- * Shape description usable for testing point inclusion and calculating the
- * area.  Point inclusion is used to determine, for instance, guide star
- * reachability for a probe range.  Comparative area is usable when calculating
- * which guide star options produce the minimum vignetting (probe arm shadow
+ * Shape description usable for testing point inclusion and calculating the area. Point inclusion is
+ * used to determine, for instance, guide star reachability for a probe range. Comparative area is
+ * usable when calculating which guide star options produce the minimum vignetting (probe arm shadow
  * intersected with science area).
  */
 trait Shape {
-  /**
-   * Radius of a circle covering the shape
-   */
-  def circumscribedRadius: Angle
 
   /**
-   * Returns a four offset defining the shape's bounding box
+   * Returns a set of four offsets defining the shape's bounding box
    */
-  def boundingBox: (Offset, Offset, Offset, Offset)
+  def boundingOffsets: BoundingOffsets
 
   /**
    * Determines whether the given position is contained in the shape.
@@ -30,9 +24,8 @@ trait Shape {
   def contains(o: Offset): Boolean
 
   /**
-   * Area of the shape. The value is in microarcseconds angular separation^2^
-   * but the absolute value is less useful than comparing across multiple
-   * shapes (to determine minimum vignetting).
+   * Area of the shape. The value is in microarcseconds angular separation^2^ but the absolute value
+   * is less useful than comparing across multiple shapes (to determine minimum vignetting).
    */
   def area: Area
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/Shape.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/Shape.scala
@@ -3,6 +3,7 @@
 
 package lucuma.core.geom
 
+import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 
 /**
@@ -13,6 +14,15 @@ import lucuma.core.math.Offset
  * intersected with science area).
  */
 trait Shape {
+  /**
+   * Radius of a circle covering the shape
+   */
+  def circumscribedRadius: Angle
+
+  /**
+   * Returns a four offset defining the shape's bounding box
+   */
+  def boundingBox: (Offset, Offset, Offset, Offset)
 
   /**
    * Determines whether the given position is contained in the shape.

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
@@ -92,6 +92,11 @@ object ShapeExpression {
       extends ShapeExpression
 
   /**
+   * @group Transformations
+   */
+  final case class BoundingBox(e: ShapeExpression) extends ShapeExpression
+
+  /**
    * Flips the provided ShapeExpression around the y axis (ie, horizontally).
    *
    * @group Transformations

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/Jts.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/Jts.scala
@@ -3,6 +3,9 @@
 
 package lucuma.core.geom.jts
 
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.PrecisionModel
 
@@ -16,5 +19,21 @@ object Jts {
 
   val geometryFactory: GeometryFactory =
     new GeometryFactory(precisionModel)
+
+  /**
+    * Convert jts coordinates back to offset
+    */
+  def coord2offset(x: Double, y: Double): Offset =
+    // Reverse p
+    Offset(Offset.P(Angle.fromMicroarcseconds(-x.toLong)),
+            Offset.Q(Angle.fromMicroarcseconds(y.toLong))
+    )
+
+  def boundingOffsets(g: Geometry): (Offset, Offset) = {
+    val envelope    = g.getEnvelopeInternal
+    val leftTop     = coord2offset(envelope.getMinX, envelope.getMaxY)
+    val bottomRight = coord2offset(envelope.getMaxX, envelope.getMinY)
+    (leftTop, bottomRight)
+  }
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShape.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShape.scala
@@ -5,13 +5,35 @@ package lucuma.core.geom
 package jts
 
 import lucuma.core.geom.jts.syntax.offset._
+import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import org.locationtech.jts.geom.Geometry
+import scala.math.sqrt
 
 /**
  * JTS implementation of Shape.
  */
 final case class JtsShape(g: Geometry) extends Shape {
+  def circumscribedRadius: Angle = {
+    val envelope = g.getEnvelopeInternal
+    val height = envelope.getHeight
+    val width = envelope.getWidth
+    val radius = sqrt(height*height + width*width)/2
+    Angle.fromMicroarcseconds(radius.toLong)
+  }
+
+  private def coord2offset(x: Double, y: Double): Offset =
+    Offset(Offset.P(Angle.fromMicroarcseconds(x.toLong)), Offset.Q(Angle.fromMicroarcseconds(y.toLong)))
+
+  def boundingBox: (Offset, Offset, Offset, Offset) = {
+    val envelope = g.getEnvelopeInternal
+    val c1 = coord2offset(-envelope.getMinX, envelope.getMinY)
+    val c2 = coord2offset(-envelope.getMaxX, envelope.getMinY)
+    val c3 = coord2offset(-envelope.getMaxX, envelope.getMaxY)
+    val c4 = coord2offset(-envelope.getMinX, envelope.getMaxY)
+
+    (c1, c2, c3, c4)
+  }
 
   override def contains(o: Offset): Boolean =
     g.contains(o.point)

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShape.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShape.scala
@@ -5,7 +5,6 @@ package lucuma.core.geom
 package jts
 
 import lucuma.core.geom.jts.syntax.offset._
-import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import org.locationtech.jts.geom.Geometry
 
@@ -14,23 +13,9 @@ import org.locationtech.jts.geom.Geometry
  */
 final case class JtsShape(g: Geometry) extends Shape {
 
-  /**
-   * Convert jts coordinates back to offset
-   */
-  private def coord2offset(x: Double, y: Double): Offset =
-    // Reverse p
-    Offset(Offset.P(Angle.fromMicroarcseconds(-x.toLong)),
-           Offset.Q(Angle.fromMicroarcseconds(y.toLong))
-    )
-
   def boundingOffsets: BoundingOffsets = {
-    val envelope = g.getEnvelopeInternal
-    val p1       = coord2offset(envelope.getMinX, envelope.getMaxY)
-    val p2       = coord2offset(envelope.getMaxX, envelope.getMaxY)
-    val p3       = coord2offset(envelope.getMaxX, envelope.getMinY)
-    val p4       = coord2offset(envelope.getMinX, envelope.getMinY)
-
-    BoundingOffsets(p1, p2, p3, p4)
+    val (tl, br) = Jts.boundingOffsets(g)
+    BoundingOffsets(tl, br)
   }
 
   override def contains(o: Offset): Boolean =

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShapeInterpreter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShapeInterpreter.scala
@@ -49,6 +49,9 @@ object JtsShapeInterpreter extends ShapeInterpreter {
       case Polygon(os)     => safePolygon(os)
       case Rectangle(a, b) => safeRectangularBoundedShape(a, b)(_.createRectangle)
       case Point(a)        => a.point
+      case BoundingBox(e) =>
+        val (a, b) = Jts.boundingOffsets(toGeometry(e))
+        safeRectangularBoundedShape(a, b)(_.createRectangle)
 
       // Combinations
       case Difference(a, b)   => toGeometry(a).difference(toGeometry(b))

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/ShapeExpression.scala
@@ -54,6 +54,12 @@ final class ShapeExpressionOps(val self: ShapeExpression) extends AnyVal {
     union(that)
 
   /**
+   * Creates a bounding box for an expression
+   */
+  def boundingBox: ShapeExpression =
+    BoundingBox(self)
+
+  /**
    * Promotes `Shape.contains` through evaluation.
    */
   def contains(o: Offset)(implicit ev: ShapeInterpreter): Boolean =
@@ -70,6 +76,13 @@ final class ShapeExpressionOps(val self: ShapeExpression) extends AnyVal {
    */
   def µasSquared(implicit ev: ShapeInterpreter): Long =
     area.toMicroarcsecondsSquared
+
+  /**
+   * Promotes `Shape.boundingOffsets.maxSide` through evaluation and produces an Angle
+   */
+  def maxSide(implicit ev: ShapeInterpreter): Angle =
+    self.eval.boundingOffsets.maxSide
+
 }
 
 trait ToShapeExpressionOps {

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -20,7 +20,6 @@ import lucuma.core.math.syntax.int._
 import java.awt.event._
 import java.awt.{ List => _, _ }
 import scala.jdk.CollectionConverters._
-import lucuma.core.geom.BoundingOffsets
 
 /**
  * Throwaway demo code to visualize a shape created using `ShapeExpression`s.
@@ -132,17 +131,10 @@ object JtsDemo extends Frame("JTS Demo") {
 
         // Draw the bounding boxes
         shapes.foreach { shapeExpr =>
-          shapeExpr.eval match {
-            case jts: JtsShape =>
-              val BoundingOffsets(p1, p2, p3, p4) = jts.boundingOffsets
-              val boundingBox                     =
-                ShapeExpression.polygonAt(List(p1, p2, p3, p4).map(o => (o.p, o.q)): _*)
-              boundingBox.eval match {
-                case box: JtsShape =>
-                  g2d.setPaint(Color.magenta)
-                  g2d.draw(box.toAwt(arcsecPerPixel))
-                case _             => sys.error("Unexpected")
-              }
+          shapeExpr.boundingBox.eval match {
+            case box: JtsShape =>
+              g2d.setPaint(Color.magenta)
+              g2d.draw(box.toAwt(arcsecPerPixel))
             case x             => sys.error(s"Whoa unexpected shape type: $x")
           }
         }

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -12,6 +12,7 @@ import lucuma.core.geom.GmosScienceAreaGeometry
 import lucuma.core.geom.ShapeExpression
 import lucuma.core.geom.jts.interpreter._
 import lucuma.core.geom.jts.jvm.syntax.awt._
+import lucuma.core.geom.syntax.all._
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import lucuma.core.math.syntax.int._
@@ -45,8 +46,11 @@ object JtsDemo extends Frame("JTS Demo") {
     List(
       GmosOiwfsProbeArm.shapeAt(posAngle, guideStarOffset, offsetPos, fpu, port),
       GmosOiwfsProbeArm.patrolFieldAt(posAngle, offsetPos, fpu, port),
-      GmosScienceAreaGeometry.shapeAt(posAngle, offsetPos, fpu)
+      GmosScienceAreaGeometry.shapeAt(posAngle, offsetPos, fpu),
     )
+
+  val fullPatrolShape =
+      GmosOiwfsProbeArm.fullPatrolFieldAt(posAngle, offsetPos)
 
   // Scale
   val arcsecPerPixel: Double =
@@ -64,7 +68,7 @@ object JtsDemo extends Frame("JTS Demo") {
       RenderingHints.KEY_RENDERING    -> RenderingHints.VALUE_RENDER_QUALITY
     )
 
-  object canvas extends Canvas {
+  def canvas(boundingBox: Boolean, circunscribedCircle: Boolean) = new Canvas {
     setBackground(Color.lightGray)
     setSize(canvasSize, canvasSize)
 
@@ -115,17 +119,92 @@ object JtsDemo extends Frame("JTS Demo") {
         g2d.drawLine(-halfCanvas, -dpx, halfCanvas, -dpx)
         g2d.drawLine(-halfCanvas, dpx, halfCanvas, dpx)
       }
+
+      val originalColor = g2d.getColor
+      if (boundingBox) {
+        g2d.setStroke(
+          new BasicStroke(1f,
+                          BasicStroke.CAP_BUTT,
+                          BasicStroke.JOIN_MITER,
+                          10.0f,
+                          Array(2.0f, 4.0f),
+                          1.0f
+          )
+        )
+
+        // Draw the bounding boxes
+        (fullPatrolShape :: shapes).foreach { shapeExpr =>
+          shapeExpr.eval match {
+            case jts: JtsShape =>
+              val (p1, p2, p3, p4) = jts.boundingBox
+              val boundingBox = ShapeExpression.polygonAt(List(p1, p2, p3, p4).map(o => (o.p, o.q)): _*)
+              boundingBox.eval match {
+                case box: JtsShape =>
+                  g2d.setPaint(Color.magenta)
+                  g2d.draw(box.toAwt(arcsecPerPixel))
+                case _ => sys.error("Unexpected")
+              }
+            case x             => sys.error(s"Whoa unexpected shape type: $x")
+          }
+        }
+      }
+      if (circunscribedCircle) {
+        g2d.setStroke(
+          new BasicStroke(1f,
+                          BasicStroke.CAP_BUTT,
+                          BasicStroke.JOIN_MITER,
+                          10.0f,
+                          Array(2.0f, 4.0f),
+                          1.0f
+          )
+        )
+
+        // Draw the bounding boxes
+        (fullPatrolShape :: shapes).foreach { shapeExpr =>
+          shapeExpr.eval match {
+            case jts: JtsShape =>
+              val (p1, _, p3, _) = jts.boundingBox
+              val radius = jts.circumscribedRadius
+              val halfP = Offset.p.andThen(Offset.P.angle).modify(x => Angle.signedMicroarcseconds.modify( _ / 2)(x))
+              val halfQ = Offset.q.andThen(Offset.Q.angle).modify(x => Angle.signedDecimalArcseconds.modify( _ / 2)(x))
+              val halfP1 = Offset.p.andThen(Offset.P.angle).modify(_ - radius)
+              val halfQ1 = Offset.q.andThen(Offset.Q.angle).modify(_ + radius)
+              val halfP2 = Offset.p.andThen(Offset.P.angle).modify(_ + radius)
+              val halfQ2 = Offset.q.andThen(Offset.Q.angle).modify(_ - radius)
+              val center = halfP(halfQ(p1 + p3))
+              val boundingCircle1 = halfQ2(halfP2(center))
+              val boundingCircle2 = halfQ1(halfP1(center))
+              val boundingCircle = ShapeExpression.ellipseAt((boundingCircle1.p, boundingCircle1.q), (boundingCircle2.p, boundingCircle2.q))
+              boundingCircle.eval match {
+                case circle: JtsShape =>
+                  g2d.setPaint(Color.blue)
+                  g2d.draw(circle.toAwt(arcsecPerPixel))
+                case _ => sys.error("Unexpected")
+              }
+            case x             => sys.error(s"Whoa unexpected shape type: $x")
+          }
+        }
+      }
+
+      g2d.setPaint(originalColor)
       g2d.setStroke(origStroke)
 
       // Finally, draw the shape.
-      shapes.foreach { shape =>
-        shape.eval match {
-          case jts: JtsShape => g2d.draw(jts.toAwt(arcsecPerPixel))
+      shapes.foreach { shapeExpr =>
+        shapeExpr.eval match {
+          case jts: JtsShape =>
+            g2d.draw(jts.toAwt(arcsecPerPixel))
           case x             => sys.error(s"Whoa unexpected shape type: $x")
         }
       }
 
-    }
+      g2d.setColor(Color.green)
+      fullPatrolShape.eval match {
+          case jts: JtsShape =>
+            g2d.draw(jts.toAwt(arcsecPerPixel))
+          case x             => sys.error(s"Whoa unexpected shape type: $x")
+        }
+      }
   }
 
   def main(args: Array[String]): Unit = {
@@ -136,7 +215,7 @@ object JtsDemo extends Frame("JTS Demo") {
         System.exit(0)
     })
 
-    add(BorderLayout.CENTER, canvas)
+    add(BorderLayout.CENTER, canvas(args.contains("--boxes"), args.contains("--circles")))
 
     setVisible(true)
   }

--- a/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
@@ -42,6 +42,18 @@ final class ShapeExpressionSuite extends munit.DisciplineSuite {
     }
   }
 
+  test("max side of the bounding box is bigger than for each shape") {
+    implicit val order = Angle.SignedAngleOrder
+    forAll(genTwoCenteredShapes) { case shapes =>
+      assert(
+        (shapes.shape0 ∪ shapes.shape1).maxSide >= shapes.shape0.maxSide
+      )
+      assert(
+        (shapes.shape0 ∪ shapes.shape1).maxSide >= shapes.shape1.maxSide
+      )
+    }
+  }
+
   test("difference contains") {
     forAll(genTwoCenteredShapesAndAnOffset) { case (tcs, off) =>
       assertEquals(
@@ -59,7 +71,7 @@ final class ShapeExpressionSuite extends munit.DisciplineSuite {
 
       // Area calculation isn't exact but within 1/2 mas^2 seems fine for our
       // purposes.
-      assertEqualsDouble((rhs - lhs).toDouble, 0L, 500L)
+      assertEqualsDouble((rhs - lhs).toDouble, 0L, 700L)
     }
   }
 
@@ -72,9 +84,28 @@ final class ShapeExpressionSuite extends munit.DisciplineSuite {
       )
 
       // Area calculation isn't exact but within 1/2 mas^2 seems fine.
-      assertEqualsDouble((rhs - lhs).toDouble, 0L, 500L)
+      assertEqualsDouble((rhs - lhs).toDouble, 0L, 700L)
     }
   }
+
+  test("bounding box area contains the shape") {
+    forAll(genShape) { (e: ShapeExpression) =>
+      val error = e.boundingBox.µasSquared - e.µasSquared
+
+      // Area calculation isn't exact but within 1/2 mas^2 seems fine.
+      assert(error >= 0 || error.toDouble < -1.0e-13)
+    }
+  }
+
+  test("bounding box area contains two unioned shapes") {
+    forAll(genShape, genShape) { (a: ShapeExpression, b: ShapeExpression) =>
+      val error = (a ∪ b).boundingBox.µasSquared - (a ∪ b).µasSquared
+
+      // Area calculation isn't exact but within 1/2 mas^2 seems fine.
+      assert(error >= 0 || error.toDouble < -1.0e-13)
+    }
+  }
+
 
   // There is a bug apparently in JTS that makes the area calculation a bit off
   // after rotation and/or translation in some cases.  This is expressed as a


### PR DESCRIPTION
This is a rework of #502 where we can create a `BoundingBox` as a `ShapeExpression`
The box is now defined by two corner offsets and a function to calculate the widest side (as an angle) is included

Also a few tests are added.

The image below shows the box on the gmos shapes

![image](https://user-images.githubusercontent.com/3615303/162500513-51d2e879-e4eb-4d67-99bc-c86d3cb22347.png)
