### PR TITLE
Add geometry for the ags field in gmos and group all the gmos geometries

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosCandidatesArea.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosCandidatesArea.scala
@@ -13,12 +13,12 @@ import lucuma.core.math.syntax.int._
   * GMOS area that could be reachable by the patrol arm
   * https://www.gemini.edu/instrumentation/gmos/capability#Guiding
   */
-trait GmosPatrolArea {
+trait GmosCandidatesArea {
 
   /**
     * GMOS area where the probe arm can reach centered at 0
     */
-  def patrolArea: ShapeExpression =
+  def candidatesArea: ShapeExpression =
     // 4.9 arcmin radius
     // NOTE There is some debate on whether this should be 4.8
     ShapeExpression.centeredEllipse((4.9 * 60 * 2).toInt.arcsec,
@@ -28,18 +28,17 @@ trait GmosPatrolArea {
   /**
     * GMOS area where the probe arm can reach centered with a given posAngle and offset
     */
-  def patrolAreaAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
-    patrolArea ↗ offsetPos ⟲ posAngle
+  def candidatesAreaAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
+    candidatesArea ↗ offsetPos ⟲ posAngle
 
   /**
     * GMOS area reachable by the problem arm for a set of posAngles and offsets
     */
-  def patrolAreaAt(posAngles: List[Angle], offsetPositions: List[Offset]): ShapeExpression =
+  def candidatesAreaAt(posAngles: List[Angle], offsetPositions: List[Offset]): ShapeExpression =
     (for {
       a <- posAngles
       o <- offsetPositions
-    } yield patrolAreaAt(a, o)).fold(ShapeExpression.Empty)(_ ∪ _)
+    } yield candidatesAreaAt(a, o)).fold(ShapeExpression.Empty)(_ ∪ _)
 }
 
-object patrolArea extends GmosPatrolArea
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosOiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosOiwfsProbeArm.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.core.geom
+package lucuma.core.geom.gmos
 
 import cats.syntax.all._
 import lucuma.core.enum.GmosNorthFpu
@@ -22,7 +22,7 @@ import scala.math.sin
 /**
   * Description of the GMOS OIWFS probe arm geometry.
   */
-object GmosOiwfsProbeArm {
+trait GmosOiwfsProbeArm {
   private val PickoffArmLength: Angle      = 358460.mas
   private val PickoffMirrorSize: Angle     = 20.arcsec
   private val ProbeArmLength: Angle        = PickoffArmLength - PickoffMirrorSize.bisect
@@ -155,3 +155,5 @@ object GmosOiwfsProbeArm {
   }
 
 }
+
+object probeArm extends GmosOiwfsProbeArm

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosOiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosOiwfsProbeArm.scala
@@ -156,4 +156,4 @@ trait GmosOiwfsProbeArm {
 
 }
 
-object probeArm extends GmosOiwfsProbeArm
+object probeArm extends GmosOiwfsProbeArm with GmosCandidatesArea

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosPatrolArea.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosPatrolArea.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom.gmos
+
+import lucuma.core.geom.ShapeExpression
+import lucuma.core.geom.syntax.all._
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.int._
+
+/**
+  * GMOS area that could be reachable by the patrol arm
+  * https://www.gemini.edu/instrumentation/gmos/capability#Guiding
+  */
+trait GmosPatrolArea {
+
+  /**
+    * GMOS area where the probe arm can reach centered at 0
+    */
+  def patrolArea: ShapeExpression =
+    // 4.9 arcmin radius
+    // NOTE There is some debate on whether this should be 4.8
+    ShapeExpression.centeredEllipse((4.9 * 60 * 2).toInt.arcsec,
+                                    (4.9 * 60 * 2).toInt.arcsec
+    )
+
+  /**
+    * GMOS area where the probe arm can reach centered with a given posAngle and offset
+    */
+  def patrolAreaAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
+    patrolArea ↗ offsetPos ⟲ posAngle
+
+  /**
+    * GMOS area reachable by the problem arm for a set of posAngles and offsets
+    */
+  def patrolAreaAt(posAngles: List[Angle], offsetPositions: List[Offset]): ShapeExpression =
+    (for {
+      a <- posAngles
+      o <- offsetPositions
+    } yield patrolAreaAt(a, o)).fold(ShapeExpression.Empty)(_ ∪ _)
+}
+
+object patrolArea extends GmosPatrolArea
+

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometry.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.core.geom
+package lucuma.core.geom.gmos
 
 import lucuma.core.enum.GmosNorthFpu
 import lucuma.core.enum.GmosSouthFpu
@@ -14,7 +14,7 @@ import lucuma.core.math.syntax.int._
 /**
   * GMOS science area geometry.
   */
-object GmosScienceAreaGeometry {
+trait GmosScienceAreaGeometry {
 
   // base target
   def base: ShapeExpression =
@@ -110,3 +110,5 @@ object GmosScienceAreaGeometry {
   }
 
 }
+
+object scienceArea extends GmosScienceAreaGeometry

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/package.scala
@@ -1,0 +1,6 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom.gmos
+
+object all extends GmosOiwfsProbeArm with GmosScienceAreaGeometry with GmosPatrolArea

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/package.scala
@@ -3,4 +3,4 @@
 
 package lucuma.core.geom.gmos
 
-object all extends GmosOiwfsProbeArm with GmosScienceAreaGeometry with GmosPatrolArea
+object all extends GmosOiwfsProbeArm with GmosScienceAreaGeometry with GmosCandidatesArea

--- a/modules/tests/js/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/js/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -4,7 +4,7 @@
 package lucuma.core.geom.jts
 package demo
 
-import lucuma.core.geom.GmosOiwfsProbeArm
+import lucuma.core.geom.gmos._
 import lucuma.core.geom.jts.JtsShape
 import lucuma.core.geom.jts.interpreter._
 import lucuma.core.geom.svg._
@@ -16,7 +16,7 @@ import lucuma.svgdotjs.Svg
  */
 object JtsDemo {
   def main(args: Array[String]): Unit =
-    GmosOiwfsProbeArm.shape.eval match {
+    probeArm.shape.eval match {
       case j: JtsShape =>
         val svg: Svg = new Svg()
         j.toSvg(svg)

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -7,8 +7,7 @@ package demo
 import lucuma.core.enum.GmosNorthFpu
 import lucuma.core.enum.GmosSouthFpu
 import lucuma.core.enum.PortDisposition
-import lucuma.core.geom.GmosOiwfsProbeArm
-import lucuma.core.geom.GmosScienceAreaGeometry
+import lucuma.core.geom.gmos._
 import lucuma.core.geom.ShapeExpression
 import lucuma.core.geom.jts.interpreter._
 import lucuma.core.geom.jts.jvm.syntax.awt._
@@ -44,9 +43,10 @@ object JtsDemo extends Frame("JTS Demo") {
   // Shape to display
   val shapes: List[ShapeExpression] =
     List(
-      GmosOiwfsProbeArm.shapeAt(posAngle, guideStarOffset, offsetPos, fpu, port),
-      GmosOiwfsProbeArm.patrolFieldAt(posAngle, offsetPos, fpu, port),
-      GmosScienceAreaGeometry.shapeAt(posAngle, offsetPos, fpu)
+      probeArm.shapeAt(posAngle, guideStarOffset, offsetPos, fpu, port),
+      probeArm.patrolFieldAt(posAngle, offsetPos, fpu, port),
+      scienceArea.shapeAt(posAngle, offsetPos, fpu),
+      patrolArea.patrolAreaAt(posAngle, offsetPos)
     )
 
   // Scale

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -46,7 +46,7 @@ object JtsDemo extends Frame("JTS Demo") {
       probeArm.shapeAt(posAngle, guideStarOffset, offsetPos, fpu, port),
       probeArm.patrolFieldAt(posAngle, offsetPos, fpu, port),
       scienceArea.shapeAt(posAngle, offsetPos, fpu),
-      patrolArea.patrolAreaAt(posAngle, offsetPos)
+      probeArm.candidatesAreaAt(posAngle, offsetPos)
     )
 
   // Scale


### PR DESCRIPTION
This PR adds a geometry that includes the area we should read candidate targets for AGS

![image](https://user-images.githubusercontent.com/3615303/163437202-064ea958-0812-40d0-816a-4c975a21e8a2.png)
