### PR TITLE
Make AngularVelocityComponent an opaque type

### DIFF
--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbProperMotion.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbProperMotion.scala
@@ -5,34 +5,35 @@ package lucuma.core.math
 package arb
 
 import lucuma.core.math.ProperMotion
+import lucuma.core.math.dimensional.*
 import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.*
 import org.scalacheck.Cogen
 
 trait ArbProperMotion {
-  import ProperMotion._
+  import ProperMotion.*
 
-  implicit def arbAngularVelocityComponent[A]: Arbitrary[AngularVelocityComponent[A]] =
+  given arbAngularVelocityComponent[A]: Arbitrary[AngularVelocity Of A] =
     Arbitrary {
-      arbitrary[Long].map(AngularVelocityComponent.μasy[A].get)
+      arbitrary[Long].map(AngularVelocity.μasy[A].get)
     }
 
-  implicit def cogAngularVelocity[A]: Cogen[AngularVelocityComponent[A]] =
+  given cogAngularVelocity[A]: Cogen[AngularVelocity Of A] =
     Cogen[Long].contramap(_.μasy.value)
 
-  implicit val arbProperMotion: Arbitrary[ProperMotion] =
+  given Arbitrary[ProperMotion] =
     Arbitrary {
       for {
-        ra  <- arbitrary[AngularVelocityComponent[VelocityAxis.RA]]
-        dec <- arbitrary[AngularVelocityComponent[VelocityAxis.Dec]]
+        ra  <- arbitrary[AngularVelocity Of VelocityAxis.RA]
+        dec <- arbitrary[AngularVelocity Of VelocityAxis.Dec]
       } yield ProperMotion(ra, dec)
     }
 
-  implicit val cogProperMotion: Cogen[ProperMotion] =
+  given Cogen[ProperMotion] =
     Cogen[
       (
-        AngularVelocityComponent[VelocityAxis.RA],
-        AngularVelocityComponent[VelocityAxis.Dec]
+        AngularVelocity Of VelocityAxis.RA,
+        AngularVelocity Of VelocityAxis.Dec
       )
     ].contramap(x => (x.ra, x.dec))
 }

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSiderealTracking.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSiderealTracking.scala
@@ -3,21 +3,21 @@
 
 package lucuma.core.model.arb
 
-import lucuma.core.math._
-import lucuma.core.math.arb._
-import lucuma.core.model._
-import org.scalacheck.Arbitrary._
-import org.scalacheck.Cogen._
-import org.scalacheck._
+import lucuma.core.math.*
+import lucuma.core.math.arb.*
+import lucuma.core.model.*
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen.*
+import org.scalacheck.*
 
 trait ArbSiderealTracking {
-  import ArbEpoch._
-  import ArbCoordinates._
-  import ArbProperMotion._
-  import ArbRadialVelocity._
-  import ArbParallax._
+  import ArbEpoch.*
+  import ArbCoordinates.*
+  import ArbProperMotion.given
+  import ArbRadialVelocity.*
+  import ArbParallax.*
 
-  implicit val arbSiderealTracking: Arbitrary[SiderealTracking] =
+  given Arbitrary[SiderealTracking] =
     Arbitrary {
       for {
         cs <- arbitrary[Coordinates]
@@ -28,7 +28,7 @@ trait ArbSiderealTracking {
       } yield SiderealTracking(cs, ap, pv, rv, px)
     }
 
-  implicit val cogSiderealTracking: Cogen[SiderealTracking] =
+  given Cogen[SiderealTracking] =
     Cogen[
       (
         Coordinates,

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
@@ -4,23 +4,23 @@
 package lucuma.core.model
 package arb
 
-import cats.syntax.all._
-import eu.timepit.refined.scalacheck.string._
+import cats.syntax.all.*
+import eu.timepit.refined.scalacheck.string.*
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Cogen._
-import org.scalacheck._
+import org.scalacheck.Cogen.*
+import org.scalacheck.*
 
 trait ArbTarget {
 
-  import ArbEphemerisKey._
-  import ArbSiderealTracking._
-  import ArbEnumerated._
-  import ArbSourceProfile._
-  import ArbCatalogInfo._
+  import ArbEphemerisKey.*
+  import ArbSiderealTracking.given
+  import ArbEnumerated.*
+  import ArbSourceProfile.*
+  import ArbCatalogInfo.*
 
-  implicit val ArbSiderealTarget: Arbitrary[Target.Sidereal] =
+  given Arbitrary[Target.Sidereal] =
     Arbitrary {
       for {
         n <- arbitrary[NonEmptyString]
@@ -30,7 +30,7 @@ trait ArbTarget {
       } yield Target.Sidereal(n, t, b, c)
     }
 
-  implicit val arbNonsiderealTarget: Arbitrary[Target.Nonsidereal] =
+  given Arbitrary[Target.Nonsidereal] =
     Arbitrary {
       for {
         n <- arbitrary[NonEmptyString]
@@ -39,19 +39,19 @@ trait ArbTarget {
       } yield Target.Nonsidereal(n, t, b)
     }
 
-  implicit val arbTarget: Arbitrary[Target] = Arbitrary(
+  given Arbitrary[Target] = Arbitrary(
     Gen.oneOf(arbitrary[Target.Sidereal], arbitrary[Target.Nonsidereal])
   )
 
-  implicit val cogSiderealTarget: Cogen[Target.Sidereal] =
+  given Cogen[Target.Sidereal] =
     Cogen[(String, SiderealTracking, SourceProfile, Option[CatalogInfo])]
       .contramap(t => (t.name.value, t.tracking, t.sourceProfile, t.catalogInfo))
 
-  implicit val cogNonsiderealTarget: Cogen[Target.Nonsidereal] =
+  given Cogen[Target.Nonsidereal] =
     Cogen[(String, EphemerisKey, SourceProfile)]
       .contramap(t => (t.name.value, t.ephemerisKey, t.sourceProfile))
 
-  implicit val cogTarget: Cogen[Target] =
+  given Cogen[Target] =
     Cogen[Either[Target.Sidereal, Target.Nonsidereal]]
       .contramap {
         case t @ Target.Sidereal(_, _, _, _) => t.asLeft

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
@@ -16,6 +16,10 @@ final class ProperMotionSuite extends DisciplineSuite {
   // Laws
   checkAll("Order[ProperMotion]", OrderTests[ProperMotion].order)
   checkAll("Monoid[ProperMotion]", MonoidTests[ProperMotion].monoid)
+  checkAll("Order[AngularVelocityComponent]", OrderTests[ProperMotion.AngularVelocityComponent[VelocityAxis.RA]].order)
+  checkAll("Monoid[AngularVelocityComponent]", MonoidTests[ProperMotion.AngularVelocityComponent[VelocityAxis.RA]].monoid)
+  checkAll("Order[AngularVelocityComponent]", OrderTests[ProperMotion.AngularVelocityComponent[VelocityAxis.Dec]].order)
+  checkAll("Monoid[AngularVelocityComponent]", MonoidTests[ProperMotion.AngularVelocityComponent[VelocityAxis.Dec]].monoid)
 
   checkAll("milliarcsecondsPerYear", SplitMonoTests(ProperMotion.milliarcsecondsPerYear).splitMono)
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/ProperMotionSuite.scala
@@ -3,8 +3,9 @@
 
 package lucuma.core.math
 
-import cats.kernel.laws.discipline._
-import lucuma.core.math.arb.ArbProperMotion._
+import cats.kernel.laws.discipline.*
+import lucuma.core.math.arb.ArbProperMotion.given
+import lucuma.core.math.dimensional.*
 import lucuma.core.model.SiderealTracking
 import lucuma.core.optics.laws.discipline.SplitMonoTests
 import munit.DisciplineSuite
@@ -16,10 +17,10 @@ final class ProperMotionSuite extends DisciplineSuite {
   // Laws
   checkAll("Order[ProperMotion]", OrderTests[ProperMotion].order)
   checkAll("Monoid[ProperMotion]", MonoidTests[ProperMotion].monoid)
-  checkAll("Order[AngularVelocityComponent]", OrderTests[ProperMotion.AngularVelocityComponent[VelocityAxis.RA]].order)
-  checkAll("Monoid[AngularVelocityComponent]", MonoidTests[ProperMotion.AngularVelocityComponent[VelocityAxis.RA]].monoid)
-  checkAll("Order[AngularVelocityComponent]", OrderTests[ProperMotion.AngularVelocityComponent[VelocityAxis.Dec]].order)
-  checkAll("Monoid[AngularVelocityComponent]", MonoidTests[ProperMotion.AngularVelocityComponent[VelocityAxis.Dec]].monoid)
+  checkAll("Order[AngularVelocityComponent]", OrderTests[ProperMotion.RA].order)
+  checkAll("Monoid[AngularVelocityComponent]", MonoidTests[ProperMotion.RA].monoid)
+  checkAll("Order[AngularVelocityComponent]", OrderTests[ProperMotion.Dec].order)
+  checkAll("Monoid[AngularVelocityComponent]", MonoidTests[ProperMotion.Dec].monoid)
 
   checkAll("milliarcsecondsPerYear", SplitMonoTests(ProperMotion.milliarcsecondsPerYear).splitMono)
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/UnitSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/dimensional/UnitSuite.scala
@@ -4,15 +4,15 @@
 package lucuma.core.math.dimensional
 
 import cats.Eq
-import cats.kernel.laws.discipline._
-import lucuma.core.math.BrightnessUnits._
+import cats.kernel.laws.discipline.*
+import lucuma.core.math.BrightnessUnits.*
 import lucuma.core.math.dimensional.arb.ArbUnits
-import lucuma.core.syntax.display._
-import lucuma.core.util.arb.ArbEnumerated._
-import org.scalacheck.Prop._
+import lucuma.core.syntax.display.*
+import lucuma.core.util.arb.ArbEnumerated.*
+import org.scalacheck.Prop.*
 
 class UnitSuite extends munit.DisciplineSuite {
-  import ArbUnits._
+  import ArbUnits.*
 
   // Laws
   checkAll("Units", EqTests[Units].eqv)

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SiderealTrackingSuite.scala
@@ -3,29 +3,31 @@
 
 package lucuma.core.model
 
-import cats.kernel.laws.discipline._
-import cats.syntax.all._
+import cats.kernel.laws.discipline.*
+import cats.syntax.all.*
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Epoch
 import lucuma.core.math.Parallax
 import lucuma.core.math.ProperMotion
-import lucuma.core.math.arb._
-import lucuma.core.model.arb._
-import monocle.law.discipline._
+import lucuma.core.math.ProperMotion.AngularVelocity
+import lucuma.core.math.VelocityAxis
+import lucuma.core.math.arb.*
+import lucuma.core.model.arb.*
+import monocle.law.discipline.*
 import munit.DisciplineSuite
 import org.scalacheck.Prop.forAll
 
 import java.time.Instant
 
 final class SiderealTrackingSuite extends DisciplineSuite {
-  import ArbCoordinates._
-  import ArbDeclination._
-  import ArbEpoch._
-  import ArbParallax._
-  import ArbProperMotion._
-  import ArbRightAscension._
-  import ArbSiderealTracking._
-  import ArbRadialVelocity._
+  import ArbCoordinates.*
+  import ArbDeclination.*
+  import ArbEpoch.*
+  import ArbParallax.*
+  import ArbProperMotion.given
+  import ArbRightAscension.*
+  import ArbSiderealTracking.given
+  import ArbRadialVelocity.*
 
   // Laws
   checkAll("SiderealTracking", OrderTests[SiderealTracking].order)
@@ -47,8 +49,8 @@ final class SiderealTrackingSuite extends DisciplineSuite {
 
   test("coordinatesOn corrected by cos(dec) case 1") {
     val coord = Coordinates.fromHmsDms.getOption("11 05 28.577 +43 31 36.39").get
-    val pmra = ProperMotion.RA.milliarcsecondsPerYear.reverseGet(BigDecimal(-4406.469))
-    val pmdec = ProperMotion.Dec.milliarcsecondsPerYear.reverseGet(BigDecimal(938.527))
+    val pmra = AngularVelocity.milliarcsecondsPerYear[VelocityAxis.RA].reverseGet(BigDecimal(-4406.469))
+    val pmdec = AngularVelocity.milliarcsecondsPerYear[VelocityAxis.Dec].reverseGet(BigDecimal(938.527))
     val tracking = SiderealTracking(coord, Epoch.J2000, ProperMotion(pmra, pmdec).some, none, Parallax.fromMicroarcseconds(203887).some)
     val refEpoch = Instant.ofEpochSecond(4102444800L)
     assertEquals(tracking.at(refEpoch), Coordinates.fromHmsDms.getOption("11 04 48.043284 +43 33 09.795210"))
@@ -56,8 +58,8 @@ final class SiderealTrackingSuite extends DisciplineSuite {
 
   test("coordinatesOn corrected by cos(dec) case 2") {
     val coord = Coordinates.fromHmsDms.getOption("14 29 42.946 -62 40 46.16").get
-    val pmra = ProperMotion.RA.milliarcsecondsPerYear.reverseGet(BigDecimal(-3781.741))
-    val pmdec = ProperMotion.Dec.milliarcsecondsPerYear.reverseGet(BigDecimal(769.465))
+    val pmra = AngularVelocity.milliarcsecondsPerYear[VelocityAxis.RA].reverseGet(BigDecimal(-3781.741))
+    val pmdec = AngularVelocity.milliarcsecondsPerYear[VelocityAxis.Dec].reverseGet(BigDecimal(769.465))
     val tracking = SiderealTracking(coord, Epoch.J2000, ProperMotion(pmra, pmdec).some, none, Parallax.fromMicroarcseconds(768465).some)
     val refEpoch = Instant.ofEpochSecond(4102444800L)
     assertEquals(tracking.at(refEpoch), Coordinates.fromHmsDms.getOption("14 28 48.054809 -62 39 28.543030"))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -3,45 +3,45 @@
 
 package lucuma.core.model
 
-import cats.Order._
-import cats.kernel.laws.discipline._
-import eu.timepit.refined.cats._
-import eu.timepit.refined.scalacheck.string._
-import lucuma.core.arb._
+import cats.Order.*
+import cats.kernel.laws.discipline.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.scalacheck.string.*
+import lucuma.core.arb.*
 import lucuma.core.enums.Band
-import lucuma.core.math.arb._
+import lucuma.core.math.arb.*
 import lucuma.core.math.dimensional.arb.ArbMeasure
-import lucuma.core.model.arb._
+import lucuma.core.model.arb.*
 import lucuma.core.util.arb.ArbCollection
-import lucuma.core.util.arb._
+import lucuma.core.util.arb.*
 import lucuma.core.util.laws.GidTests
-import monocle.law.discipline._
-import munit._
+import monocle.law.discipline.*
+import munit.*
 
 final class TargetSuite extends DisciplineSuite {
-  import ArbTarget._
-  import ArbSourceProfile._
-  import ArbSiderealTracking._
-  import ArbEphemerisKey._
-  import ArbParallax._
-  import ArbEnumerated._
-  import ArbCoordinates._
-  import ArbRightAscension._
-  import ArbDeclination._
-  import ArbProperMotion._
-  import ArbRadialVelocity._
-  import ArbGid._
-  import ArbEpoch._
-  import ArbCatalogInfo._
-  import Target._
-  import ArbEmissionLine._
-  import ArbSpectralDefinition._
-  import ArbAngle._
-  import ArbUnnormalizedSED._
-  import ArbRefined._
-  import ArbMeasure._
-  import ArbCollection._
-  import ArbWavelength._
+  import ArbTarget.given
+  import ArbSourceProfile.*
+  import ArbSiderealTracking.given
+  import ArbEphemerisKey.*
+  import ArbParallax.*
+  import ArbEnumerated.*
+  import ArbCoordinates.*
+  import ArbRightAscension.*
+  import ArbDeclination.*
+  import ArbProperMotion.given
+  import ArbRadialVelocity.given
+  import ArbGid.*
+  import ArbEpoch.*
+  import ArbCatalogInfo.*
+  import Target.*
+  import ArbEmissionLine.*
+  import ArbSpectralDefinition.*
+  import ArbAngle.*
+  import ArbUnnormalizedSED.*
+  import ArbRefined.*
+  import ArbMeasure.*
+  import ArbCollection.*
+  import ArbWavelength.*
 
   // Laws for Target.Sidereal
   checkAll("Eq[Target.Sidereal]", EqTests[Target.Sidereal].eqv)

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/UnnormalizedSEDSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/UnnormalizedSEDSuite.scala
@@ -3,23 +3,23 @@
 
 package lucuma.core.model
 
-import cats.kernel.laws.discipline._
+import cats.kernel.laws.discipline.*
 import coulomb.ops.algebra.cats.all.given
-import eu.timepit.refined.cats._
-import eu.timepit.refined.scalacheck.numeric._
-import lucuma.core.math.arb._
-import lucuma.core.model.arb._
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.scalacheck.numeric.*
+import lucuma.core.math.arb.*
+import lucuma.core.model.arb.*
 import lucuma.core.util.arb.ArbEnumerated
 import monocle.law.discipline.LensTests
 import monocle.law.discipline.PrismTests
-import munit._
+import munit.*
 
 final class UnnormalizedSEDSuite extends DisciplineSuite {
-  import UnnormalizedSED._
-  import ArbUnnormalizedSED._
-  import ArbEnumerated._
+  import UnnormalizedSED.*
+  import ArbUnnormalizedSED.*
+  import ArbEnumerated.*
   import ArbQuantity.given
-  import ArbRefined._
+  import ArbRefined.*
 
   // Laws
   checkAll("Order[CoolStarModel]", OrderTests[CoolStarModel].order)


### PR DESCRIPTION
This is a small experiment converting `AngularVelocityComponent` to an opaque type. I think several core classes could become opaque types including angle and Wavelength.
This class is particularly good for testing because we already have a benchmark.
I tested js size (using the test js ouput) and found a small reduction in size and the benchmark showed an increase from ~5500 ops/sec to ~5900 ops/sec