### PR TITLE
Add Display to Gid

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/util/Gid.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Gid.scala
@@ -51,6 +51,7 @@ final class Gid[A](
 ) extends BoundedEnumerable[A]
     with Order[A]
     with Show[A]
+    with Display[A]
     with Encoder[A]
     with Decoder[A] {
 
@@ -109,6 +110,10 @@ final class Gid[A](
 
   // Show
   final override def show(a: A): String =
+    fromString.reverseGet(a)
+
+  // Display
+  final override def shortName(a: A): String = 
     fromString.reverseGet(a)
 
   // Decoder


### PR DESCRIPTION
`Gid` now acts as a `Display` instance.

This was omitted from `Uid` on purpose: I'm not sure we ever want to show a `UUID` to users in a UI. However, showing `Gid`s is fairly common.