### PR TITLE
Time brightness

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.55"
+ThisBuild / tlBaseVersion                         := "0.56"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BrightnessUnits.scala
@@ -6,9 +6,11 @@ package core
 package math
 
 import cats.data.NonEmptyList
+import cats.data.NonEmptyMap
 import lucuma.core.math.dimensional._
 import lucuma.core.math.units._
 import lucuma.core.util.Enumerated
+import lucuma.core.util.Timestamp
 
 object BrightnessUnits {
   type Integrated
@@ -19,6 +21,7 @@ object BrightnessUnits {
   trait FluxDensityContinuum[+T]
 
   type BrightnessMeasure[T] = Measure[BigDecimal] Of Brightness[T]
+  type BrightnessMeasureOverTime[T] = NonEmptyMap[Timestamp, Measure[BigDecimal] Of Brightness[T]]
 
   // Brightness Integrated
   implicit object VegaMagnitudeIsIntegratedBrightnessUnit

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SourceProfile.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SourceProfile.scala
@@ -209,27 +209,27 @@ object SourceProfile {
 
   /** @group Optics */
   val integratedBrightnesses
-    : Optional[SourceProfile, SortedMap[Band, BrightnessMeasure[Integrated]]] =
+    : Optional[SourceProfile, SortedMap[Band, BrightnessMeasureOverTime[Integrated]]] =
     integratedSpectralDefinition.andThen(SpectralDefinition.brightnesses[Integrated])
 
   /** @group Optics */
-  val surfaceBrightnesses: Optional[SourceProfile, SortedMap[Band, BrightnessMeasure[Surface]]] =
+  val surfaceBrightnesses: Optional[SourceProfile, SortedMap[Band, BrightnessMeasureOverTime[Surface]]] =
     surfaceSpectralDefinition.andThen(SpectralDefinition.brightnesses[Surface])
 
   /** @group Optics */
-  val integratedBrightnessesT: Traversal[SourceProfile, BrightnessMeasure[Integrated]] =
+  val integratedBrightnessesT: Traversal[SourceProfile, BrightnessMeasureOverTime[Integrated]] =
     integratedSpectralDefinition.andThen(SpectralDefinition.brightnessesT[Integrated])
 
   /** @group Optics */
-  val surfaceBrightnessesT: Traversal[SourceProfile, BrightnessMeasure[Surface]] =
+  val surfaceBrightnessesT: Traversal[SourceProfile, BrightnessMeasureOverTime[Surface]] =
     surfaceSpectralDefinition.andThen(SpectralDefinition.brightnessesT[Surface])
 
   /** @group Optics */
-  def integratedBrightnessIn[T](b: Band): Traversal[SourceProfile, BrightnessMeasure[Integrated]] =
+  def integratedBrightnessIn[T](b: Band): Traversal[SourceProfile, BrightnessMeasureOverTime[Integrated]] =
     integratedSpectralDefinition.andThen(SpectralDefinition.brightnessIn[Integrated](b))
 
   /** @group Optics */
-  def surfaceBrightnessIn[T](b: Band): Traversal[SourceProfile, BrightnessMeasure[Surface]] =
+  def surfaceBrightnessIn[T](b: Band): Traversal[SourceProfile, BrightnessMeasureOverTime[Surface]] =
     surfaceSpectralDefinition.andThen(SpectralDefinition.brightnessIn[Surface](b))
 
   /** @group Optics */

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SpectralDefinition.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SpectralDefinition.scala
@@ -44,7 +44,7 @@ object SpectralDefinition {
 
   final case class BandNormalized[T](
     sed:          UnnormalizedSED,
-    brightnesses: SortedMap[Band, BrightnessMeasure[T]]
+    brightnesses: SortedMap[Band, BrightnessMeasureOverTime[T]]
   ) extends SpectralDefinition[T] {
     lazy val bands: List[Band] = brightnesses.keys.toList
 
@@ -59,7 +59,7 @@ object SpectralDefinition {
     ): BandNormalized[T0] =
       BandNormalized(
         sed,
-        brightnesses.map { case (band, brightness) => band -> brightness.toTag[Brightness[T0]] }
+        brightnesses.map { case (band, brightnesses) => band -> brightnesses.map(_.toTag[Brightness[T0]]) }
       )
   }
 
@@ -74,15 +74,15 @@ object SpectralDefinition {
       Focus[BandNormalized[T]](_.sed)
 
     /** @group Optics */
-    def brightnesses[T]: Lens[BandNormalized[T], SortedMap[Band, BrightnessMeasure[T]]] =
+    def brightnesses[T]: Lens[BandNormalized[T], SortedMap[Band, BrightnessMeasureOverTime[T]]] =
       Focus[BandNormalized[T]](_.brightnesses)
 
     /** @group Optics */
-    def brightnessesT[T]: Traversal[BandNormalized[T], BrightnessMeasure[T]] =
+    def brightnessesT[T]: Traversal[BandNormalized[T], BrightnessMeasureOverTime[T]] =
       brightnesses.each
 
     /** @group Optics */
-    def brightnessIn[T](b: Band): Traversal[BandNormalized[T], BrightnessMeasure[T]] =
+    def brightnessIn[T](b: Band): Traversal[BandNormalized[T], BrightnessMeasureOverTime[T]] =
       brightnesses.filterIndex((a: Band) => a === b)
   }
 
@@ -152,15 +152,15 @@ object SpectralDefinition {
     bandNormalized.andThen(BandNormalized.sed[T])
 
   /** @group Optics */
-  def brightnesses[T]: Optional[SpectralDefinition[T], SortedMap[Band, BrightnessMeasure[T]]] =
+  def brightnesses[T]: Optional[SpectralDefinition[T], SortedMap[Band, BrightnessMeasureOverTime[T]]] =
     bandNormalized.andThen(BandNormalized.brightnesses[T])
 
   /** @group Optics */
-  def brightnessesT[T]: Traversal[SpectralDefinition[T], BrightnessMeasure[T]] =
+  def brightnessesT[T]: Traversal[SpectralDefinition[T], BrightnessMeasureOverTime[T]] =
     bandNormalized.andThen(BandNormalized.brightnessesT[T])
 
   /** @group Optics */
-  def brightnessIn[T](b: Band): Traversal[SpectralDefinition[T], BrightnessMeasure[T]] =
+  def brightnessIn[T](b: Band): Traversal[SpectralDefinition[T], BrightnessMeasureOverTime[T]] =
     bandNormalized.andThen(BandNormalized.brightnessIn[T](b))
 
   /** @group Optics */

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -208,29 +208,29 @@ object Target extends WithGid('t'.refined) with TargetOptics {
       sourceProfile.andThen(SourceProfile.unnormalizedSED)
 
     /** @group Optics */
-    val integratedBrightnesses: Optional[Sidereal, SortedMap[Band, BrightnessMeasure[Integrated]]] =
+    val integratedBrightnesses: Optional[Sidereal, SortedMap[Band, BrightnessMeasureOverTime[Integrated]]] =
       sourceProfile.andThen(SourceProfile.integratedBrightnesses)
 
     /** @group Optics */
-    val surfaceBrightnesses: Optional[Sidereal, SortedMap[Band, BrightnessMeasure[Surface]]] =
+    val surfaceBrightnesses: Optional[Sidereal, SortedMap[Band, BrightnessMeasureOverTime[Surface]]] =
       sourceProfile.andThen(SourceProfile.surfaceBrightnesses)
 
     /** @group Optics */
-    val integratedBrightnessesT: Traversal[Sidereal, BrightnessMeasure[Integrated]] =
+    val integratedBrightnessesT: Traversal[Sidereal, BrightnessMeasureOverTime[Integrated]] =
       sourceProfile.andThen(SourceProfile.integratedBrightnessesT)
 
     /** @group Optics */
-    val surfaceBrightnessesT: Traversal[Sidereal, BrightnessMeasure[Surface]] =
+    val surfaceBrightnessesT: Traversal[Sidereal, BrightnessMeasureOverTime[Surface]] =
       sourceProfile.andThen(SourceProfile.surfaceBrightnessesT)
 
     /** @group Optics */
     def integratedBrightnessIn[T](
       b: Band
-    ): Traversal[Sidereal, BrightnessMeasure[Integrated]] =
+    ): Traversal[Sidereal, BrightnessMeasureOverTime[Integrated]] =
       sourceProfile.andThen(SourceProfile.integratedBrightnessIn(b))
 
     /** @group Optics */
-    def surfaceBrightnessIn[T](b: Band): Traversal[Sidereal, BrightnessMeasure[Surface]] =
+    def surfaceBrightnessIn[T](b: Band): Traversal[Sidereal, BrightnessMeasureOverTime[Surface]] =
       sourceProfile.andThen(SourceProfile.surfaceBrightnessIn(b))
 
     /** @group Optics */
@@ -328,29 +328,29 @@ object Target extends WithGid('t'.refined) with TargetOptics {
 
     /** @group Optics */
     val integratedBrightnesses
-      : Optional[Nonsidereal, SortedMap[Band, BrightnessMeasure[Integrated]]] =
+      : Optional[Nonsidereal, SortedMap[Band, BrightnessMeasureOverTime[Integrated]]] =
       sourceProfile.andThen(SourceProfile.integratedBrightnesses)
 
     /** @group Optics */
-    val surfaceBrightnesses: Optional[Nonsidereal, SortedMap[Band, BrightnessMeasure[Surface]]] =
+    val surfaceBrightnesses: Optional[Nonsidereal, SortedMap[Band, BrightnessMeasureOverTime[Surface]]] =
       sourceProfile.andThen(SourceProfile.surfaceBrightnesses)
 
     /** @group Optics */
-    val integratedBrightnessesT: Traversal[Nonsidereal, BrightnessMeasure[Integrated]] =
+    val integratedBrightnessesT: Traversal[Nonsidereal, BrightnessMeasureOverTime[Integrated]] =
       sourceProfile.andThen(SourceProfile.integratedBrightnessesT)
 
     /** @group Optics */
-    val surfaceBrightnessesT: Traversal[Nonsidereal, BrightnessMeasure[Surface]] =
+    val surfaceBrightnessesT: Traversal[Nonsidereal, BrightnessMeasureOverTime[Surface]] =
       sourceProfile.andThen(SourceProfile.surfaceBrightnessesT)
 
     /** @group Optics */
     def integratedBrightnessIn[T](
       b: Band
-    ): Traversal[Nonsidereal, BrightnessMeasure[Integrated]] =
+    ): Traversal[Nonsidereal, BrightnessMeasureOverTime[Integrated]] =
       sourceProfile.andThen(SourceProfile.integratedBrightnessIn(b))
 
     /** @group Optics */
-    def surfaceBrightnessIn[T](b: Band): Traversal[Nonsidereal, BrightnessMeasure[Surface]] =
+    def surfaceBrightnessIn[T](b: Band): Traversal[Nonsidereal, BrightnessMeasureOverTime[Surface]] =
       sourceProfile.andThen(SourceProfile.surfaceBrightnessIn(b))
 
     /** @group Optics */
@@ -462,29 +462,29 @@ trait TargetOptics { this: Target.type =>
     sourceProfile.andThen(SourceProfile.unnormalizedSED)
 
   /** @group Optics */
-  val integratedBrightnesses: Optional[Target, SortedMap[Band, BrightnessMeasure[Integrated]]] =
+  val integratedBrightnesses: Optional[Target, SortedMap[Band, BrightnessMeasureOverTime[Integrated]]] =
     sourceProfile.andThen(SourceProfile.integratedBrightnesses)
 
   /** @group Optics */
-  val surfaceBrightnesses: Optional[Target, SortedMap[Band, BrightnessMeasure[Surface]]] =
+  val surfaceBrightnesses: Optional[Target, SortedMap[Band, BrightnessMeasureOverTime[Surface]]] =
     sourceProfile.andThen(SourceProfile.surfaceBrightnesses)
 
   /** @group Optics */
-  val integratedBrightnessesT: Traversal[Target, BrightnessMeasure[Integrated]] =
+  val integratedBrightnessesT: Traversal[Target, BrightnessMeasureOverTime[Integrated]] =
     sourceProfile.andThen(SourceProfile.integratedBrightnessesT)
 
   /** @group Optics */
-  val surfaceBrightnessesT: Traversal[Target, BrightnessMeasure[Surface]] =
+  val surfaceBrightnessesT: Traversal[Target, BrightnessMeasureOverTime[Surface]] =
     sourceProfile.andThen(SourceProfile.surfaceBrightnessesT)
 
   /** @group Optics */
   def integratedBrightnessIn[T](
     b: Band
-  ): Traversal[Target, BrightnessMeasure[Integrated]] =
+  ): Traversal[Target, BrightnessMeasureOverTime[Integrated]] =
     sourceProfile.andThen(SourceProfile.integratedBrightnessIn(b))
 
   /** @group Optics */
-  def surfaceBrightnessIn[T](b: Band): Traversal[Target, BrightnessMeasure[Surface]] =
+  def surfaceBrightnessIn[T](b: Band): Traversal[Target, BrightnessMeasureOverTime[Surface]] =
     sourceProfile.andThen(SourceProfile.surfaceBrightnessIn(b))
 
   /** @group Optics */

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbEmissionLine.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbEmissionLine.scala
@@ -4,9 +4,9 @@
 package lucuma.core.model.arb
 
 import cats.Order._
+import cats.laws.discipline.arbitrary.*
 import coulomb.*
 import coulomb.syntax.*
-import cats.laws.discipline.arbitrary.*
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.math.BrightnessUnits
 import lucuma.core.math.arb.ArbRefined

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSpectralDefinition.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSpectralDefinition.scala
@@ -37,7 +37,7 @@ trait ArbSpectralDefinition {
   import ArbWavelength._
   import ArbTimestamp._
 
-  implicit def cogBrightnessMeasureOverTime[K: Cogen: Ordering, V: Cogen]: Cogen[NonEmptyMap[K, V]] =
+  implicit def cogNonEmptyMap[K: Cogen: Ordering, V: Cogen]: Cogen[NonEmptyMap[K, V]] =
     Cogen[Map[K, V]].contramap(_.toSortedMap.toMap)
 
   implicit def arbBandNormalizedSpectralDefinition[T](implicit

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSpectralDefinition.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSpectralDefinition.scala
@@ -4,9 +4,9 @@
 package lucuma.core.model.arb
 
 import cats.Order._
-import cats.syntax.all._
 import cats.data.NonEmptyMap
 import cats.laws.discipline.arbitrary.*
+import cats.syntax.all._
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.enums.Band
 import lucuma.core.math.BrightnessUnits
@@ -20,8 +20,8 @@ import lucuma.core.model.SpectralDefinition
 import lucuma.core.model.UnnormalizedSED
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.arb.ArbTimestamp
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
 
 import scala.collection.immutable.SortedMap

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/EmissionLineSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/EmissionLineSuite.scala
@@ -3,7 +3,9 @@
 
 package lucuma.core.model
 
+import cats.data.NonEmptyMap
 import cats.implicits._
+import cats.laws.discipline.arbitrary.*
 import cats.kernel.laws.discipline._
 import coulomb.*
 import coulomb.ops.algebra.cats.all.given
@@ -14,27 +16,32 @@ import lucuma.core.math.arb._
 import lucuma.core.math.dimensional.arb.ArbMeasure
 import lucuma.core.math.units._
 import lucuma.core.model.arb.ArbEmissionLine
+import lucuma.core.model.arb.ArbSpectralDefinition
 import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.arb.ArbTimestamp
+import lucuma.core.util.Timestamp
 import monocle.law.discipline.LensTests
 import munit._
 
 final class EmissionLineSuite extends DisciplineSuite {
   import ArbEnumerated._
+  import ArbTimestamp._
   import ArbEmissionLine._
   import ArbRefined._
   import ArbMeasure._
+  import ArbSpectralDefinition.*
   import ArbQuantity.given
 
   // Brightness type conversions
   val e1Integrated: EmissionLine[Integrated] =
     EmissionLine(
       PosBigDecimalOne.withUnit[KilometersPerSecond],
-      WattsPerMeter2IsIntegratedLineFluxUnit.unit.withValueTagged(PosBigDecimalOne)
+      NonEmptyMap.of(Timestamp.Min -> WattsPerMeter2IsIntegratedLineFluxUnit.unit.withValueTagged(PosBigDecimalOne))
     )
   val e1Surface: EmissionLine[Surface]       =
     EmissionLine(
       PosBigDecimalOne.withUnit[KilometersPerSecond],
-      WattsPerMeter2Arcsec2IsSurfaceLineFluxUnit.unit.withValueTagged(PosBigDecimalOne)
+      NonEmptyMap.of(Timestamp.Min -> WattsPerMeter2Arcsec2IsSurfaceLineFluxUnit.unit.withValueTagged(PosBigDecimalOne))
     )
   test("Brightness type conversion Integrated -> Surface") {
     assertEquals(e1Integrated.to[Surface], e1Surface)

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/EmissionLineSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/EmissionLineSuite.scala
@@ -5,8 +5,8 @@ package lucuma.core.model
 
 import cats.data.NonEmptyMap
 import cats.implicits._
-import cats.laws.discipline.arbitrary.*
 import cats.kernel.laws.discipline._
+import cats.laws.discipline.arbitrary.*
 import coulomb.*
 import coulomb.ops.algebra.cats.all.given
 import coulomb.syntax.*
@@ -17,9 +17,9 @@ import lucuma.core.math.dimensional.arb.ArbMeasure
 import lucuma.core.math.units._
 import lucuma.core.model.arb.ArbEmissionLine
 import lucuma.core.model.arb.ArbSpectralDefinition
+import lucuma.core.util.Timestamp
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.arb.ArbTimestamp
-import lucuma.core.util.Timestamp
 import monocle.law.discipline.LensTests
 import munit._
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
@@ -21,10 +21,10 @@ import lucuma.core.math.arb.ArbWavelength
 import lucuma.core.math.dimensional.arb.ArbMeasure
 import lucuma.core.math.units._
 import lucuma.core.model.arb._
+import lucuma.core.util.Timestamp
 import lucuma.core.util.arb.ArbCollection
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.arb.ArbTimestamp
-import lucuma.core.util.Timestamp
 import monocle.law.discipline._
 import munit._
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
@@ -4,7 +4,9 @@
 package lucuma.core.model
 
 import cats.Order._
+import cats.data.NonEmptyMap
 import cats.kernel.laws.discipline._
+import cats.laws.discipline.arbitrary.*
 import coulomb.*
 import coulomb.syntax.*
 import eu.timepit.refined.cats._
@@ -21,6 +23,8 @@ import lucuma.core.math.units._
 import lucuma.core.model.arb._
 import lucuma.core.util.arb.ArbCollection
 import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.arb.ArbTimestamp
+import lucuma.core.util.Timestamp
 import monocle.law.discipline._
 import munit._
 
@@ -30,6 +34,7 @@ final class SourceProfileSuite extends DisciplineSuite {
   import ArbAngle._
   import ArbEmissionLine._
   import ArbEnumerated._
+  import ArbTimestamp._
   import ArbMeasure._
   import ArbRefined._
   import ArbSourceProfile._
@@ -43,7 +48,7 @@ final class SourceProfileSuite extends DisciplineSuite {
     SpectralDefinition.BandNormalized(
       UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
       SortedMap(
-        Band.R -> Band.R.defaultUnits[Integrated].withValueTagged(BigDecimal(10.0))
+        Band.R -> NonEmptyMap.of(Timestamp.Min -> Band.R.defaultUnits[Integrated].withValueTagged(BigDecimal(10.0)))
       )
     )
 
@@ -51,7 +56,7 @@ final class SourceProfileSuite extends DisciplineSuite {
     SpectralDefinition.BandNormalized(
       UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
       SortedMap(
-        Band.R -> Band.R.defaultUnits[Surface].withValueTagged(BigDecimal(10.0))
+        Band.R -> NonEmptyMap.of(Timestamp.Min -> Band.R.defaultUnits[Surface].withValueTagged(BigDecimal(10.0)))
       )
     )
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
@@ -65,7 +65,7 @@ final class SourceProfileSuite extends DisciplineSuite {
       SortedMap(
         Wavelength.Min -> EmissionLine(
           PosBigDecimalOne.withUnit[KilometersPerSecond],
-          WattsPerMeter2IsIntegratedLineFluxUnit.unit.withValueTagged(PosBigDecimalOne)
+          NonEmptyMap.of(Timestamp.Min -> WattsPerMeter2IsIntegratedLineFluxUnit.unit.withValueTagged(PosBigDecimalOne))
         )
       ),
       WattsPerMeter2MicrometerIsIntegratedFluxDensityContinuumUnit.unit
@@ -77,7 +77,7 @@ final class SourceProfileSuite extends DisciplineSuite {
       SortedMap(
         Wavelength.Min -> EmissionLine(
           PosBigDecimalOne.withUnit[KilometersPerSecond],
-          WattsPerMeter2Arcsec2IsSurfaceLineFluxUnit.unit.withValueTagged(PosBigDecimalOne)
+          NonEmptyMap.of(Timestamp.Min -> WattsPerMeter2Arcsec2IsSurfaceLineFluxUnit.unit.withValueTagged(PosBigDecimalOne))
         )
       ),
       WattsPerMeter2MicrometerArcsec2IsSurfaceFluxDensityContinuumUnit.unit

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
@@ -62,7 +62,7 @@ final class SpectralDefinitionSuite extends DisciplineSuite {
       SortedMap(
         Wavelength.Min -> EmissionLine(
           PosBigDecimalOne.withUnit[KilometersPerSecond],
-          ErgsPerSecondCentimeter2IsIntegratedLineFluxUnit.unit.withValueTagged(PosBigDecimalOne)
+          NonEmptyMap.of(Timestamp.Min -> ErgsPerSecondCentimeter2IsIntegratedLineFluxUnit.unit.withValueTagged(PosBigDecimalOne))
         )
       ),
       WattsPerMeter2MicrometerIsIntegratedFluxDensityContinuumUnit.unit.withValueTagged(
@@ -75,9 +75,8 @@ final class SpectralDefinitionSuite extends DisciplineSuite {
       SortedMap(
         Wavelength.Min -> EmissionLine(
           PosBigDecimalOne.withUnit[KilometersPerSecond],
-          ErgsPerSecondCentimeter2Arcsec2IsSurfaceLineFluxUnit.unit.withValueTagged(
-            PosBigDecimalOne
-          )
+          NonEmptyMap.of(Timestamp.Min ->
+            ErgsPerSecondCentimeter2Arcsec2IsSurfaceLineFluxUnit.unit.withValueTagged(PosBigDecimalOne))
         )
       ),
       WattsPerMeter2MicrometerArcsec2IsSurfaceFluxDensityContinuumUnit.unit.withValueTagged(

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
@@ -19,10 +19,10 @@ import lucuma.core.math.arb.ArbWavelength
 import lucuma.core.math.dimensional.arb.ArbMeasure
 import lucuma.core.math.units._
 import lucuma.core.model.arb._
+import lucuma.core.util.Timestamp
 import lucuma.core.util.arb.ArbCollection
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.arb.ArbTimestamp
-import lucuma.core.util.Timestamp
 import monocle.law.discipline._
 import munit._
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
@@ -4,7 +4,9 @@
 package lucuma.core.model
 
 import cats.Order._
+import cats.data.NonEmptyMap
 import cats.kernel.laws.discipline._
+import cats.laws.discipline.arbitrary.*
 import coulomb.*
 import coulomb.syntax.*
 import eu.timepit.refined.cats._
@@ -19,6 +21,8 @@ import lucuma.core.math.units._
 import lucuma.core.model.arb._
 import lucuma.core.util.arb.ArbCollection
 import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.arb.ArbTimestamp
+import lucuma.core.util.Timestamp
 import monocle.law.discipline._
 import munit._
 
@@ -27,6 +31,7 @@ import scala.collection.immutable.SortedMap
 final class SpectralDefinitionSuite extends DisciplineSuite {
   import ArbUnnormalizedSED._
   import ArbEnumerated._
+  import ArbTimestamp._
   import BrightnessUnits._
   import ArbSpectralDefinition._
   import ArbRefined._
@@ -40,7 +45,7 @@ final class SpectralDefinitionSuite extends DisciplineSuite {
     SpectralDefinition.BandNormalized(
       UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
       SortedMap(
-        Band.R -> Band.R.defaultUnits[Integrated].withValueTagged(BigDecimal(10.0))
+        Band.R -> NonEmptyMap.of(Timestamp.Min -> Band.R.defaultUnits[Integrated].withValueTagged(BigDecimal(10.0)))
       )
     )
 
@@ -48,7 +53,7 @@ final class SpectralDefinitionSuite extends DisciplineSuite {
     SpectralDefinition.BandNormalized(
       UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
       SortedMap(
-        Band.R -> Band.R.defaultUnits[Surface].withValueTagged(BigDecimal(10.0))
+        Band.R -> NonEmptyMap.of(Timestamp.Min -> Band.R.defaultUnits[Surface].withValueTagged(BigDecimal(10.0)))
       )
     )
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -4,7 +4,9 @@
 package lucuma.core.model
 
 import cats.Order._
+import cats.data.NonEmptyMap
 import cats.kernel.laws.discipline._
+import cats.laws.discipline.arbitrary.*
 import eu.timepit.refined.cats._
 import eu.timepit.refined.scalacheck.string._
 import lucuma.core.arb._
@@ -25,6 +27,7 @@ final class TargetSuite extends DisciplineSuite {
   import ArbEphemerisKey._
   import ArbParallax._
   import ArbEnumerated._
+  import ArbTimestamp._
   import ArbCoordinates._
   import ArbRightAscension._
   import ArbDeclination._


### PR DESCRIPTION
This is a proposal for adding a time dimension to Magnitudes
Basically it replaces measurement values with `NonEmptyMap[Timestamp, BrightnessMeasure[T]]`

`NonEmptyMap` is backed by a `SortedMap` thus we'd keep the entries in order and we need at least one, signalling the common case where the value is constant

There are a few things missing, like interpolation of values and lenses but wanted to request a first impression on the impact of this change.