### PR TITLE
Add addition and subtraction to Wavelength

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/Wavelength.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Wavelength.scala
@@ -59,6 +59,16 @@ final case class Wavelength(toPicometers: Quantity[PosInt, Picometer]) {
 
   def angstrom: Quantity[Rational, Angstrom] = Å
 
+  /**
+    * Addition, with result constrained to Wavelength.Max
+    */
+  def +(that: Wavelength): Wavelength = Wavelength.plus(this, that)
+  
+  /**
+    * Subtraction, with result constrained to Wavelength.Min
+    */
+  def -(that: Wavelength): Wavelength = Wavelength.minus(this, that)
+
   override def toString: String =
     s"Wavelength(${toPicometers.show})"
 
@@ -125,6 +135,25 @@ object Wavelength {
     refineV[Positive](a).toOption.flatMap(a =>
       Option.when(a.value <= MaxAngstrom)(Wavelength(a.withUnit[Angstrom]))
     )
+
+  /**
+   * Adds 2 Wavelengths, constraining new value to Wavelength.Max
+   * @group operator
+   */
+  def plus(a: Wavelength, b: Wavelength): Wavelength = {
+    val newPico = a.toPicometers.value.value + b.toPicometers.value.value
+    Wavelength.fromInt(newPico).getOrElse(Wavelength.Max)
+  }
+
+  /**
+   * Subracts Wavelength b from Wavelength a, constraining new value to Wavelength.Min
+   * @group operator
+   */
+  def minus(a: Wavelength, b: Wavelength): Wavelength = {
+    val newPico = a.toPicometers.value.value - b.toPicometers.value.value
+    Wavelength.fromInt(newPico).getOrElse(Wavelength.Min)
+  }
+    
 
   /**
    * Prism from Int in pm into Wavelength and back.

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/WavelengthSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/WavelengthSuite.scala
@@ -94,6 +94,30 @@ final class WavelengthSuite extends munit.DisciplineSuite {
     assertEquals(Wavelength.fromAngstroms(Wavelength.MaxAngstrom + 1),  none)
   }
 
+  test("Addition") {
+    forAll { (a: Wavelength, b: Wavelength) =>
+      val newPico = a.toPicometers.value.value.toLong + b.toPicometers.value.value.toLong
+      val newWavelength = 
+        if (newPico.isValidInt && newPico.toInt <= Wavelength.Max.toPicometers.value.value) 
+          Wavelength.unsafeFromInt(newPico.toInt)
+        else Wavelength.Max
+      assertEquals(Wavelength.plus(a, b), newWavelength)
+      assertEquals(a + b, newWavelength)
+    }
+  }
+
+  test("Subtraction") {
+    forAll { (a: Wavelength, b: Wavelength) =>
+      val newPico = a.toPicometers.value.value - b.toPicometers.value.value
+      val newWavelength = 
+        if (newPico >= Wavelength.Min.toPicometers.value.value)
+          Wavelength.unsafeFromInt(newPico)
+        else Wavelength.Min
+      assertEquals(Wavelength.minus(a, b), newWavelength)
+      assertEquals(a - b, newWavelength)
+    }
+  }
+
   private def testFormat[U](scale: Int, format: Format[BigDecimal, Wavelength])(toRational: Wavelength => Quantity[Rational, U]) =
     forAll { (w: Wavelength) =>
       assertEquals(format.getOption(toRational(w).value.toBigDecimal(scale, RoundingMode.HALF_UP)),  w.some)


### PR DESCRIPTION
There is currently unsafe math being performed in `lucuma-itc` by performing the addition/subtraction on the refined `.toPicometers` values and testing for "out of range". However, by the `toPicometers` can never be out of range by the logic of the refined algebra. 

The addition provided here constrains the value to a max of Wavelength.Max, and subtraction to a min of Wavelength.Min. (So that `Wavelength(2) - Wavelength(2) === Wavelength(1)`, not `Wavelength(Int.MaxValue)`