### PR TITLE
Unify tracking methods for Sidereal and Nonsidereal targets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.55"
+ThisBuild / tlBaseVersion                         := "0.56"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/benchmarks/src/main/scala/lucuma/core/ProperMotionBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/lucuma/core/ProperMotionBenchmark.scala
@@ -26,7 +26,7 @@ class ProperMotionBenchmark {
     Some(Parallax.fromMicroarcseconds(10000000L))
   )
 
-  val instant = Instant.now()
+  val instant: Instant = Instant.now()
 
   @Benchmark
   def simpleRun: Unit = {

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
@@ -51,8 +51,8 @@ final case class SiderealTracking(
   parallax:        Option[Parallax]
 ) {
 
-  def at(i: Timestamp): Option[Coordinates] =
-    plusYears(epoch.untilInstant(i.toInstant))
+  def at(i: Instant): Option[Coordinates] =
+    plusYears(epoch.untilInstant(i))
 
   /** Coordinates `elapsedYears` fractional epoch-years after `epoch`. */
   def plusYears(elapsedYears: Double): Option[Coordinates] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SiderealTracking.scala
@@ -7,6 +7,7 @@ import cats._
 import cats.syntax.all._
 import coulomb.policy.spire.standard.given
 import lucuma.core.math._
+import lucuma.core.util.Timestamp
 import monocle.Focus
 import monocle.Lens
 
@@ -50,8 +51,8 @@ final case class SiderealTracking(
   parallax:        Option[Parallax]
 ) {
 
-  def at(i: Instant): Option[Coordinates] =
-    plusYears(epoch.untilInstant(i))
+  def at(i: Timestamp): Option[Coordinates] =
+    plusYears(epoch.untilInstant(i.toInstant))
 
   /** Coordinates `elapsedYears` fractional epoch-years after `epoch`. */
   def plusYears(elapsedYears: Double): Option[Coordinates] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -41,6 +41,7 @@ object Target extends WithGid('t'.refined) with TargetOptics {
     catalogInfo:   Option[CatalogInfo]
   ) extends Target {
     def at(i: Instant) = tracking.at(i).map(SiderealCoordinates.apply)
+    def atEpoch = SiderealCoordinates(tracking.baseCoordinates)
   }
 
   object Sidereal extends SiderealOptics {
@@ -69,6 +70,7 @@ object Target extends WithGid('t'.refined) with TargetOptics {
     sourceProfile: SourceProfile
   ) extends Target {
     def at(i: Instant) = none
+    def atEpoch = EphemerisCoordinates(Coordinates.Zero, Offset.Zero)
   }
 
   object Nonsidereal extends NonsiderealOptics {

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -23,6 +23,7 @@ import monocle.Prism
 import monocle.Traversal
 import monocle.macros.GenPrism
 
+import java.time.Instant
 import scala.collection.immutable.SortedMap
 
 /** A target of observation. */
@@ -39,7 +40,7 @@ object Target extends WithGid('t'.refined) with TargetOptics {
     sourceProfile: SourceProfile,
     catalogInfo:   Option[CatalogInfo]
   ) extends Target {
-    def at(i: Timestamp) = tracking.at(i).map(SiderealCoordinates.apply)
+    def at(i: Instant) = tracking.at(i).map(SiderealCoordinates.apply)
   }
 
   object Sidereal extends SiderealOptics {
@@ -67,7 +68,7 @@ object Target extends WithGid('t'.refined) with TargetOptics {
     ephemerisKey:  EphemerisKey,
     sourceProfile: SourceProfile
   ) extends Target {
-    def at(i: Timestamp) = none
+    def at(i: Instant) = none
   }
 
   object Nonsidereal extends NonsiderealOptics {

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -13,6 +13,7 @@ import lucuma.core.enums.Band
 import lucuma.core.math.BrightnessUnits._
 import lucuma.core.math._
 import lucuma.core.math.dimensional._
+import lucuma.core.util.Timestamp
 import lucuma.core.util.WithGid
 import lucuma.refined._
 import monocle.Focus
@@ -25,7 +26,7 @@ import monocle.macros.GenPrism
 import scala.collection.immutable.SortedMap
 
 /** A target of observation. */
-sealed trait Target extends Product with Serializable {
+sealed trait Target extends Tracking with Product with Serializable {
   def name: NonEmptyString
   def sourceProfile: SourceProfile
 }
@@ -37,7 +38,9 @@ object Target extends WithGid('t'.refined) with TargetOptics {
     tracking:      SiderealTracking,
     sourceProfile: SourceProfile,
     catalogInfo:   Option[CatalogInfo]
-  ) extends Target
+  ) extends Target {
+    def at(i: Timestamp) = tracking.at(i).map(SiderealCoordinates.apply)
+  }
 
   object Sidereal extends SiderealOptics {
     implicit val eqSidereal: Eq[Sidereal] =
@@ -63,7 +66,9 @@ object Target extends WithGid('t'.refined) with TargetOptics {
     name:          NonEmptyString,
     ephemerisKey:  EphemerisKey,
     sourceProfile: SourceProfile
-  ) extends Target
+  ) extends Target {
+    def at(i: Timestamp) = none
+  }
 
   object Nonsidereal extends NonsiderealOptics {
     implicit val eqNonsidereal: Eq[Nonsidereal] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Tracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Tracking.scala
@@ -10,6 +10,8 @@ import lucuma.core.util.Timestamp
 import monocle.Focus
 import monocle.Lens
 
+import java.time.Instant
+
 /** A coordinate along with a rate of change in RA and Dec for some time unit
   *
   * @param coord coordinates
@@ -18,7 +20,6 @@ import monocle.Lens
   */
 sealed trait TrackedCoordinates {
   def coord: Coordinates
-  def delta: Offset /* per time unit */
 }
 
 /** A coordinate along with a rate of change in RA and Dec for some time unit,
@@ -31,7 +32,7 @@ sealed trait TrackedCoordinates {
   */
 case class EphemerisCoordinates(
                    override val coord: Coordinates,
-                   override val delta: Offset /* per time unit */)
+                   val delta: Offset /* per time unit */)
     extends TrackedCoordinates {
 
   /** Interpolates the position and rate of change at a point between this
@@ -95,9 +96,7 @@ trait EphemerisCoordinatesOptics {
 
 }
 
-case class SiderealCoordinates(override val coord: Coordinates) extends TrackedCoordinates {
-  override val delta: Offset =  Offset.Zero
-}
+case class SiderealCoordinates(override val coord: Coordinates) extends TrackedCoordinates
 
 object SiderealCoordinates extends SiderealCoordinatesOptics {
   given Eq[SiderealCoordinates] = Eq.by(_.coord)
@@ -121,6 +120,6 @@ trait SiderealCoordinatesOptics {
  * Implementors can calculate the coordinates for a given object at a certain timestamp
  */
 trait Tracking {
-  def at(i: Timestamp): Option[TrackedCoordinates]
+  def at(i: Instant): Option[TrackedCoordinates]
 }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Tracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Tracking.scala
@@ -121,5 +121,12 @@ trait SiderealCoordinatesOptics {
  */
 trait Tracking {
   def at(i: Instant): Option[TrackedCoordinates]
+  def atEpoch: TrackedCoordinates
 }
 
+object Tracking {
+  def const(coord: Coordinates): Tracking = new Tracking {
+    def at(i: Instant): Option[TrackedCoordinates] = Some(SiderealCoordinates(coord))
+    def atEpoch: TrackedCoordinates = SiderealCoordinates(coord)
+  }
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/Time.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/Time.scala
@@ -41,7 +41,7 @@ trait ToInstantOps {
 
 object instant extends ToInstantOps {
   extension(i: Instant)
-    def toTimestamp: Option[Timestamp] = Timestamp.fromInstant(i)
+    def toTimestamp: Option[Timestamp] = Timestamp.fromInstantTruncated(i)
 }
 
 final class ZonedDateTimeOps(private val self: ZonedDateTime) extends AnyVal {

--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/Time.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/Time.scala
@@ -6,6 +6,7 @@ package lucuma.core.syntax
 import cats.syntax.all._
 import lucuma.core.optics.Spire
 import lucuma.core.syntax.boundedInterval._
+import lucuma.core.util.Timestamp
 import org.typelevel.cats.time._
 import spire.math.Bounded
 import spire.math.Empty
@@ -38,7 +39,10 @@ trait ToInstantOps {
     new InstantOps(i)
 }
 
-object instant extends ToInstantOps
+object instant extends ToInstantOps {
+  extension(i: Instant)
+    def toTimestamp: Option[Timestamp] = Timestamp.fromInstant(i)
+}
 
 final class ZonedDateTimeOps(private val self: ZonedDateTime) extends AnyVal {
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
@@ -7,6 +7,8 @@ import cats.kernel.laws.discipline._
 import lucuma.core.math.arb.ArbProperMotion._
 import lucuma.core.model.SiderealTracking
 import lucuma.core.optics.laws.discipline.SplitMonoTests
+import lucuma.core.syntax.instant.*
+import lucuma.core.util.Timestamp
 import munit.DisciplineSuite
 
 import java.time.Instant
@@ -29,7 +31,7 @@ final class ProperMotionSuite extends DisciplineSuite {
       )
 
     // July 4th 2022, around mid day
-    val instant = Instant.ofEpochMilli(1656966489)
-    assertEquals(tracking.at(instant), Some(Coordinates.fromHmsDms.getOption("11:59:57.096334 -00:00:58.073307").get))
+    val instant = Instant.ofEpochMilli(1656966489).toTimestamp
+    assertEquals(instant.flatMap(tracking.at), Some(Coordinates.fromHmsDms.getOption("11:59:57.096334 -00:00:58.073307").get))
   }
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
@@ -31,7 +31,7 @@ final class ProperMotionSuite extends DisciplineSuite {
       )
 
     // July 4th 2022, around mid day
-    val instant = Instant.ofEpochMilli(1656966489).toTimestamp
-    assertEquals(instant.flatMap(tracking.at), Some(Coordinates.fromHmsDms.getOption("11:59:57.096334 -00:00:58.073307").get))
+    val instant = Instant.ofEpochMilli(1656966489)
+    assertEquals(tracking.at(instant), Some(Coordinates.fromHmsDms.getOption("11:59:57.096334 -00:00:58.073307").get))
   }
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
@@ -11,6 +11,8 @@ import lucuma.core.math.Parallax
 import lucuma.core.math.ProperMotion
 import lucuma.core.math.arb._
 import lucuma.core.model.arb._
+import lucuma.core.syntax.instant.*
+import lucuma.core.util.Timestamp
 import monocle.law.discipline._
 import munit.DisciplineSuite
 import org.scalacheck.Prop.forAll
@@ -50,8 +52,8 @@ final class SiderealTrackingSuite extends DisciplineSuite {
     val pmra = ProperMotion.RA.milliarcsecondsPerYear.reverseGet(BigDecimal(-4406.469))
     val pmdec = ProperMotion.Dec.milliarcsecondsPerYear.reverseGet(BigDecimal(938.527))
     val tracking = SiderealTracking(coord, Epoch.J2000, ProperMotion(pmra, pmdec).some, none, Parallax.fromMicroarcseconds(203887).some)
-    val refEpoch = Instant.ofEpochSecond(4102444800L)
-    assertEquals(tracking.at(refEpoch), Coordinates.fromHmsDms.getOption("11 04 48.043284 +43 33 09.795210"))
+    val refEpoch = Instant.ofEpochSecond(4102444800L).toTimestamp
+    assertEquals(refEpoch.flatMap(tracking.at), Coordinates.fromHmsDms.getOption("11 04 48.043284 +43 33 09.795210"))
   }
 
   test("coordinatesOn corrected by cos(dec) case 2") {
@@ -59,8 +61,8 @@ final class SiderealTrackingSuite extends DisciplineSuite {
     val pmra = ProperMotion.RA.milliarcsecondsPerYear.reverseGet(BigDecimal(-3781.741))
     val pmdec = ProperMotion.Dec.milliarcsecondsPerYear.reverseGet(BigDecimal(769.465))
     val tracking = SiderealTracking(coord, Epoch.J2000, ProperMotion(pmra, pmdec).some, none, Parallax.fromMicroarcseconds(768465).some)
-    val refEpoch = Instant.ofEpochSecond(4102444800L)
-    assertEquals(tracking.at(refEpoch), Coordinates.fromHmsDms.getOption("14 28 48.054809 -62 39 28.543030"))
+    val refEpoch = Instant.ofEpochSecond(4102444800L).toTimestamp
+    assertEquals(refEpoch.flatMap(tracking.at), Coordinates.fromHmsDms.getOption("14 28 48.054809 -62 39 28.543030"))
   }
 
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
@@ -52,8 +52,8 @@ final class SiderealTrackingSuite extends DisciplineSuite {
     val pmra = ProperMotion.RA.milliarcsecondsPerYear.reverseGet(BigDecimal(-4406.469))
     val pmdec = ProperMotion.Dec.milliarcsecondsPerYear.reverseGet(BigDecimal(938.527))
     val tracking = SiderealTracking(coord, Epoch.J2000, ProperMotion(pmra, pmdec).some, none, Parallax.fromMicroarcseconds(203887).some)
-    val refEpoch = Instant.ofEpochSecond(4102444800L).toTimestamp
-    assertEquals(refEpoch.flatMap(tracking.at), Coordinates.fromHmsDms.getOption("11 04 48.043284 +43 33 09.795210"))
+    val refEpoch = Instant.ofEpochSecond(4102444800L)
+    assertEquals(tracking.at(refEpoch), Coordinates.fromHmsDms.getOption("11 04 48.043284 +43 33 09.795210"))
   }
 
   test("coordinatesOn corrected by cos(dec) case 2") {
@@ -61,8 +61,8 @@ final class SiderealTrackingSuite extends DisciplineSuite {
     val pmra = ProperMotion.RA.milliarcsecondsPerYear.reverseGet(BigDecimal(-3781.741))
     val pmdec = ProperMotion.Dec.milliarcsecondsPerYear.reverseGet(BigDecimal(769.465))
     val tracking = SiderealTracking(coord, Epoch.J2000, ProperMotion(pmra, pmdec).some, none, Parallax.fromMicroarcseconds(768465).some)
-    val refEpoch = Instant.ofEpochSecond(4102444800L).toTimestamp
-    assertEquals(refEpoch.flatMap(tracking.at), Coordinates.fromHmsDms.getOption("14 28 48.054809 -62 39 28.543030"))
+    val refEpoch = Instant.ofEpochSecond(4102444800L)
+    assertEquals(tracking.at(refEpoch), Coordinates.fromHmsDms.getOption("14 28 48.054809 -62 39 28.543030"))
   }
 
 }


### PR DESCRIPTION
We have separated ways to express tracking for sidereal and non sidereals and I think they could be unified.

This is a proposal on how we could do it but I have some questions though as I'm unfamiliar with how non-sidereals are handled, see some comments inline. I'd appreciate any insights.

This would help with asterisms handling in explore as well, basically I'd like for the generic `Target` trait to have a way to express that the coordinates could vary on time.

I also switched to use `Timestamp` on `SiderealTracking` to make it consistent with `Ephemeris`