### PR TITLE
Timestamp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.54"
+ThisBuild / tlBaseVersion                         := "0.55"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Ephemeris.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Ephemeris.scala
@@ -6,8 +6,8 @@ package lucuma.core.model
 import cats.Eq
 import cats.Foldable
 import cats.Monoid
-import cats.syntax.all._
 import cats.kernel.Order.catsKernelOrderingForOrder
+import cats.syntax.all._
 import lucuma.core.optics.SplitMono
 import lucuma.core.syntax.treemap._
 import lucuma.core.util.Timestamp

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Ephemeris.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Ephemeris.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.Foldable
 import cats.Monoid
 import cats.syntax.all._
+import cats.kernel.Order.catsKernelOrderingForOrder
 import lucuma.core.optics.SplitMono
 import lucuma.core.syntax.treemap._
 import lucuma.core.util.Timestamp

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Timestamp.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Timestamp.scala
@@ -3,125 +3,162 @@
 
 package lucuma.core.util
 
-import cats._
-import cats.syntax.all._
+import cats.Order
+import cats.syntax.either.*
+import cats.syntax.order.*
+import io.circe.Decoder
+import io.circe.Encoder
 import lucuma.core.optics.Format
+import lucuma.core.optics.SplitEpi
+import monocle.Prism
+import org.typelevel.cats.time.instances.instant.*
 
 import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter.ISO_DATE_TIME
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoField
 import java.time.temporal.ChronoUnit.MICROS
+import java.util.Locale
 
-/** Timestamp wraps a `java.util.Instant` that is truncated to microsecond
-  * resolution.  This allows Timestamps to roundtrip to/from the database
-  * where only microsecond resolution is supported.  In addition the min
-  * and max instants that are supported are determined by the postgres limit for
-  * timestamps.
-  *
-  * @param toInstant
-  */
-sealed abstract case class Timestamp(toInstant: Instant) {
+/**
+ * Timestamp is an Instant truncated and limited to fit in a database
+ * `timestamp` column.  Using a `Timestamp`, we're guaranteed to safely
+ * round-trip values through the database.
+ */
 
-  import Timestamp.{ MaxInstant, MinInstant }
-
-  // Guaranteed by construction, but verified here.
-  assert(!toInstant.isBefore(MinInstant))
-  assert(!toInstant.isAfter(MaxInstant))
-  assert((toInstant.getNano % 1000L) === 0)
-
-  /** Gets the number of seconds from the Java epoch of 1970-01-01T00:00:00Z. */
-  def epochSecond: Long =
-    toInstant.getEpochSecond
-
-  /** Gets the number of microseconds after the start of the second returned
-    * by `epochSecond`.
-    */
-  def µs: Long =
-    toInstant.getNano / 1000L
-
-  /** Converts this instant to the number of milliseconds from the epoch of
-    * 1970-01-01T00:00:00Z.
-    */
-  def toEpochMilli: Long =
-    toInstant.toEpochMilli
-
-  /** Creates an updated instance of Timestamp by applying the given
-    * function to its wrapped Instant.  The computed Instant is truncated to
-    * microsecond precision and validated.
-    */
-  private def mod(f: Instant => Instant): Option[Timestamp] =
-    Timestamp.fromInstant(f(toInstant))
-
-  def plusMillis(millisToAdd: Long): Option[Timestamp] =
-    mod(_.plusMillis(millisToAdd))
-
-  def plusMicros(microsToAdd: Long): Option[Timestamp] =
-    mod(_.plusNanos(microsToAdd * 1000))
-
-  def plusSeconds(secondsToAdd: Long): Option[Timestamp] =
-    mod(_.plusSeconds(secondsToAdd))
-
-  override def toString: String =
-    toInstant.toString
-}
+opaque type Timestamp = Instant
 
 object Timestamp {
 
-  private val MinInstant: Instant =
-    ZonedDateTime.of(-4712, 1, 1, 0, 0, 0, 0, UTC).toInstant
+  val Min: Timestamp =
+    ZonedDateTime.of( -4712, 1, 1, 0, 0, 0, 0, UTC).toInstant
 
-  private val MaxInstant: Instant =
+  val Max: Timestamp =
     ZonedDateTime.of(294275, 12, 31, 23, 59, 59, 999999000, UTC).toInstant
 
-  /** Minimum time that can be stored in a postgres timestamp. */
-  val Min: Timestamp =
-    unsafeFromInstant(MinInstant)
-
-  /** Maximum time that can be stored in a postgres timestamp. */
-  val Max: Timestamp =
-    unsafeFromInstant(MaxInstant)
-
-  /** `Instant.EPOCH` transformed to `Timestamp`. */
+  /** Instant.EPOCH transformed to Timestamp */
   val Epoch: Timestamp =
-    unsafeFromInstant(Instant.EPOCH)
+    Instant.EPOCH
 
-  /** Creates a Timestamp from the given Instant, assuring that the time
-    * value recorded has a round number of microseconds and that it is within
-    * the range supported by postgres.
-    *
-    * @group Constructors
-    */
-  def fromInstant(i: Instant): Option[Timestamp] = {
-    val iʹ = i.truncatedTo(MICROS)
-    if (iʹ.isBefore(MinInstant) || iʹ.isAfter(MaxInstant)) None
-    else Some(new Timestamp(iʹ) {})
-  }
+  /**
+   * Converts valid `Instant`s to `Timestamp`.  `Instant`s with sub-microsecond
+   * precision or that are above or beyond the range of `Timestamp` produce
+   * `None` while valid `Instant`s produce `Some` corresponding `Timestamp`.
+   */
+  def fromInstant(value: Instant): Option[Timestamp] =
+    Option.when(Min <= value && value <= Max && value.truncatedTo(MICROS) === value)(value)
 
-  /** Creates a Timestamp from the given Instant if possible, throwing an
-    * exception if the time is out of the valid range `Min` <= time <= `Max`.
-    *
-    * @group Constructors
-    */
-  def unsafeFromInstant(i: Instant): Timestamp =
-    fromInstant(i).getOrElse(sys.error(s"$i out of Timestamp range"))
+  /**
+   * Truncates any sub-microsecond precision in the given `Instant` and then
+   * attempts to get the corresponding `Timestamp`.  This will be successful
+   * for `Instants` that fall within the range `Min` to `Max` (inclusive).
+   */
+  def fromInstantTruncated(value: Instant): Option[Timestamp] =
+    fromInstant(value.truncatedTo(MICROS))
 
-  val instant: Format[Instant, Timestamp] =
-    Format[Instant, Timestamp](fromInstant, _.toInstant)
+  def unsafeFromInstant(value: Instant): Timestamp =
+    fromInstant(value).getOrElse(sys.error(s"$value out of Timestamp range or includes sub-microsecond precision"))
 
-  /** Creates a Timestamp representing the current time using milliseconds
-    * from the Java time epoch.
-    *
-    * @group Constructors
-    */
+  def unsafeFromInstantTruncated(value: Instant): Timestamp =
+    fromInstantTruncated(value).getOrElse(sys.error(s"$value out of Timestamp range"))
+
+  def fromLocalDateTime(value: LocalDateTime): Option[Timestamp] =
+    fromInstant(value.toInstant(UTC))
+
+  def unsafeFromLocalDateTime(value: LocalDateTime): Timestamp =
+    fromLocalDateTime(value).getOrElse(sys.error(s"$value out of Timestamp range or includes sub-microsecond precision"))
+
   def ofEpochMilli(epochMilli: Long): Option[Timestamp] =
     fromInstant(Instant.ofEpochMilli(epochMilli))
 
-  implicit val OrderingTimestamp: Ordering[Timestamp] =
-    Ordering.by(_.toInstant)
+  private def formatter(iso: Boolean): DateTimeFormatter = {
+    val builder =
+      new DateTimeFormatterBuilder()
+        .append(DateTimeFormatter.ISO_LOCAL_DATE)
+        .appendLiteral(if (iso) then 'T' else ' ')
+        .appendPattern("HH:mm:ss")
+        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
 
-  implicit val OrderTimestamp: Order[Timestamp] =
-    Order.fromOrdering
+    (if (iso) builder.appendLiteral('Z') else builder).toFormatter(Locale.US)
+  }
 
-  implicit val ShowTimestamp: Show[Timestamp] =
-    Show.fromToString
+  val Formatter: DateTimeFormatter =
+    formatter(iso = false)
+
+  private val IsoFormatter: DateTimeFormatter =
+    formatter(iso = true)
+
+  def parse(s: String): Either[String, Timestamp] =
+    Either
+      .catchOnly[DateTimeParseException](LocalDateTime.parse(s, Formatter).toInstant(UTC))
+      .orElse(Either.catchOnly[DateTimeParseException](LocalDateTime.parse(s, IsoFormatter).toInstant(UTC)))
+      .leftMap(_ => s"Could not parse as a Timestamp: $s")
+      .flatMap(fromInstant(_).toRight(s"Invalid Timestamp: $s"))
+
+  extension (timestamp: Timestamp) {
+
+    def format: String =
+      Formatter.format(toLocalDateTime)
+
+    def isoFormat: String =
+      IsoFormatter.format(toLocalDateTime)
+
+    def toInstant: Instant =
+      timestamp
+
+    def toLocalDateTime: LocalDateTime =
+      LocalDateTime.ofInstant(timestamp, UTC)
+
+    /** Gets the number of seconds from the Java epoch of 1970-01-01T00:00:00Z. */
+    def epochSecond: Long =
+      timestamp.getEpochSecond
+
+    /**
+     * Gets the number of microseconds after the start of the second returned
+     * by `epochSecond`.
+     */
+    def µs: Long =
+      timestamp.getNano / 1000L
+
+    /**
+     *  Converts this instant to the number of milliseconds from the epoch of
+     * 1970-01-01T00:00:00Z.
+     */
+    def toEpochMilli: Long =
+      timestamp.toEpochMilli
+
+    def plusMillisOption(millisToAdd: Long): Option[Timestamp] =
+      fromInstant(timestamp.plusMillis(millisToAdd))
+
+    def plusMicrosOption(microsToAdd: Long): Option[Timestamp] =
+      fromInstant(timestamp.plusNanos(microsToAdd * 1000))
+
+    def plusSecondsOption(secondsToAdd: Long): Option[Timestamp] =
+      fromInstant(timestamp.plusSeconds(secondsToAdd))
+  }
+
+  val FromString: Format[String, Timestamp] =
+    Format(parse(_).toOption, _.format)
+
+  val FromInstant: Prism[Instant, Timestamp] =
+    Prism(fromInstant)(toInstant)
+
+  val FromLocalDateTime: Prism[LocalDateTime, Timestamp] =
+    Prism(fromLocalDateTime)(toLocalDateTime)
+
+  given orderTimestamp: Order[Timestamp] with
+    def compare(t0: Timestamp, t1: Timestamp): Int =
+      t0.compareTo(t1)
+
+  given decoderTimestamp: Decoder[Timestamp] =
+    Decoder.decodeString.emap(parse)
+
+  given encoderTimestamp: Encoder[Timestamp] =
+    Encoder.encodeString.contramap[Timestamp](_.format)
+
 }

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbEphemeris.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbEphemeris.scala
@@ -4,6 +4,7 @@
 package lucuma.core.model
 package arb
 
+import cats.kernel.Order.catsKernelOrderingForOrder
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Offset
 import lucuma.core.math.arb.ArbCoordinates

--- a/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestamp.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestamp.scala
@@ -7,6 +7,7 @@ package arb
 import lucuma.core.arb.ArbTime
 import lucuma.core.util.Timestamp
 import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
 
 import java.time._
 
@@ -19,11 +20,24 @@ trait ArbTimestamp {
       for {
         m <- Gen.choose(0L, Duration.between(Instant.EPOCH, Timestamp.Max.toInstant).toMillis)
         u <- Gen.choose(0L, 999L)
-      } yield Timestamp.Epoch.plusMillis(m).flatMap(_.plusMicros(u)).getOrElse(Timestamp.Epoch)
+      } yield Timestamp.Epoch.plusMillisOption(m).flatMap(_.plusMicrosOption(u)).getOrElse(Timestamp.Epoch)
     }
 
   implicit val cogTimestamp: Cogen[Timestamp] =
     Cogen[Instant].contramap(_.toInstant)
+
+  val genTimestampString: Gen[String] =
+    Gen.oneOf(
+      arbitrary[Timestamp].map(_.format),
+      arbitrary[Timestamp].map(_.format).map(s => s"${s}000"),
+      arbitrary[Timestamp].map(_.isoFormat),
+      arbitrary[(Timestamp, Int, Char)].map { case (t, i, c) =>
+        val cs = t.format.toCharArray
+        val in = (i % cs.size).abs
+        cs(in) = c
+        String.valueOf(cs)
+      }
+    )
 
 }
 

--- a/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestamp.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestamp.scala
@@ -6,8 +6,8 @@ package arb
 
 import lucuma.core.arb.ArbTime
 import lucuma.core.util.Timestamp
-import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck._
 
 import java.time._
 


### PR DESCRIPTION
When I needed timestamps in `lucuma-odb` I recalled that I had produced a `Timestamp` wrapper class in the old `gem` project.  I copied it over and converted it to be an `opaque type` instead of a simple wrapper.  (I don't know if value classes were a thing at the time.) At any rate, @cquiroz subsequently pointed out that `Timestamp` was already in `lucuma-core`. Since an `opaque type` seems like a better way to handle this than a wrapper I'm bringing the `lucuma-odb` `Timestamp` over to `lucuma-core`.