### PR TITLE
Inline NewType.apply

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.55"
+ThisBuild / tlBaseVersion                         := "0.56"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/util/NewType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/NewType.scala
@@ -20,11 +20,11 @@ import monocle.Iso
 trait NewType[Wrapped]:
   opaque type Type = Wrapped
 
-  def apply(w: Wrapped): Type = w
+  inline def apply(w: Wrapped): Type = w
 
   extension (t: Type) inline def value: Wrapped = t
 
-  val value: Iso[Type, Wrapped] = Iso[Type, Wrapped](_.value)(apply)
+  val value: Iso[Type, Wrapped] = Iso[Type, Wrapped](_.value)(w => apply(w))
 
   given (using CanEqual[Wrapped, Wrapped]): CanEqual[Type, Type] = CanEqual.derived
   given (using eq: Eq[Wrapped]): Eq[Type]                        = eq


### PR DESCRIPTION
This avoids boxing and unboxing of primitive types when defining `NewType` values.

Eg, when defining `Switch extends NewType[Boolean]`, the code `val foo = Switch(false)` before compiled to:
```
foo = BoxesRunTime.unboxToBoolean(Switch.apply(BoxesRunTime.boxToBoolean(false)));
```

and now:
```
foo = false
```