### PR TITLE
Derive Enumerated from enum.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.53"
+ThisBuild / tlBaseVersion                         := "0.54"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Enumerated.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Enumerated.scala
@@ -7,10 +7,11 @@ package util
 
 import cats.Order
 import cats.data.NonEmptyList
-import cats.syntax.all._
-import io.circe._
-import lucuma.core.syntax.string._
+import cats.syntax.all.*
+import io.circe.*
+import lucuma.core.syntax.string.*
 import monocle.Prism
+
 import scala.quoted.*
 
 /**

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Enumerated.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Enumerated.scala
@@ -11,6 +11,7 @@ import cats.syntax.all._
 import io.circe._
 import lucuma.core.syntax.string._
 import monocle.Prism
+import scala.quoted.*
 
 /**
  * Typeclass for an enumerated type with unique string tags and a canonical ordering.
@@ -70,6 +71,23 @@ object Enumerated {
   def fromTag[A](implicit ev: Enumerated[A]): Prism[String, A] =
     Prism[String, A](ev.fromTag)(e => ev.tag(e))
 
+  private def enumValuesImpl[E: Type](using Quotes): Expr[Array[E]] =
+    import quotes.reflect.*
+    val companion = Ref(TypeRepr.of[E].typeSymbol.companionModule)
+    Select.unique(companion, "values").asExprOf[Array[E]]
+
+  private def tagImpl[E](x: Expr[E])(using Quotes): Expr[String] =
+    import quotes.reflect.*
+    Select.unique(x.asTerm, "tag").asExprOf[String]
+
+  private def enumeratedImpl[E: Type](using Quotes): Expr[Enumerated[E]] =
+    '{
+      Enumerated
+        .fromNEL(NonEmptyList.fromList(${ enumValuesImpl[E] }.toList).get)
+        .withTag(x => ${ tagImpl[E]('x) })
+    }
+
+  inline def derived[E]: Enumerated[E] = ${ enumeratedImpl[E] }
 }
 
 /** @group Typeclasses */

--- a/modules/tests/shared/src/test/scala/lucuma/core/enums/EnumeratedSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enums/EnumeratedSuite.scala
@@ -10,6 +10,11 @@ import monocle.law.discipline.PrismTests
 import munit._
 
 import scala.reflect.ClassTag
+import scala.tools.nsc.doc.html.HtmlTags.Th
+
+enum Theme(val tag: String) derives Enumerated:
+   case Light extends Theme("light")
+   case Dark extends Theme("dark")
 
 final class EnumeratedSuite extends DisciplineSuite {
 
@@ -24,4 +29,16 @@ final class EnumeratedSuite extends DisciplineSuite {
   checkEnumLaws[TwilightType]
   checkEnumLaws[EventType]
   checkEnumLaws[KeywordName]
+
+  // Derivation
+  checkEnumLaws[Theme]
+  
+  test("Derived members") {
+    val derived = Enumerated[Theme]
+    val built = Enumerated.from(Theme.Light, Theme.Dark).withTag(_.tag)
+
+    assertEquals(derived.all, built.all)
+    assertEquals(derived.all.map(_.tag), built.all.map(_.tag))
+    assertEquals(derived.all.map(_.tag).map(derived.fromTag), built.all.map(_.tag).map(built.fromTag))
+  }
 }


### PR DESCRIPTION
Derives an `Enumerated` instance for `enum`s with `val tag: String`.

Example:
```scala
enum Theme(val tag: String) derives Enumerated:
   case Light extends Theme("light")
   case Dark extends Theme("dark")
```

Compilation fails if:
- Applied to something other than an `enum` (actual requirement is that `object E` must have a `values` method that returns an `Array[E]`).
- There is no ~~publicly accessible~~ `tag`, or it doesn't return a `String`.