### PR TITLE
Truncate rounds both ways. Round parallax on parse.

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/Parallax.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Parallax.scala
@@ -18,6 +18,8 @@ import lucuma.core.optics._
 import spire.math.Rational
 import spire.std.long._
 
+import scala.math.BigDecimal.RoundingMode
+
 /**
  * Parallax stored as microarcseconds
  * Normally parallax is expressed in milliarcseconds but simbad reports them
@@ -80,8 +82,9 @@ sealed trait ParallaxOptics {
    */
   lazy val milliarcseconds: SplitMono[Parallax, BigDecimal] =
     microarcseconds
-      .imapB(_.underlying.movePointRight(3).longValue,
-             n => new java.math.BigDecimal(n).movePointLeft(3)
+      .imapB(
+        _.setScale(3, RoundingMode.HALF_UP).underlying.movePointRight(3).longValue,
+        n => new java.math.BigDecimal(n).movePointLeft(3)
       )
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/math/validation/MathValidators.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/validation/MathValidators.scala
@@ -30,7 +30,7 @@ trait MathValidators {
       a => (a.toMicroarcseconds / 1000000.0).toString
     )
 
-  private def trucateAngle(angle: Angle): Angle =
+  private def truncateAngle(angle: Angle): Angle =
     Angle.fromBigDecimalDegrees(
       (angle.toBigDecimalDegrees * 100)
         .setScale(0, scala.math.BigDecimal.RoundingMode.HALF_UP) / 100 + 0.0
@@ -40,17 +40,17 @@ trait MathValidators {
     InputValidWedge(
       _.toBigDecimalOption
         .map(Angle.fromBigDecimalDegrees)
-        .map(trucateAngle)
+        .map(truncateAngle)
         .toRight("Invalid Angle")
         .toEitherErrorsUnsafe,
-      a => f"${a.toBigDecimalDegrees}%.2f".replace("360.00", "0.00")
+      a => f"${truncateAngle(a).toBigDecimalDegrees}%.2f".replace("360.00", "0.00")
     )
 
   val truncatedAngleSignedDegrees: InputValidWedge[Angle] =
     InputValidWedge(
       truncatedAngleDegrees.getValid,
       a =>
-        f"${a.toSignedBigDecimalDegrees}%.2f"
+        f"${truncateAngle(a).toSignedBigDecimalDegrees}%.2f"
           .replace("-0.00", "0.00")
           .replace("180.00", "-180.00")
     )
@@ -73,7 +73,7 @@ trait MathValidators {
   val truncatedRA: InputValidWedge[RightAscension] =
     InputValidWedge(
       rightAscension.getValid.andThen(_.map(truncateRA)),
-      ra => RightAscension.fromStringHMS.reverseGet(ra).dropRight(3)
+      ra => RightAscension.fromStringHMS.reverseGet(truncateRA(ra)).dropRight(3)
     )
 
   val declination: InputValidSplitEpi[Declination] =
@@ -96,7 +96,7 @@ trait MathValidators {
       declination.getValid.andThen(_.map(truncateDec)),
       dec =>
         Declination.fromStringSignedDMS
-          .reverseGet(dec)
+          .reverseGet(truncateDec(dec))
           .dropRight(4)
           .replace("-00:00:00.00", "+00:00:00.00")
     )

--- a/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidWedge.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidWedge.scala
@@ -14,6 +14,8 @@ import lucuma.refined._
 import monocle.Iso
 import monocle.Prism
 
+import scala.math.BigDecimal.RoundingMode
+
 /**
  * Convenience version of `ValidWedge` when the error type is `NonEmptyChain[NonEmptyString]` and
  * `T` is `String`.
@@ -70,10 +72,10 @@ object InputValidWedge {
   def truncatedBigDecimal(decimals: DigitCount): InputValidWedge[BigDecimal] =
     InputValidWedge(
       InputValidSplitEpi.bigDecimal.getValid
-        .andThen(_.map(_.setScale(decimals.value, scala.math.BigDecimal.RoundingMode.HALF_UP))),
-      bd =>
-        s"%.${decimals.value}f"
-          .format(bd)
+        .andThen(_.map(_.setScale(decimals.value, RoundingMode.HALF_UP))),
+        _.setScale(decimals.value, RoundingMode.HALF_UP)
+          .underlying
+          .toPlainString
           .replaceAll("^-0\\.(0+)$", "0.$1") // Remove negative 0
     )
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/validation/InputValidSplitEpiInstancesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/validation/InputValidSplitEpiInstancesSuite.scala
@@ -3,33 +3,14 @@
 
 package lucuma.core.validation
 
-import eu.timepit.refined.cats._
-import eu.timepit.refined.scalacheck.all._
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.scalacheck.all.*
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.optics.laws.discipline.ValidSplitEpiTests
 import munit.DisciplineSuite
 import org.scalacheck.Arbitrary
 
-final class InputValidSplitEpiInstancesSuite extends DisciplineSuite {
-
-  // The scientific notation formatters use `java.text.DecimalFormat` which in Scala.js seems
-  // to have trouble formatting BigDecimals with very high absolute scale or precision.
-  // We therefore use these bounded arbitraries.
-  implicit lazy val arbBigDecimalLimitedPrecision: Arbitrary[BigDecimal] =
-    Arbitrary(
-      org.scalacheck.Arbitrary.arbBigDecimal.arbitrary.suchThat(x =>
-        x.scale.abs < 100 && x.precision <= 15
-      )
-    )
-
-  implicit lazy val arbPosBigDecimalLimitedPrecision: Arbitrary[PosBigDecimal] =
-    Arbitrary(
-      arbBigDecimalLimitedPrecision.arbitrary
-        .map(_.abs)
-        .suchThat(_ > 0)
-        .map(PosBigDecimal.unsafeFrom)
-    )
-
+final class InputValidSplitEpiInstancesSuite extends DisciplineSuite with LimitedBigDecimals:
   // Laws
   checkAll("nonEmptyString", ValidSplitEpiTests(InputValidSplitEpi.nonEmptyString).validSplitEpi)
   checkAll("int", ValidSplitEpiTests(InputValidSplitEpi.int).validSplitEpi)
@@ -44,4 +25,3 @@ final class InputValidSplitEpiInstancesSuite extends DisciplineSuite {
     "posBigDecimalWithScientificNotation",
     ValidSplitEpiTests(InputValidSplitEpi.posBigDecimalWithScientificNotation).validSplitEpi
   )
-}

--- a/modules/tests/shared/src/test/scala/lucuma/core/validation/InputValidWedgeInstancesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/validation/InputValidWedgeInstancesSuite.scala
@@ -3,18 +3,16 @@
 
 package lucuma.core.validation
 
-import eu.timepit.refined.auto._
-import eu.timepit.refined.cats._
-import lucuma.core.math.arb.ArbRefined
+import eu.timepit.refined.auto.*
+import eu.timepit.refined.cats.*
+import lucuma.core.math.arb.ArbRefined.*
 import lucuma.core.optics.laws.discipline.ValidWedgeTests
-import lucuma.refined._
+import lucuma.refined.*
 import munit.DisciplineSuite
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 
-final class InputValidWedgeInstancesSuite extends DisciplineSuite {
-  import ArbRefined._
-
+final class InputValidWedgeInstancesSuite extends DisciplineSuite:
   val genNumericString: Gen[String]      = arbitrary[BigDecimal].map(_.toString)
   val genMaybeNumericString: Gen[String] =
     Gen.frequency(5 -> genNumericString, 1 -> arbitrary[String])
@@ -28,5 +26,3 @@ final class InputValidWedgeInstancesSuite extends DisciplineSuite {
     "truncatedPosBigDecimal(2)",
     ValidWedgeTests(InputValidWedge.truncatedPosBigDecimal(2.refined)).validWedgeWith(genMaybeNumericString)
   )
-
-}

--- a/modules/tests/shared/src/test/scala/lucuma/core/validation/package.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/validation/package.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.validation
+
+import eu.timepit.refined.types.numeric.PosBigDecimal
+import org.scalacheck.Arbitrary
+
+trait LimitedBigDecimals:
+  // The scientific notation formatters use `java.text.DecimalFormat` which in Scala.js seems
+  // to have trouble formatting BigDecimals with very high absolute scale or precision.
+  // We therefore use these bounded arbitraries.
+  implicit lazy val arbBigDecimalLimitedPrecision: Arbitrary[BigDecimal] =
+    Arbitrary(
+      org.scalacheck.Arbitrary.arbBigDecimal.arbitrary.suchThat(x =>
+        x.scale.abs < 100 && x.precision <= 15
+      )
+    )
+
+  implicit lazy val arbPosBigDecimalLimitedPrecision: Arbitrary[PosBigDecimal] =
+    Arbitrary(
+      arbBigDecimalLimitedPrecision.arbitrary
+        .map(_.abs)
+        .suchThat(_ > 0)
+        .map(PosBigDecimal.unsafeFrom)
+    )


### PR DESCRIPTION
- Make truncating validators round both ways (when parsing and when formatting).
- Parallax parser now rounds.