### PR TITLE
Pos angle constraint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.39"
+ThisBuild / tlBaseVersion                         := "0.40"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 ThisBuild / scalacOptions += "-Xsource:3"

--- a/modules/core/shared/src/main/scala/lucuma/core/model/PosAngle.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/PosAngle.scala
@@ -4,7 +4,7 @@
 package lucuma.core.model
 
 import cats.Eq
-import cats.syntax.all._
+import cats.syntax.all.*
 import lucuma.core.math.Angle
 import monocle.Focus
 import monocle.Lens
@@ -114,5 +114,20 @@ object PosAngle {
 
   val parallacticOverrideAnglePrism: Optional[PosAngle, Angle] =
     parallacticOverridePrism.andThen(ParallacticOverride.angle)
+
+  val angleOptional: Optional[PosAngle, Angle] =
+    Optional[PosAngle, Angle]({
+      case Fixed(angle)               => angle.some
+      case AllowFlip(angle)           => angle.some
+      case AverageParallactic         => none
+      case ParallacticOverride(angle) => angle.some
+      case Unconstrained              => none
+    })({ a => {
+      case Fixed(_)                   => Fixed(a)
+      case AllowFlip(_)               => AllowFlip(a)
+      case AverageParallactic         => AverageParallactic
+      case ParallacticOverride(_)     => ParallacticOverride(a)
+      case Unconstrained              => Unconstrained
+    }})
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/PosAngleConstraint.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/PosAngleConstraint.scala
@@ -13,12 +13,17 @@ import monocle.Prism
 import monocle.macros.GenPrism
 
 /**
-  * Position Angle model
+  * Position Angle Constraint model.  Defines how the position angle will be
+ * constrained.
   */
-sealed trait PosAngle extends Product with Serializable
+sealed trait PosAngleConstraint extends Product with Serializable
 
-object PosAngle {
-  case class Fixed(angle: Angle) extends PosAngle {
+object PosAngleConstraint {
+
+  /**
+   * Specifies that the position angle must be set to the specified angle.
+   */
+  case class Fixed(angle: Angle) extends PosAngleConstraint {
     override def toString: String = s"Fixed(${angle.toDoubleDegrees})"
   }
 
@@ -31,10 +36,14 @@ object PosAngle {
    *
    *  @group Constructors
    */
-  def fixed(angle: Angle): PosAngle =
+  def fixed(angle: Angle): PosAngleConstraint =
     Fixed(angle)
 
-  case class AllowFlip(angle: Angle) extends PosAngle {
+  /**
+   * Specifies a position angle equal to the given angle or the given angle
+   * plus 180 degrees.
+   */
+  case class AllowFlip(angle: Angle) extends PosAngleConstraint {
     override def toString: String = s"AllowFlip(${angle.toDoubleDegrees})"
   }
 
@@ -47,10 +56,14 @@ object PosAngle {
    *
    *  @group Constructors
    */
-  def allowFlip(angle: Angle): PosAngle =
+  def allowFlip(angle: Angle): PosAngleConstraint =
     AllowFlip(angle)
 
-  case object AverageParallactic extends PosAngle {
+  /**
+   * Specifies that the position angle be set to the average parallactic
+   * angle at the time of the observation.
+   */
+  case object AverageParallactic extends PosAngleConstraint {
     override def toString: String = "AverageParallactic"
   }
 
@@ -59,10 +72,14 @@ object PosAngle {
    *
    *  @group Constructors
    */
-  val averageParallactic: PosAngle =
+  val averageParallactic: PosAngleConstraint =
     AverageParallactic
 
-  case class ParallacticOverride(angle: Angle) extends PosAngle {
+  /**
+   * Specifies a fixed position angle, remembering that originally the
+   * average parallactic angle was desired.
+   */
+  case class ParallacticOverride(angle: Angle) extends PosAngleConstraint {
     override def toString: String = s"ParallacticOverride(${angle.toDoubleDegrees})"
   }
 
@@ -75,10 +92,14 @@ object PosAngle {
    *
    *  @group Constructors
    */
-  def parallacticOverride(angle: Angle): PosAngle =
+  def parallacticOverride(angle: Angle): PosAngleConstraint =
     ParallacticOverride(angle)
 
-  case object Unconstrained extends PosAngle {
+  /**
+   * Specifies that there is no constraint on the position angle.  It may be
+   * set to any value for this observation.
+   */
+  case object Unconstrained extends PosAngleConstraint {
     override def toString: String = "Unconstrained"
   }
 
@@ -87,12 +108,12 @@ object PosAngle {
    *
    *  @group Constructors
    */
-  val unconstrained: PosAngle =
+  val unconstrained: PosAngleConstraint =
     Unconstrained
 
-  val Default: PosAngle = Fixed(Angle.Angle0)
+  val Default: PosAngleConstraint = Fixed(Angle.Angle0)
 
-  implicit val eqPosAngle: Eq[PosAngle] = Eq.instance {
+  implicit val eqPosAngle: Eq[PosAngleConstraint] = Eq.instance {
     case (Fixed(a), Fixed(b))                             => a === b
     case (AllowFlip(a), AllowFlip(b))                     => a === b
     case (AverageParallactic, AverageParallactic)         => true
@@ -101,22 +122,22 @@ object PosAngle {
     case _                                                => false
   }
 
-  val fixedPrism: Prism[PosAngle, Fixed] = GenPrism[PosAngle, Fixed]
+  val fixedPrism: Prism[PosAngleConstraint, Fixed] = GenPrism[PosAngleConstraint, Fixed]
 
-  val fixedAnglePrism: Optional[PosAngle, Angle] = fixedPrism.andThen(Fixed.angle)
+  val fixedAnglePrism: Optional[PosAngleConstraint, Angle] = fixedPrism.andThen(Fixed.angle)
 
-  val allowFlipPrism: Prism[PosAngle, AllowFlip] = GenPrism[PosAngle, AllowFlip]
+  val allowFlipPrism: Prism[PosAngleConstraint, AllowFlip] = GenPrism[PosAngleConstraint, AllowFlip]
 
-  val allowFlipAnglePrism: Optional[PosAngle, Angle] = allowFlipPrism.andThen(AllowFlip.angle)
+  val allowFlipAnglePrism: Optional[PosAngleConstraint, Angle] = allowFlipPrism.andThen(AllowFlip.angle)
 
-  val parallacticOverridePrism: Prism[PosAngle, ParallacticOverride] =
-    GenPrism[PosAngle, ParallacticOverride]
+  val parallacticOverridePrism: Prism[PosAngleConstraint, ParallacticOverride] =
+    GenPrism[PosAngleConstraint, ParallacticOverride]
 
-  val parallacticOverrideAnglePrism: Optional[PosAngle, Angle] =
+  val parallacticOverrideAnglePrism: Optional[PosAngleConstraint, Angle] =
     parallacticOverridePrism.andThen(ParallacticOverride.angle)
 
-  val angleOptional: Optional[PosAngle, Angle] =
-    Optional[PosAngle, Angle]({
+  val angleOptional: Optional[PosAngleConstraint, Angle] =
+    Optional[PosAngleConstraint, Angle]({
       case Fixed(angle)               => angle.some
       case AllowFlip(angle)           => angle.some
       case AverageParallactic         => none

--- a/modules/core/shared/src/main/scala/lucuma/core/model/PosAngleConstraint.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/PosAngleConstraint.scala
@@ -13,9 +13,9 @@ import monocle.Prism
 import monocle.macros.GenPrism
 
 /**
-  * Position Angle Constraint model.  Defines how the position angle will be
+ * Position Angle Constraint model.  Defines how the position angle will be
  * constrained.
-  */
+ */
 sealed trait PosAngleConstraint extends Product with Serializable
 
 object PosAngleConstraint extends PosAngleConstraintOptics {

--- a/modules/core/shared/src/main/scala/lucuma/core/model/PosAngleConstraint.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/PosAngleConstraint.scala
@@ -129,6 +129,8 @@ sealed trait PosAngleConstraintOptics { self: PosAngleConstraint.type =>
   /**
    * Optional that extracts the position angle for those constraints where a
    * particular angle is defined: `Fixed`, `AllowFlip` and `ParallacticOverride`.
+   *
+   * @group Optics
    */
   val angle: Optional[PosAngleConstraint, Angle] =
     Optional[PosAngleConstraint, Angle]({
@@ -145,21 +147,39 @@ sealed trait PosAngleConstraintOptics { self: PosAngleConstraint.type =>
       case PosAngleConstraint.Unconstrained              => PosAngleConstraint.Unconstrained
     }})
 
+  /**
+   * @group Optics
+   */
   val toFixed: Prism[PosAngleConstraint, PosAngleConstraint.Fixed] =
     GenPrism[PosAngleConstraint, PosAngleConstraint.Fixed]
 
+  /**
+   * @group Optics
+   */
   val fixedAngle: Optional[PosAngleConstraint, Angle] =
     toFixed.andThen(PosAngleConstraint.Fixed.angle)
 
+  /**
+   * @group Optics
+   */
   val toAllowFlip: Prism[PosAngleConstraint, PosAngleConstraint.AllowFlip] =
     GenPrism[PosAngleConstraint, PosAngleConstraint.AllowFlip]
 
+  /**
+   * @group Optics
+   */
   val allowFlipAngle: Optional[PosAngleConstraint, Angle] =
     toAllowFlip.andThen(PosAngleConstraint.AllowFlip.angle)
 
+  /**
+   * @group Optics
+   */
   val toParallacticOverride: Prism[PosAngleConstraint, PosAngleConstraint.ParallacticOverride] =
     GenPrism[PosAngleConstraint, PosAngleConstraint.ParallacticOverride]
 
+  /**
+   * @group Optics
+   */
   val parallacticOverrideAngle: Optional[PosAngleConstraint, Angle] =
     toParallacticOverride.andThen(PosAngleConstraint.ParallacticOverride.angle)
 

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbPosAngle.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbPosAngle.scala
@@ -3,7 +3,7 @@
 
 package lucuma.core.model.arb
 
-import lucuma.core.model.PosAngle
+import lucuma.core.model.PosAngleConstraint
 import lucuma.core.math.arb.ArbAngle._
 import lucuma.core.math.Angle
 import org.scalacheck.Arbitrary
@@ -13,51 +13,51 @@ import org.scalacheck.Gen
 
 trait ArbPosAngle {
 
-  implicit val fixedPosAngleArb = Arbitrary[PosAngle.Fixed] {
+  implicit val fixedPosAngleArb = Arbitrary[PosAngleConstraint.Fixed] {
     for {
       a <- arbitrary[Angle]
-    } yield PosAngle.Fixed(a)
+    } yield PosAngleConstraint.Fixed(a)
   }
 
-  implicit def fixedPosAngleCogen: Cogen[PosAngle.Fixed] =
+  implicit def fixedPosAngleCogen: Cogen[PosAngleConstraint.Fixed] =
     Cogen[Angle].contramap(_.angle)
 
-  implicit val allowFlipPosAngleArb = Arbitrary[PosAngle.AllowFlip] {
+  implicit val allowFlipPosAngleArb = Arbitrary[PosAngleConstraint.AllowFlip] {
     for {
       a <- arbitrary[Angle]
-    } yield PosAngle.AllowFlip(a)
+    } yield PosAngleConstraint.AllowFlip(a)
   }
 
-  implicit def allowFlipCogen: Cogen[PosAngle.AllowFlip] =
+  implicit def allowFlipCogen: Cogen[PosAngleConstraint.AllowFlip] =
     Cogen[Angle].contramap(_.angle)
 
-  implicit val parallacticOverridePosAngleArb = Arbitrary[PosAngle.ParallacticOverride] {
+  implicit val parallacticOverridePosAngleArb = Arbitrary[PosAngleConstraint.ParallacticOverride] {
     for {
       a <- arbitrary[Angle]
-    } yield PosAngle.ParallacticOverride(a)
+    } yield PosAngleConstraint.ParallacticOverride(a)
   }
 
-  implicit def parallacticOverridePosAngleCogen: Cogen[PosAngle.ParallacticOverride] =
+  implicit def parallacticOverridePosAngleCogen: Cogen[PosAngleConstraint.ParallacticOverride] =
     Cogen[Angle].contramap(_.angle)
 
-  implicit val posAngleArb = Arbitrary[PosAngle] {
+  implicit val posAngleArb = Arbitrary[PosAngleConstraint] {
     for {
-      f <- arbitrary[PosAngle.Fixed]
-      v <- arbitrary[PosAngle.AllowFlip]
-      p <- Gen.const(PosAngle.AverageParallactic)
-      o <- arbitrary[PosAngle.ParallacticOverride]
-      u <- Gen.const(PosAngle.Unconstrained)
+      f <- arbitrary[PosAngleConstraint.Fixed]
+      v <- arbitrary[PosAngleConstraint.AllowFlip]
+      p <- Gen.const(PosAngleConstraint.AverageParallactic)
+      o <- arbitrary[PosAngleConstraint.ParallacticOverride]
+      u <- Gen.const(PosAngleConstraint.Unconstrained)
       a <- Gen.oneOf(f, v, p, o, u)
     } yield a
   }
 
-  implicit def posAngleCogen: Cogen[PosAngle] =
+  implicit def posAngleCogen: Cogen[PosAngleConstraint] =
     Cogen[Option[Option[Either[Angle, Either[Angle, Either[Angle, Angle]]]]]].contramap {
-      case PosAngle.AverageParallactic     => None
-      case PosAngle.Unconstrained          => Some(None)
-      case PosAngle.Fixed(a)               => Some(Some(Left(a)))
-      case PosAngle.AllowFlip(a)           => Some(Some(Right(Left(a))))
-      case PosAngle.ParallacticOverride(a) => Some(Some(Right(Right(Left(a)))))
+      case PosAngleConstraint.AverageParallactic     => None
+      case PosAngleConstraint.Unconstrained          => Some(None)
+      case PosAngleConstraint.Fixed(a)               => Some(Some(Left(a)))
+      case PosAngleConstraint.AllowFlip(a)           => Some(Some(Right(Left(a))))
+      case PosAngleConstraint.ParallacticOverride(a) => Some(Some(Right(Right(Left(a)))))
     }
 }
 

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbPosAngleConstraint.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbPosAngleConstraint.scala
@@ -11,45 +11,49 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
 
-trait ArbPosAngle {
+trait ArbPosAngleConstraint {
 
-  implicit val fixedPosAngleArb = Arbitrary[PosAngleConstraint.Fixed] {
-    for {
-      a <- arbitrary[Angle]
-    } yield PosAngleConstraint.Fixed(a)
-  }
+  implicit val fixedPosAngleArb: Arbitrary[PosAngleConstraint.Fixed] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Angle]
+      } yield PosAngleConstraint.Fixed(a)
+    }
 
   implicit def fixedPosAngleCogen: Cogen[PosAngleConstraint.Fixed] =
     Cogen[Angle].contramap(_.angle)
 
-  implicit val allowFlipPosAngleArb = Arbitrary[PosAngleConstraint.AllowFlip] {
-    for {
-      a <- arbitrary[Angle]
-    } yield PosAngleConstraint.AllowFlip(a)
-  }
+  implicit val allowFlipPosAngleArb: Arbitrary[PosAngleConstraint.AllowFlip] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Angle]
+      } yield PosAngleConstraint.AllowFlip(a)
+    }
 
   implicit def allowFlipCogen: Cogen[PosAngleConstraint.AllowFlip] =
     Cogen[Angle].contramap(_.angle)
 
-  implicit val parallacticOverridePosAngleArb = Arbitrary[PosAngleConstraint.ParallacticOverride] {
-    for {
-      a <- arbitrary[Angle]
-    } yield PosAngleConstraint.ParallacticOverride(a)
-  }
+  implicit val parallacticOverridePosAngleArb: Arbitrary[PosAngleConstraint.ParallacticOverride] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Angle]
+      } yield PosAngleConstraint.ParallacticOverride(a)
+    }
 
   implicit def parallacticOverridePosAngleCogen: Cogen[PosAngleConstraint.ParallacticOverride] =
     Cogen[Angle].contramap(_.angle)
 
-  implicit val posAngleArb = Arbitrary[PosAngleConstraint] {
-    for {
-      f <- arbitrary[PosAngleConstraint.Fixed]
-      v <- arbitrary[PosAngleConstraint.AllowFlip]
-      p <- Gen.const(PosAngleConstraint.AverageParallactic)
-      o <- arbitrary[PosAngleConstraint.ParallacticOverride]
-      u <- Gen.const(PosAngleConstraint.Unconstrained)
-      a <- Gen.oneOf(f, v, p, o, u)
-    } yield a
-  }
+  implicit val posAngleArb: Arbitrary[PosAngleConstraint] =
+    Arbitrary {
+      for {
+        f <- arbitrary[PosAngleConstraint.Fixed]
+        v <- arbitrary[PosAngleConstraint.AllowFlip]
+        p <- Gen.const(PosAngleConstraint.AverageParallactic)
+        o <- arbitrary[PosAngleConstraint.ParallacticOverride]
+        u <- Gen.const(PosAngleConstraint.Unconstrained)
+        a <- Gen.oneOf(f, v, p, o, u)
+      } yield a
+    }
 
   implicit def posAngleCogen: Cogen[PosAngleConstraint] =
     Cogen[Option[Option[Either[Angle, Either[Angle, Either[Angle, Angle]]]]]].contramap {
@@ -61,4 +65,4 @@ trait ArbPosAngle {
     }
 }
 
-object ArbPosAngle extends ArbPosAngle
+object ArbPosAngleConstraint extends ArbPosAngleConstraint

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/PosAngleConstraintSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/PosAngleConstraintSuite.scala
@@ -9,12 +9,12 @@ import lucuma.core.model.arb.ArbPosAngle
 import monocle.law.discipline._
 import munit.DisciplineSuite
 
-class PosAngleSuite extends DisciplineSuite {
+class PosAngleConstraintSuite extends DisciplineSuite {
 
   import ArbAngle._
   import ArbPosAngle._
 
   checkAll("Eq[PosAngle]", EqTests[PosAngleConstraint].eqv)
 
-  checkAll("Optional[PosAngle, Angle]", OptionalTests(PosAngleConstraint.angleOptional))
+  checkAll("Optional[PosAngle, Angle]", OptionalTests(PosAngleConstraint.angle))
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/PosAngleConstraintSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/PosAngleConstraintSuite.scala
@@ -5,14 +5,14 @@ package lucuma.core.model
 
 import cats.kernel.laws.discipline.EqTests
 import lucuma.core.math.arb.ArbAngle
-import lucuma.core.model.arb.ArbPosAngle
+import lucuma.core.model.arb.ArbPosAngleConstraint
 import monocle.law.discipline._
 import munit.DisciplineSuite
 
 class PosAngleConstraintSuite extends DisciplineSuite {
 
   import ArbAngle._
-  import ArbPosAngle._
+  import ArbPosAngleConstraint._
 
   checkAll("Eq[PosAngle]", EqTests[PosAngleConstraint].eqv)
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/PosAngleSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/PosAngleSuite.scala
@@ -14,7 +14,7 @@ class PosAngleSuite extends DisciplineSuite {
   import ArbAngle._
   import ArbPosAngle._
 
-  checkAll("Eq[PosAngle]", EqTests[PosAngle].eqv)
+  checkAll("Eq[PosAngle]", EqTests[PosAngleConstraint].eqv)
 
-  checkAll("Optional[PosAngle, Angle]", OptionalTests(PosAngle.angleOptional))
+  checkAll("Optional[PosAngle, Angle]", OptionalTests(PosAngleConstraint.angleOptional))
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/PosAngleSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/PosAngleSuite.scala
@@ -4,10 +4,17 @@
 package lucuma.core.model
 
 import cats.kernel.laws.discipline.EqTests
-import lucuma.core.model.PosAngle
-import lucuma.core.model.arb.ArbPosAngle._
+import lucuma.core.math.arb.ArbAngle
+import lucuma.core.model.arb.ArbPosAngle
+import monocle.law.discipline._
 import munit.DisciplineSuite
 
 class PosAngleSuite extends DisciplineSuite {
+
+  import ArbAngle._
+  import ArbPosAngle._
+
   checkAll("Eq[PosAngle]", EqTests[PosAngle].eqv)
+
+  checkAll("Optional[PosAngle, Angle]", OptionalTests(PosAngle.angleOptional))
 }


### PR DESCRIPTION
This is mostly a renaming of `PosAngle` to `PosAngleConstraint`, to better reflect that it is a constraint on the eventual position angle and not a position angle per se.  Includes:

* Rename `PosAngle` to `PosAngleConstraint along with arbitraries and test suite
* Adds a `PosAngleConstraint.angle` `Optional` to extract specific position angles where possible
* Renames and groups the optics

I'm not sure about the importance of the last point but I noticed that we were including `Prism` in the names and that we don't do that elsewhere (and that not all the optics were in fact prisms anyway).  If anybody disagrees or has better suggestions let me know.