### PR TITLE
Proper motion calculations

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,6 +16,14 @@ pull_request_rules:
   - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@17, rootJVM)
   actions:
     merge: {}
+- name: Label benchmarks PRs
+  conditions:
+  - files~=^modules/benchmarks/
+  actions:
+    label:
+      add:
+      - benchmarks
+      remove: []
 - name: Label core PRs
   conditions:
   - files~=^modules/core/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,4 @@
+version = "3.5.3"
 include ".scalafmt-common.conf"
 project.includePaths = [] # disables formatting
+runner.dialect = scala213source3

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.42"
+ThisBuild / tlBaseVersion                         := "0.43"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 ThisBuild / scalacOptions += "-Xsource:3"

--- a/build.sbt
+++ b/build.sbt
@@ -117,4 +117,11 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
       "edu.gemini.ocs" %% "edu-gemini-util-skycalc"     % "2020001.1.7" % Test,
       "com.47deg"      %% "scalacheck-toolbox-datetime" % "0.6.0"       % Test
     )
+
   )
+
+lazy val benchmarks = project
+  .in(file("modules/benchmarks"))
+  .dependsOn(core.jvm)
+  .settings(name := "lucuma-core-benchmarks")
+  .enablePlugins(NoPublishPlugin, JmhPlugin)

--- a/modules/benchmarks/src/main/scala/lucuma/core/ProperMotionBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/lucuma/core/ProperMotionBenchmark.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core
+
+import lucuma.core.model._
+import lucuma.core.math._
+import org.openjdk.jmh.annotations._
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(1)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 4, time = 1)
+@Measurement(iterations = 10, time = 10)
+class ProperMotionBenchmark {
+
+  val tracking = SiderealTracking(
+    Coordinates.Zero,
+    Epoch.J2000,
+    Some(ProperMotion.milliarcsecondsPerYear.reverseGet((3000, 4000))),
+    RadialVelocity.kilometerspersecond.getOption(1e6),
+    Some(Parallax.fromMicroarcseconds(10000000L))
+  )
+
+  val instant = Instant.now()
+
+  @Benchmark
+  def simpleRun: Unit = {
+    tracking.at(instant)
+    ()
+  }
+
+}
+
+// Baseline
+//
+// [info] Result "lucuma.core.ProperMotionBenchmark.simpleRun":
+// [info]   107.101 ±(99.9%) 0.192 ops/ms [Average]
+// [info]   (min, avg, max) = (106.867, 107.101, 107.230), stdev = 0.127
+// [info]   CI (99.9%): [106.909, 107.293] (assumes normal distribution)
+// [info] # Run complete. Total time: 00:01:45
+//
+// ProperMotion.toRadians
+//
+// [info] Result "lucuma.core.ProperMotionBenchmark.simpleRun":
+// [info]   3251.794 ±(99.9%) 111.004 ops/ms [Average]
+// [info]   (min, avg, max) = (3103.327, 3251.794, 3311.694), stdev = 73.422
+// [info]   CI (99.9%): [3140.790, 3362.798] (assumes normal distribution)
+// [info] # Run complete. Total time: 00:01:45
+//
+// RadialVelocity.toDoubleKilometersPerSecond
+// [info] Result "lucuma.core.ProperMotionBenchmark.simpleRun":
+// [info]   4752.024 ±(99.9%) 40.378 ops/ms [Average]
+// [info]   (min, avg, max) = (4677.622, 4752.024, 4765.228), stdev = 26.708
+// [info]   CI (99.9%): [4711.645, 4792.402] (assumes normal distribution)
+// [info] # Run complete. Total time: 00:01:45

--- a/modules/benchmarks/src/main/scala/lucuma/core/ProperMotionBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/lucuma/core/ProperMotionBenchmark.scala
@@ -58,3 +58,10 @@ class ProperMotionBenchmark {
 // [info]   (min, avg, max) = (4677.622, 4752.024, 4765.228), stdev = 26.708
 // [info]   CI (99.9%): [4711.645, 4792.402] (assumes normal distribution)
 // [info] # Run complete. Total time: 00:01:45
+//
+// Inline trigonometric functions
+// [info] Result "lucuma.core.ProperMotionBenchmark.simpleRun":
+// [info]   5013.637 ±(99.9%) 5.885 ops/ms [Average]
+// [info]   (min, avg, max) = (5010.050, 5013.637, 5021.292), stdev = 3.892
+// [info]   CI (99.9%): [5007.753, 5019.522] (assumes normal distribution)
+// [info] # Run complete. Total time: 00:01:45

--- a/modules/core/shared/src/main/scala/lucuma/core/math/ProperMotion.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/ProperMotion.scala
@@ -36,7 +36,7 @@ final case class ProperMotion(
 
 object ProperMotion extends ProperMotionOptics {
   final case class AngularVelocityComponent[A](μasy: Quantity[Long, MicroArcSecondPerYear]) {
-    def toRadians: Double = μasy.to[Double, Degree %/ Year].value.toRadians
+    def toRadians: Double = (μasy.value.toDouble / (3600 * 1e6)).toRadians
 
     val masy: Quantity[Rational, MilliArcSecondPerYear] = μasy.to[Rational, MilliArcSecondPerYear]
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/ProperMotion.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/ProperMotion.scala
@@ -36,6 +36,7 @@ final case class ProperMotion(
 
 object ProperMotion extends ProperMotionOptics {
   final case class AngularVelocityComponent[A](μasy: Quantity[Long, MicroArcSecondPerYear]) {
+    // Direct conversion via coulomb turns to be too slow
     def toRadians: Double = (μasy.value.toDouble / (3600 * 1e6)).toRadians
 
     val masy: Quantity[Rational, MilliArcSecondPerYear] = μasy.to[Rational, MilliArcSecondPerYear]

--- a/modules/core/shared/src/main/scala/lucuma/core/math/RadialVelocity.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/RadialVelocity.scala
@@ -23,6 +23,7 @@ import spire.std.bigDecimal._
   */
 final case class RadialVelocity private (rv: Quantity[BigDecimal, MetersPerSecond]) {
 
+  // Direct conversion via coulomb turns to be too slow
   def toDoubleKilometersPerSecond: Double = rv.value.toDouble / 1000
 
   /**

--- a/modules/core/shared/src/main/scala/lucuma/core/math/RadialVelocity.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/RadialVelocity.scala
@@ -23,7 +23,7 @@ import spire.std.bigDecimal._
   */
 final case class RadialVelocity private (rv: Quantity[BigDecimal, MetersPerSecond]) {
 
-  def toDoubleKilometersPerSecond: Double = rv.to[Double, KilometersPerSecond].value
+  def toDoubleKilometersPerSecond: Double = rv.value.toDouble / 1000
 
   /**
     * Converts the radial velocity to a Redshift, approximate

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
@@ -117,7 +117,7 @@ object SiderealTracking extends SiderealTrackingOptics {
   private type Vec3 = (Double, Double, Double)
 
   // |+| gives us addition for VecN, but we also need scalar multiplication
-  private implicit class Vec3Ops(a: Vec3) {
+  private implicit class Vec3Ops(val a: Vec3) extends AnyVal {
     def *(d: Double): Vec3 =
       (a._1 * d, a._2 * d, a._3 * d)
   }
@@ -150,17 +150,19 @@ object SiderealTracking extends SiderealTrackingOptics {
     // Break out our components
     val (ra, dec)   = baseCoordinates
     val (dRaʹ, dDec) = properMotion
+    val cosDec = cos(dec)
+    val cosRa = cos(ra)
+    val sinDec = sin(dec)
+    val sinRa = sin(ra)
 
-    if (cos(dec) != 0) {
+    if (cosDec != 0) {
 
       // See: https://app.shortcut.com/lucuma/story/1388/proper-motion-calculation
-      val dRa  =  dRaʹ / cos(dec)
+      val dRa  =  dRaʹ / cosDec
 
       // Convert to cartesian
-      val pos: Vec3 = {
-        val cd = cos(dec)
-        (cos(ra) * cd, sin(ra) * cd, sin(dec))
-      }
+      val pos: Vec3 =
+        (cosRa * cosDec, sinRa * cosDec, sinDec)
 
       // Change per year due to radial velocity and parallax. The units work out to asec/y.
       val dPos1: Vec3 =
@@ -174,9 +176,9 @@ object SiderealTracking extends SiderealTrackingOptics {
 
       // Change per year due to proper velocity
       val dPos2 = (
-        -dRa * pos._2 - dDec * cos(ra) * sin(dec),
-        dRa * pos._1 - dDec * sin(ra) * sin(dec),
-        dDec * cos(dec)
+        -dRa * pos._2 - dDec * cosRa * sinDec,
+        dRa * pos._1 - dDec * sinRa * sinDec,
+        dDec * cosDec
       )
 
       // Our new position (still in polar coordinates). `|+|` here is scalar addition provided by

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
@@ -28,6 +28,7 @@ final class ProperMotionSuite extends DisciplineSuite {
         Some(Parallax.fromMicroarcseconds(10000000L))
       )
 
+    // July 4th 2022, around mid day
     val instant = Instant.ofEpochMilli(1656966489)
     assertEquals(tracking.at(instant), Some(Coordinates.fromHmsDms.getOption("11:59:57.096334 -00:00:58.073307").get))
   }

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
@@ -2,10 +2,14 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package lucuma.core.math
+
 import cats.kernel.laws.discipline._
 import lucuma.core.math.arb.ArbProperMotion._
+import lucuma.core.model.SiderealTracking
 import lucuma.core.optics.laws.discipline.SplitMonoTests
 import munit.DisciplineSuite
+
+import java.time.Instant
 
 final class ProperMotionSuite extends DisciplineSuite {
 
@@ -15,4 +19,16 @@ final class ProperMotionSuite extends DisciplineSuite {
 
   checkAll("milliarcsecondsPerYear", SplitMonoTests(ProperMotion.milliarcsecondsPerYear).splitMono)
 
+  test("Sanity checks") {
+    val tracking = SiderealTracking(
+        Coordinates.Zero,
+        Epoch.J2000,
+        Some(ProperMotion.milliarcsecondsPerYear.reverseGet((-3000, 4000))),
+        RadialVelocity.kilometerspersecond.getOption(10000),
+        Some(Parallax.fromMicroarcseconds(10000000L))
+      )
+
+    val instant = Instant.ofEpochMilli(1656966489)
+    assertEquals(tracking.at(instant), Some(Coordinates.fromHmsDms.getOption("11:59:57.096334 -00:00:58.073307").get))
+  }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.0-RC2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
-addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib"           % "0.9.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.10.1")
-addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.6.3")
+addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib" % "0.9.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"    % "1.10.1")
+addSbtPlugin("com.timushev.sbt"   % "sbt-updates"    % "0.6.3")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"        % "0.4.3")


### PR DESCRIPTION
When analyzing large fields some performance problems were noted.
I tracked this to the proper motion calculation and in particular it turns out that conversions done by coulomb are substantially slower than done by hand.

This may change in coulomb 3 as that part of the code is completely different but for now I'm converting the conversion to manual in two places plus a few other smaller optimizations. I tried a few other improvements to reduce the amount of allocations but it doesn't seen to have any effect

A benchmark shows a 50x improvement