### PR TITLE
bump version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.56"
+ThisBuild / tlBaseVersion                         := "0.57"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 


### PR DESCRIPTION
I mistakenly released the latest version as 0.57 instead of 0.56. This PR just bumps the version in build.sbt to match the released version.