### PR TITLE
remove Enumerated.of and Display.fromTag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.45"
+ThisBuild / tlBaseVersion                         := "0.46"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 ThisBuild / scalacOptions += "-Xsource:3"

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/Breakpoint.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/Breakpoint.scala
@@ -5,12 +5,13 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed trait Breakpoint extends Product with Serializable
+sealed abstract class Breakpoint(val tag: String) extends Product with Serializable
 
 object Breakpoint {
-  /** @group Constructors */ case object Enabled extends Breakpoint
-  /** @group Constructors */ case object Disabled extends Breakpoint
+  /** @group Constructors */ case object Enabled extends Breakpoint("enabled")
+  /** @group Constructors */ case object Disabled extends Breakpoint("disabled")
 
-  implicit val BreakpointEnumerated: Enumerated[Breakpoint] = Enumerated.of(Enabled, Disabled)
+  implicit val BreakpointEnumerated: Enumerated[Breakpoint] =
+    Enumerated.from(Enabled, Disabled).withTag(_.tag)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/CatalogName.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/CatalogName.scala
@@ -5,15 +5,14 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed trait CatalogName extends Product with Serializable
+sealed abstract class CatalogName(val tag: String) extends Product with Serializable
 
 object CatalogName {
-  case object Simbad extends CatalogName
-  case object Horizon extends CatalogName
-  case object Gaia extends CatalogName
+  case object Simbad extends CatalogName("simbad")
+  case object Gaia extends CatalogName("gaia")
 
   /** @group Typeclass Instances */
   implicit val CatalogNameEnumerated: Enumerated[CatalogName] =
-    Enumerated.of(Simbad, Horizon, Gaia)
+    Enumerated.from(Simbad, Gaia).withTag(_.tag)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/CloudExtinction.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/CloudExtinction.scala
@@ -6,29 +6,30 @@ package lucuma.core.enums
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
-sealed abstract class CloudExtinction(val toDeciBrightness: Int) extends Product with Serializable {
+sealed abstract class CloudExtinction(val tag: String, val toDeciBrightness: Int) extends Product with Serializable {
   def toBrightness: Double = toDeciBrightness / 10.0
   def label: String        = f"< $toBrightness%.1f mag"
 }
 
 object CloudExtinction {
-  case object PointOne       extends CloudExtinction(1)
-  case object PointThree     extends CloudExtinction(3)
-  case object PointFive      extends CloudExtinction(5)
-  case object OnePointZero   extends CloudExtinction(10)
-  case object OnePointFive   extends CloudExtinction(15)
-  case object TwoPointZero   extends CloudExtinction(20)
-  case object ThreePointZero extends CloudExtinction(30)
+  case object PointOne       extends CloudExtinction("point_one", 1)
+  case object PointThree     extends CloudExtinction("point_three", 3)
+  case object PointFive      extends CloudExtinction("point_five", 5)
+  case object OnePointZero   extends CloudExtinction("one_point_zero", 10)
+  case object OnePointFive   extends CloudExtinction("one_point_five", 15)
+  case object TwoPointZero   extends CloudExtinction("two_point_zero", 20)
+  case object ThreePointZero extends CloudExtinction("three_point_zero", 30)
 
   implicit val CloudExtinctionEnumerated: Enumerated[CloudExtinction] =
-    Enumerated.of(PointOne,
-                  PointThree,
-                  PointFive,
-                  OnePointZero,
-                  OnePointFive,
-                  TwoPointZero,
-                  ThreePointZero
-    )
+    Enumerated.from(
+      PointOne,
+      PointThree,
+      PointFive,
+      OnePointZero,
+      OnePointFive,
+      TwoPointZero,
+      ThreePointZero
+    ).withTag(_.tag)
 
   implicit val CloudExtinctionDisplay: Display[CloudExtinction] =
     Display.byShortName(_.label)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/CoolStarTemperature.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/CoolStarTemperature.scala
@@ -12,29 +12,32 @@ import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
 sealed abstract class CoolStarTemperature(
+  val tag: String,
   val name: String,
   val temperature: Quantity[PosBigDecimal, Kelvin]
 ) extends Product
     with Serializable
 
 object CoolStarTemperature {
-    case object T400K extends CoolStarTemperature("400K", BigDecimal(400).withRefinedUnit[Positive, Kelvin])
-    case object T600K extends CoolStarTemperature("600K", BigDecimal(600).withRefinedUnit[Positive, Kelvin])
-    case object T800K extends CoolStarTemperature("800K", BigDecimal(800).withRefinedUnit[Positive, Kelvin])
-    case object T900K extends CoolStarTemperature("900K", BigDecimal(900).withRefinedUnit[Positive, Kelvin])
-    case object T1000K extends CoolStarTemperature("1000K", BigDecimal(1000).withRefinedUnit[Positive, Kelvin])
-    case object T1200K extends CoolStarTemperature("1200K", BigDecimal(1200).withRefinedUnit[Positive, Kelvin])
-    case object T1400K extends CoolStarTemperature("1400K", BigDecimal(1400).withRefinedUnit[Positive, Kelvin])
-    case object T1600K extends CoolStarTemperature("1600K", BigDecimal(1600).withRefinedUnit[Positive, Kelvin])
-    case object T1800K extends CoolStarTemperature("1800K", BigDecimal(1800).withRefinedUnit[Positive, Kelvin])
-    case object T2000K extends CoolStarTemperature("2000K", BigDecimal(2000).withRefinedUnit[Positive, Kelvin])
-    case object T2200K extends CoolStarTemperature("2200K", BigDecimal(2200).withRefinedUnit[Positive, Kelvin])
-    case object T2400K extends CoolStarTemperature("2400K", BigDecimal(2400).withRefinedUnit[Positive, Kelvin])
-    case object T2600K extends CoolStarTemperature("2600K", BigDecimal(2600).withRefinedUnit[Positive, Kelvin])
-    case object T2800K extends CoolStarTemperature("2800K", BigDecimal(2800).withRefinedUnit[Positive, Kelvin])
+    case object T400K extends CoolStarTemperature("T400_K", "400K", BigDecimal(400).withRefinedUnit[Positive, Kelvin])
+    case object T600K extends CoolStarTemperature("T600_K", "600K", BigDecimal(600).withRefinedUnit[Positive, Kelvin])
+    case object T800K extends CoolStarTemperature("T800_K", "800K", BigDecimal(800).withRefinedUnit[Positive, Kelvin])
+    case object T900K extends CoolStarTemperature("T900_K", "900K", BigDecimal(900).withRefinedUnit[Positive, Kelvin])
+    case object T1000K extends CoolStarTemperature("T1000_K", "1000K", BigDecimal(1000).withRefinedUnit[Positive, Kelvin])
+    case object T1200K extends CoolStarTemperature("T1200_K", "1200K", BigDecimal(1200).withRefinedUnit[Positive, Kelvin])
+    case object T1400K extends CoolStarTemperature("T1400_K", "1400K", BigDecimal(1400).withRefinedUnit[Positive, Kelvin])
+    case object T1600K extends CoolStarTemperature("T1600_K", "1600K", BigDecimal(1600).withRefinedUnit[Positive, Kelvin])
+    case object T1800K extends CoolStarTemperature("T1800_K", "1800K", BigDecimal(1800).withRefinedUnit[Positive, Kelvin])
+    case object T2000K extends CoolStarTemperature("T2000_K", "2000K", BigDecimal(2000).withRefinedUnit[Positive, Kelvin])
+    case object T2200K extends CoolStarTemperature("T2200_K", "2200K", BigDecimal(2200).withRefinedUnit[Positive, Kelvin])
+    case object T2400K extends CoolStarTemperature("T2400_K", "2400K", BigDecimal(2400).withRefinedUnit[Positive, Kelvin])
+    case object T2600K extends CoolStarTemperature("T2600_K", "2600K", BigDecimal(2600).withRefinedUnit[Positive, Kelvin])
+    case object T2800K extends CoolStarTemperature("T2800_K", "2800K", BigDecimal(2800).withRefinedUnit[Positive, Kelvin])
 
   implicit val enumCoolStarTemperature: Enumerated[CoolStarTemperature] =
-    Enumerated.of(T400K, T600K, T800K, T900K, T1000K, T1200K, T1400K, T1600K, T1800K, T2000K, T2200K, T2400K, T2600K, T2800K)
+    Enumerated
+      .from(T400K, T600K, T800K, T900K, T1000K, T1200K, T1400K, T1600K, T1800K, T2000K, T2200K, T2400K, T2600K, T2800K)
+      .withTag(_.tag)
 
   implicit val displayCoolstarTemperature: Display[CoolStarTemperature] =
     Display.byShortName(_.name)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/DatasetStage.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/DatasetStage.scala
@@ -5,24 +5,24 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed trait DatasetStage extends Product with Serializable
+sealed abstract class DatasetStage(val tag: String) extends Product with Serializable
 
 object DatasetStage {
-  /** @group Constructors */ case object EndObserve extends DatasetStage
-  /** @group Constructors */ case object EndReadout extends DatasetStage
-  /** @group Constructors */ case object EndWrite extends DatasetStage
-  /** @group Constructors */ case object StartObserve extends DatasetStage
-  /** @group Constructors */ case object StartReadout extends DatasetStage
-  /** @group Constructors */ case object StartWrite extends DatasetStage
+  /** @group Constructors */ case object EndObserve extends DatasetStage("end_observe")
+  /** @group Constructors */ case object EndReadout extends DatasetStage("end_readout")
+  /** @group Constructors */ case object EndWrite extends DatasetStage("end_write")
+  /** @group Constructors */ case object StartObserve extends DatasetStage("start_observe")
+  /** @group Constructors */ case object StartReadout extends DatasetStage("start_readout")
+  /** @group Constructors */ case object StartWrite extends DatasetStage("start_write")
 
   implicit val DataStageEnumerated: Enumerated[DatasetStage] =
-    Enumerated.of(
+    Enumerated.from(
       EndObserve,
       EndReadout,
       EndWrite,
       StartObserve,
       StartReadout,
       StartWrite
-    )
+    ).withTag(_.tag)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/FocalPlane.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/FocalPlane.scala
@@ -5,14 +5,14 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed trait FocalPlane extends Product with Serializable
+sealed abstract class FocalPlane(val tag: String) extends Product with Serializable
 
 object FocalPlane {
-  case object SingleSlit   extends FocalPlane
-  case object MultipleSlit extends FocalPlane
-  case object IFU          extends FocalPlane
+  case object SingleSlit   extends FocalPlane("single_slit")
+  case object MultipleSlit extends FocalPlane("multiple_slit")
+  case object IFU          extends FocalPlane("ifu")
 
   /** @group Typeclass Instances */
   implicit val FocalPlaneEnumerated: Enumerated[FocalPlane] =
-    Enumerated.of(SingleSlit, MultipleSlit, IFU)
+    Enumerated.from(SingleSlit, MultipleSlit, IFU).withTag(_.tag)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GuideSpeed.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GuideSpeed.scala
@@ -41,6 +41,6 @@ object GuideSpeed {
 
   /** @group Typeclass Instances */
   implicit val GuideProbeEnumerated: Enumerated[GuideSpeed] =
-    Enumerated.of[GuideSpeed](Fast, Medium, Slow)
+    Enumerated.from(Fast, Medium, Slow).withTag(_.tag)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ImageQuality.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ImageQuality.scala
@@ -16,7 +16,7 @@ import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 import spire.math.Rational
 
-sealed abstract class ImageQuality(val toDeciArcSeconds: Quantity[PosInt, DeciArcSecond]) extends Product with Serializable {
+sealed abstract class ImageQuality(val tag: String, val toDeciArcSeconds: Quantity[PosInt, DeciArcSecond]) extends Product with Serializable {
   def toArcSeconds: Quantity[Rational, ArcSecond] = toDeciArcSeconds.to[Rational, ArcSecond]
   def label: String        = f"""< ${toArcSeconds.value.toDouble}%.1f\""""
 
@@ -25,27 +25,28 @@ sealed abstract class ImageQuality(val toDeciArcSeconds: Quantity[PosInt, DeciAr
 }
 
 object ImageQuality {
-  case object PointOne     extends ImageQuality(refineMV[Positive](1).withUnit[DeciArcSecond])
-  case object PointTwo     extends ImageQuality(refineMV[Positive](2).withUnit[DeciArcSecond])
-  case object PointThree   extends ImageQuality(refineMV[Positive](3).withUnit[DeciArcSecond])
-  case object PointFour    extends ImageQuality(refineMV[Positive](4).withUnit[DeciArcSecond])
-  case object PointSix     extends ImageQuality(refineMV[Positive](6).withUnit[DeciArcSecond])
-  case object PointEight   extends ImageQuality(refineMV[Positive](8).withUnit[DeciArcSecond])
-  case object OnePointZero extends ImageQuality(refineMV[Positive](10).withUnit[DeciArcSecond])
-  case object OnePointFive extends ImageQuality(refineMV[Positive](15).withUnit[DeciArcSecond])
-  case object TwoPointZero extends ImageQuality(refineMV[Positive](20).withUnit[DeciArcSecond])
+  case object PointOne     extends ImageQuality("point_one", refineMV[Positive](1).withUnit[DeciArcSecond])
+  case object PointTwo     extends ImageQuality("point_two", refineMV[Positive](2).withUnit[DeciArcSecond])
+  case object PointThree   extends ImageQuality("point_three", refineMV[Positive](3).withUnit[DeciArcSecond])
+  case object PointFour    extends ImageQuality("point_four", refineMV[Positive](4).withUnit[DeciArcSecond])
+  case object PointSix     extends ImageQuality("point_six", refineMV[Positive](6).withUnit[DeciArcSecond])
+  case object PointEight   extends ImageQuality("point_eight", refineMV[Positive](8).withUnit[DeciArcSecond])
+  case object OnePointZero extends ImageQuality("one_point_zero", refineMV[Positive](10).withUnit[DeciArcSecond])
+  case object OnePointFive extends ImageQuality("one_point_five", refineMV[Positive](15).withUnit[DeciArcSecond])
+  case object TwoPointZero extends ImageQuality("two_point_zero", refineMV[Positive](20).withUnit[DeciArcSecond])
 
   implicit val ImageQualityEnumerated: Enumerated[ImageQuality] =
-    Enumerated.of(PointOne,
-                  PointTwo,
-                  PointThree,
-                  PointFour,
-                  PointSix,
-                  PointEight,
-                  OnePointZero,
-                  OnePointFive,
-                  TwoPointZero
-    )
+    Enumerated.from(
+      PointOne,
+      PointTwo,
+      PointThree,
+      PointFour,
+      PointSix,
+      PointEight,
+      OnePointZero,
+      OnePointFive,
+      TwoPointZero
+    ).withTag(_.tag)
 
   implicit val ImageQualityDisplay: Display[ImageQuality] =
     Display.byShortName(_.label)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObsActiveStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObsActiveStatus.scala
@@ -12,7 +12,7 @@ import monocle.Iso
  * example, "allows PIs to prevent or halt execution of "Ready'' or "Ongoing''
  * observations while retaining their status information".
  */
-sealed abstract class ObsActiveStatus(val label: String, val toBoolean: Boolean) extends Product with Serializable {
+sealed abstract class ObsActiveStatus(val tag: String, val label: String, val toBoolean: Boolean) extends Product with Serializable {
 
   def fold[A](active: => A, inactive: => A): A =
     this match {
@@ -24,15 +24,15 @@ sealed abstract class ObsActiveStatus(val label: String, val toBoolean: Boolean)
 
 object ObsActiveStatus {
 
-  case object Active   extends ObsActiveStatus("Active", true)
-  case object Inactive extends ObsActiveStatus("Inactive", false)
+  case object Active   extends ObsActiveStatus("active", "Active", true)
+  case object Inactive extends ObsActiveStatus("inactive", "Inactive", false)
 
   /** @group Typeclass Instances */
   implicit val EnumeratedObsActiveStatus: Enumerated[ObsActiveStatus] =
-    Enumerated.of(
+    Enumerated.from(
       Active,
       Inactive
-    )
+    ).withTag(_.tag)
 
   implicit val DisplayObsActiveStatus: Display[ObsActiveStatus] =
     Display.byShortName(_.label)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObsStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObsStatus.scala
@@ -8,21 +8,21 @@ package enums
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
-sealed abstract class ObsStatus(val label: String) extends Product with Serializable
+sealed abstract class ObsStatus(val tag: String, val label: String) extends Product with Serializable
 
 object ObsStatus {
-  case object New       extends ObsStatus("New")
-  case object Included  extends ObsStatus("Included")
-  case object Proposed  extends ObsStatus("Proposed")
-  case object Approved  extends ObsStatus("Approved")
-  case object ForReview extends ObsStatus("For Review")
-  case object Ready     extends ObsStatus("Ready")
-  case object Ongoing   extends ObsStatus("Ongoing")
-  case object Observed  extends ObsStatus("Observed")
+  case object New       extends ObsStatus("new", "New")
+  case object Included  extends ObsStatus("included", "Included")
+  case object Proposed  extends ObsStatus("proposed", "Proposed")
+  case object Approved  extends ObsStatus("approved", "Approved")
+  case object ForReview extends ObsStatus("for_review", "For Review")
+  case object Ready     extends ObsStatus("ready", "Ready")
+  case object Ongoing   extends ObsStatus("ongoing", "Ongoing")
+  case object Observed  extends ObsStatus("observed", "Observed")
 
   /** @group Typeclass Instances */
   implicit val ObsStatusEnumerated: Enumerated[ObsStatus] =
-    Enumerated.of(
+    Enumerated.from(
       New,
       Included,
       Proposed,
@@ -31,7 +31,7 @@ object ObsStatus {
       Ready,
       Ongoing,
       Observed
-    )
+    ).withTag(_.tag)
 
   implicit val ObsStatusDisplay: Display[ObsStatus] =
     Display.byShortName(_.label)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ScienceMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ScienceMode.scala
@@ -5,13 +5,13 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed abstract class ScienceMode extends Product with Serializable
+sealed abstract class ScienceMode(val tag: String) extends Product with Serializable
 
 object ScienceMode {
-  case object Imaging      extends ScienceMode
-  case object Spectroscopy extends ScienceMode
+  case object Imaging      extends ScienceMode("imaging")
+  case object Spectroscopy extends ScienceMode("spectroscopy")
 
   implicit val ScienceModeEnumerated: Enumerated[ScienceMode] =
-    Enumerated.of(Imaging, Spectroscopy)
+    Enumerated.from(Imaging, Spectroscopy).withTag(_.tag)
 }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SequenceCommand.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SequenceCommand.scala
@@ -5,23 +5,23 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed trait SequenceCommand extends Product with Serializable
+sealed abstract class SequenceCommand(val tag: String) extends Product with Serializable
 
 object SequenceCommand {
-  /** @group Constructors */ case object Abort extends SequenceCommand
-  /** @group Constructors */ case object Continue extends SequenceCommand
-  /** @group Constructors */ case object Pause extends SequenceCommand
-  /** @group Constructors */ case object Slew extends SequenceCommand
-  /** @group Constructors */ case object Start extends SequenceCommand
-  /** @group Constructors */ case object Stop extends SequenceCommand
+  /** @group Constructors */ case object Abort extends SequenceCommand("abort")
+  /** @group Constructors */ case object Continue extends SequenceCommand("continue")
+  /** @group Constructors */ case object Pause extends SequenceCommand("pause")
+  /** @group Constructors */ case object Slew extends SequenceCommand("slew")
+  /** @group Constructors */ case object Start extends SequenceCommand("start")
+  /** @group Constructors */ case object Stop extends SequenceCommand("stop")
 
   implicit val SequenceCommandEnumerated: Enumerated[SequenceCommand] =
-    Enumerated.of(
+    Enumerated.from(
       Abort,
       Continue,
       Pause,
       Slew,
       Start,
       Stop
-    )
+    ).withTag(_.tag)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SkyBackground.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SkyBackground.scala
@@ -6,16 +6,16 @@ package lucuma.core.enums
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
-sealed abstract class SkyBackground(val label: String) extends Product with Serializable
+sealed abstract class SkyBackground(val tag: String, val label: String) extends Product with Serializable
 
 object SkyBackground {
-  case object Darkest extends SkyBackground("Darkest")
-  case object Dark    extends SkyBackground("Dark")
-  case object Gray    extends SkyBackground("Gray")
-  case object Bright  extends SkyBackground("Bright")
+  case object Darkest extends SkyBackground("darkest", "Darkest")
+  case object Dark    extends SkyBackground("dark", "Dark")
+  case object Gray    extends SkyBackground("gray", "Gray")
+  case object Bright  extends SkyBackground("bright", "Bright")
 
   implicit val SkyBackgroundEnumerated: Enumerated[SkyBackground] =
-    Enumerated.of(Darkest, Dark, Gray, Bright)
+    Enumerated.from(Darkest, Dark, Gray, Bright).withTag(_.tag)
 
   implicit val SkyBackgroundDisplay: Display[SkyBackground] =
     Display.byShortName(_.label)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SpectroscopyCapabilities.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SpectroscopyCapabilities.scala
@@ -5,13 +5,13 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed abstract class SpectroscopyCapabilities extends Product with Serializable
+sealed abstract class SpectroscopyCapabilities(val tag: String) extends Product with Serializable
 
 object SpectroscopyCapabilities {
-  case object NodAndShuffle extends SpectroscopyCapabilities
-  case object Polarimetry   extends SpectroscopyCapabilities
-  case object Coronagraphy  extends SpectroscopyCapabilities
+  case object NodAndShuffle extends SpectroscopyCapabilities("nod_and_shuffle")
+  case object Polarimetry   extends SpectroscopyCapabilities("polarimetry")
+  case object Coronagraphy  extends SpectroscopyCapabilities("coronagraphy")
 
   implicit val SpectroscopyCapabilitiesEnumerated: Enumerated[SpectroscopyCapabilities] =
-    Enumerated.of(NodAndShuffle, Polarimetry, Coronagraphy)
+    Enumerated.from(NodAndShuffle, Polarimetry, Coronagraphy).withTag(_.tag)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/StellarLibrarySpectrum.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/StellarLibrarySpectrum.scala
@@ -66,7 +66,7 @@ object StellarLibrarySpectrum {
 
   /** @group Typeclass Instances */
   implicit val StellarLibrarySpectrumEnumerated: Enumerated[StellarLibrarySpectrum] =
-    Enumerated.of(
+    Enumerated.from(
       O5V,
       O8III,
       B0V,
@@ -117,6 +117,6 @@ object StellarLibrarySpectrum {
       M6V,
       M6III,
       M9III
-    )
+    ).withTag(_.tag)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/StepStage.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/StepStage.scala
@@ -5,23 +5,23 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed trait StepStage extends Product with Serializable
+sealed abstract class StepStage(val tag: String) extends Product with Serializable
 
 object StepStage {
-  /** @group Constructors */ case object EndConfigure extends StepStage
-  /** @group Constructors */ case object EndObserve extends StepStage
-  /** @group Constructors */ case object EndStep extends StepStage
-  /** @group Constructors */ case object StartConfigure extends StepStage
-  /** @group Constructors */ case object StartObserve extends StepStage
-  /** @group Constructors */ case object StartStep extends StepStage
+  /** @group Constructors */ case object EndConfigure extends StepStage("end_configure")
+  /** @group Constructors */ case object EndObserve extends StepStage("end_observe")
+  /** @group Constructors */ case object EndStep extends StepStage("end_step")
+  /** @group Constructors */ case object StartConfigure extends StepStage("start_configure")
+  /** @group Constructors */ case object StartObserve extends StepStage("start_observe")
+  /** @group Constructors */ case object StartStep extends StepStage("start_step")
 
   implicit val StepStageEnumerated: Enumerated[StepStage] =
-    Enumerated.of(
+    Enumerated.from(
       EndConfigure,
       EndObserve,
       EndStep,
       StartConfigure,
       StartObserve,
       StartStep
-    )
+    ).withTag(_.tag)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/TacCategory.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/TacCategory.scala
@@ -5,19 +5,19 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed abstract class TacGroup(val label: String) extends Product with Serializable
+sealed abstract class TacGroup(val tag: String, val label: String) extends Product with Serializable
 
 object TacGroup {
-  case object SolarSystem        extends TacGroup("Solar System")
-  case object Exoplanets         extends TacGroup("Exoplanets")
-  case object GalacticLocalGroup extends TacGroup("Galactic/Local Group")
-  case object Extragalactic      extends TacGroup("Extragalactic")
+  case object SolarSystem        extends TacGroup("solar_system", "Solar System")
+  case object Exoplanets         extends TacGroup("exoplanets", "Exoplanets")
+  case object GalacticLocalGroup extends TacGroup("galactic_local_group", "Galactic/Local Group")
+  case object Extragalactic      extends TacGroup("extragalactic", "Extragalactic")
 
   implicit val TacGroupEnumerated: Enumerated[TacGroup] =
-    Enumerated.of(SolarSystem, Exoplanets, GalacticLocalGroup, Extragalactic)
+    Enumerated.from(SolarSystem, Exoplanets, GalacticLocalGroup, Extragalactic).withTag(_.tag)
 }
 
-sealed abstract class TacCategory(val label: String, val group: TacGroup)
+sealed abstract class TacCategory(val tag: String, val label: String, val group: TacGroup)
     extends Product
     with Serializable
 
@@ -25,46 +25,46 @@ object TacCategory {
   import TacGroup._
 
   case object SmallBodies
-      extends TacCategory("Small Bodies: Asteroids, Comets, Moons, Kuiper Belt", SolarSystem)
-  case object PlanetaryAtmospheres extends TacCategory("Planetary Atmospheres", SolarSystem)
-  case object PlanetarySurfaces    extends TacCategory("Planetary Surfaces", SolarSystem)
-  case object SolarSystemOther     extends TacCategory("Solar System Other", SolarSystem)
+      extends TacCategory("small_bodies", "Small Bodies: Asteroids, Comets, Moons, Kuiper Belt", SolarSystem)
+  case object PlanetaryAtmospheres extends TacCategory("planetary_atmospheres", "Planetary Atmospheres", SolarSystem)
+  case object PlanetarySurfaces    extends TacCategory("planetary_surfaces", "Planetary Surfaces", SolarSystem)
+  case object SolarSystemOther     extends TacCategory("solar_system_other", "Solar System Other", SolarSystem)
 
   case object ExoplanetRadialVelocities
-      extends TacCategory("Exoplanet Radial Velocities", Exoplanets)
+      extends TacCategory("exoplanet_radial_velocities", "Exoplanet Radial Velocities", Exoplanets)
   case object ExoplanetAtmospheresActivity
-      extends TacCategory("Exoplanet Atmospheres/Activity", Exoplanets)
+      extends TacCategory("exoplanet_atmospheres_activity", "Exoplanet Atmospheres/Activity", Exoplanets)
   case object ExoplanetTransits
-      extends TacCategory("Exoplanet Transits, Rossiter McLaughlin", Exoplanets)
+      extends TacCategory("exoplanet_transits", "Exoplanet Transits, Rossiter McLaughlin", Exoplanets)
   case object ExoplanetHostStar
-      extends TacCategory("Exoplanet Host Star Properties/Connections", Exoplanets)
-  case object ExoplanetOther extends TacCategory("Exoplanet Other", Exoplanets)
+      extends TacCategory("exoplanet_host_star", "Exoplanet Host Star Properties/Connections", Exoplanets)
+  case object ExoplanetOther extends TacCategory("exoplanet_other", "Exoplanet Other", Exoplanets)
 
   case object StellarAstrophysics
-      extends TacCategory("Stellar Astrophysics, Evolution, Supernovae, Abundances",
+      extends TacCategory("stellar_astrophysics", "Stellar Astrophysics, Evolution, Supernovae, Abundances",
                           GalacticLocalGroup
       )
   case object StellarPopulations
-      extends TacCategory("Stellar Populations, Clusters, Chemical Evolution", GalacticLocalGroup)
-  case object StarFormation extends TacCategory("Star Formation", GalacticLocalGroup)
+      extends TacCategory("stellar_populations", "Stellar Populations, Clusters, Chemical Evolution", GalacticLocalGroup)
+  case object StarFormation extends TacCategory("star_formation", "Star Formation", GalacticLocalGroup)
   case object GaseousAstrophysics
-      extends TacCategory("Gaseous Astrophysics, H II regions, PN, ISM, SN remnants, Novae",
+      extends TacCategory("gaseous_astrophysics", "Gaseous Astrophysics, H II regions, PN, ISM, SN remnants, Novae",
                           GalacticLocalGroup
       )
   case object StellarRemnants
-      extends TacCategory("Stellar Remnants/Compact Objects, WD, NS, BH", GalacticLocalGroup)
-  case object GalacticOther extends TacCategory("Galactic Other", GalacticLocalGroup)
+      extends TacCategory("stellar_remnants", "Stellar Remnants/Compact Objects, WD, NS, BH", GalacticLocalGroup)
+  case object GalacticOther extends TacCategory("galactic_other", "Galactic Other", GalacticLocalGroup)
 
   case object Cosmology
-      extends TacCategory("Cosmology, Fundamental Physics, Large Scale Structure", Extragalactic)
-  case object ClustersOfGalaxies extends TacCategory("Clusters/Groups of Galaxies", Extragalactic)
-  case object HighZUniverse      extends TacCategory("High-z Universe", Extragalactic)
-  case object LowZUniverse       extends TacCategory("Low-z Universe", Extragalactic)
-  case object ActiveGalaxies     extends TacCategory("Active Galaxies, Quasars, SMBH", Extragalactic)
-  case object ExtragalacticOther extends TacCategory("Extragalactic Other", Extragalactic)
+      extends TacCategory("cosmology", "Cosmology, Fundamental Physics, Large Scale Structure", Extragalactic)
+  case object ClustersOfGalaxies extends TacCategory("clusters_of_galaxies", "Clusters/Groups of Galaxies", Extragalactic)
+  case object HighZUniverse      extends TacCategory("high_z_universe", "High-z Universe", Extragalactic)
+  case object LowZUniverse       extends TacCategory("low_z_universe", "Low-z Universe", Extragalactic)
+  case object ActiveGalaxies     extends TacCategory("active_galaxies", "Active Galaxies, Quasars, SMBH", Extragalactic)
+  case object ExtragalacticOther extends TacCategory("extragalactic_other", "Extragalactic Other", Extragalactic)
 
   implicit val TacCategoryEnumerated: Enumerated[TacCategory] =
-    Enumerated.of(
+    Enumerated.from(
       SmallBodies,
       PlanetaryAtmospheres,
       PlanetarySurfaces,
@@ -86,5 +86,5 @@ object TacCategory {
       LowZUniverse,
       ActiveGalaxies,
       ExtragalacticOther
-    )
+    ).withTag(_.tag)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ToOActivation.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ToOActivation.scala
@@ -5,13 +5,13 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-sealed abstract class ToOActivation(val label: String) extends Product with Serializable
+sealed abstract class ToOActivation(val tag: String, val label: String) extends Product with Serializable
 
 object ToOActivation {
-  case object None     extends ToOActivation("None")
-  case object Standard extends ToOActivation("Standard")
-  case object Rapid    extends ToOActivation("Rapid")
+  case object None     extends ToOActivation("none", "None")
+  case object Standard extends ToOActivation("standard", "Standard")
+  case object Rapid    extends ToOActivation("rapid", "Rapid")
 
   implicit val ToOActivationEnumerated: Enumerated[ToOActivation] =
-    Enumerated.of(None, Standard, Rapid)
+    Enumerated.from(None, Standard, Rapid).withTag(_.tag)
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/WaterVapor.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/WaterVapor.scala
@@ -6,16 +6,16 @@ package lucuma.core.enums
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
-sealed abstract class WaterVapor(val label: String) extends Product with Serializable
+sealed abstract class WaterVapor(val tag: String, val label: String) extends Product with Serializable
 
 object WaterVapor {
-  case object VeryDry extends WaterVapor("Very Dry")
-  case object Dry     extends WaterVapor("Dry")
-  case object Median  extends WaterVapor("Median")
-  case object Wet     extends WaterVapor("Wet")
+  case object VeryDry extends WaterVapor("very_dry", "Very Dry")
+  case object Dry     extends WaterVapor("dry", "Dry")
+  case object Median  extends WaterVapor("median", "Median")
+  case object Wet     extends WaterVapor("wet", "Wet")
 
   implicit val WaterVaporEnumerated: Enumerated[WaterVapor] =
-    Enumerated.of(VeryDry, Dry, Median, Wet)
+    Enumerated.from(VeryDry, Dry, Median, Wet).withTag(_.tag)
 
   implicit val WatorVaporDisplay: Display[WaterVapor] =
     Display.byShortName(_.label)

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Display.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Display.scala
@@ -43,13 +43,6 @@ object Display {
       def shortName(a: A) = toShortName(a)
     }
 
-  /**
-   * Create an instance of `Display` for an `Enumerated` using its `tag` as both shortName and
-   * longName.
-   */
-  def byTag[A: Enumerated]: Display[A] =
-    Display.byShortName(Enumerated[A].tag)
-
   implicit val contravariantDisplay: Contravariant[Display] = new Contravariant[Display] {
     def contramap[A, B](fa: Display[A])(f: B => A): Display[B] =
       new Display[B] {

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Enumerated.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Enumerated.scala
@@ -55,12 +55,6 @@ object Enumerated {
 
   def apply[A](implicit ev: Enumerated[A]): ev.type = ev
 
-  def of[A <: Product](a: A, as: A*): Enumerated[A] =
-    new Enumerated[A] {
-      def all: List[A]      = a :: as.toList
-      def tag(a: A): String = a.productPrefix
-    }
-
   @inline
   def from[A](a: A, as: A*): Applied[A] = new Applied(a :: as.toList)
   def fromNEL[A](as: NonEmptyList[A]): Applied[A]   = new Applied(as.toList)


### PR DESCRIPTION
This disconnects the `tag` property of `Enumerated` instances from their `productPrefix`, and removes the ability to easily derive `Display` from tags (which should never be shown to the user). See discussion starting at https://gemini-software.slack.com/archives/GJQDX830D/p1660328710537259 