### PR TITLE
Elevation range validators, Display.byTag, scientific notation normalization

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/validation/ModelValidators.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/validation/ModelValidators.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.validation
+
+import eu.timepit.refined.auto._
+import lucuma.core.model.ElevationRange
+import lucuma.core.optics.ValidSplitEpi
+import lucuma.core.validation._
+
+object ModelValidators {
+  private val airMassErrorMsg   =
+    f"Must be ${ElevationRange.AirMass.MinValue.toDouble}%.1f to ${ElevationRange.AirMass.MaxValue.toDouble}%.1f"
+  private val hourAngleErrorMsg =
+    f"Must be ${ElevationRange.HourAngle.MinHour.toDouble}%.1f to ${ElevationRange.HourAngle.MaxHour.toDouble}%.1f"
+
+  val airMassElevationRangeValidWedge: InputValidWedge[ElevationRange.AirMass.DecimalValue] =
+    InputValidWedge
+      .truncatedBigDecimal(decimals = 1)
+      .andThen(
+        ValidSplitEpi
+          .forRefined[String, BigDecimal, ElevationRange.AirMass.Value](airMassErrorMsg)
+          .toErrorsValidSplitEpiUnsafe
+      )
+
+  val hourAngleElevationRangeValidWedge: InputValidWedge[ElevationRange.HourAngle.DecimalHour] =
+    InputValidWedge
+      .truncatedBigDecimal(decimals = 1)
+      .andThen(
+        ValidSplitEpi
+          .forRefined[String, BigDecimal, ElevationRange.HourAngle.Hour](hourAngleErrorMsg)
+          .toErrorsValidSplitEpiUnsafe
+      )
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Display.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Display.scala
@@ -6,43 +6,54 @@ package lucuma.core.util
 import cats.Contravariant
 
 /**
-  * Typeclass for things that can be shown in a user interface.
-  * @group Typeclasses
-  */
-trait Display[A]     {
+ * Typeclass for things that can be shown in a user interface.
+ * @group Typeclasses
+ */
+trait Display[A] {
   def shortName(a: A): String
-  def longName(a:  A): String = shortName(a)
+  def longName(a: A): String = shortName(a)
 }
 
 object Display {
   def apply[A](implicit ev: Display[A]): ev.type = ev
 
-  /** Create an instance of Display using the provided functions. 
-   * 
-   * @param toShortName function that maps A to the shortName
-   * @param toLongName function that maps A to the longName
-  */
-  def by[A](toShortName: A => String, toLongName: A => String): Display[A] = 
+  /**
+   * Create an instance of `Display` using the provided functions.
+   *
+   * @param toShortName
+   *   function that maps `A` to the shortName
+   * @param toLongName
+   *   function that maps `A` to the longName
+   */
+  def by[A](toShortName: A => String, toLongName: A => String): Display[A] =
     new Display[A] {
-      def shortName(a: A) = toShortName(a)
-      override def longName(a: A)  = toLongName(a)
+      def shortName(a: A)         = toShortName(a)
+      override def longName(a: A) = toLongName(a)
     }
 
-  /** Create an instance of Display using the provided function 
-   * for the shortName. The longName will be the same as the 
-   * shortName.
-   * 
-   * @param toShortName function that maps A to the shortName
+  /**
+   * Create an instance of `Display` using the provided function for the shortName. The longName
+   * will be the same as the shortName.
+   *
+   * @param toShortName
+   *   function that maps A to the shortName
    */
-  def byShortName[A](toShortName: A => String): Display[A] = 
+  def byShortName[A](toShortName: A => String): Display[A] =
     new Display[A] {
       def shortName(a: A) = toShortName(a)
     }
+
+  /**
+   * Create an instance of `Display` for an `Enumerated` using its `tag` as both shortName and
+   * longName.
+   */
+  def byTag[A: Enumerated]: Display[A] =
+    Display.byShortName(Enumerated[A].tag)
 
   implicit val contravariantDisplay: Contravariant[Display] = new Contravariant[Display] {
     def contramap[A, B](fa: Display[A])(f: B => A): Display[B] =
       new Display[B] {
-        def shortName(b: B) = fa.shortName(f(b)) 
+        def shortName(b: B)         = fa.shortName(f(b))
         override def longName(b: B) = fa.longName(f(b))
       }
   }

--- a/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidSplitEpi.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidSplitEpi.scala
@@ -176,6 +176,6 @@ object InputValidSplitEpi {
     val formatter = new DecimalFormat("0.0E0")
     formatter.setRoundingMode(RoundingMode.HALF_UP)
     formatter.setMaximumFractionDigits(decimals.map(_.value).getOrElse(x.precision - 1))
-    formatter.format(x.bigDecimal)
+    formatter.format(x.bigDecimal).stripSuffix("E0").toLowerCase
   }
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/validation/ModelValidatorsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/validation/ModelValidatorsSuite.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.validation
+
+import eu.timepit.refined.cats._
+import eu.timepit.refined.scalacheck.all._
+import lucuma.core.optics.laws.discipline.ValidWedgeTests
+import munit.DisciplineSuite
+
+final class ModelValidatorsSuite extends DisciplineSuite {
+  checkAll(
+    "airMassElevationRangeValidWedge",
+    ValidWedgeTests(ModelValidators.airMassElevationRangeValidWedge).validWedgeLaws
+  )
+
+  checkAll(
+    "hourAngleElevationRangeValidWedge",
+    ValidWedgeTests(ModelValidators.hourAngleElevationRangeValidWedge).validWedgeLaws
+  )
+}


### PR DESCRIPTION
- Validators for elevation range.
- `Display.byTag` for `Enumerated`s.
- Normalize scientific notation, by using lowercase `e` and removing `e0`.