### PR TITLE
Make SED optional

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/SourceProfile.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SourceProfile.scala
@@ -188,8 +188,8 @@ object SourceProfile {
     surfaceSpectralDefinition.andThen(SpectralDefinition.emissionLines[Surface])
 
   /** @group Optics */
-  val unnormalizedSED: Optional[SourceProfile, UnnormalizedSED] =
-    Optional[SourceProfile, UnnormalizedSED](p =>
+  val unnormalizedSED: Optional[SourceProfile, Option[UnnormalizedSED]] =
+    Optional[SourceProfile, Option[UnnormalizedSED]](p =>
       integratedSpectralDefinition
         .andThen(SpectralDefinition.unnormalizedSED[Integrated])
         .getOption(p)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/SpectralDefinition.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/SpectralDefinition.scala
@@ -4,14 +4,14 @@
 package lucuma.core.model
 
 import cats.Eq
-import cats.Order._
-import cats.syntax.all._
-import eu.timepit.refined.cats._
+import cats.Order.*
+import cats.syntax.all.*
+import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.enums.Band
-import lucuma.core.math.BrightnessUnits._
+import lucuma.core.math.BrightnessUnits.*
 import lucuma.core.math.Wavelength
-import lucuma.core.math.dimensional._
+import lucuma.core.math.dimensional.*
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
@@ -43,7 +43,7 @@ sealed trait SpectralDefinition[T] {
 object SpectralDefinition {
 
   final case class BandNormalized[T](
-    sed:          UnnormalizedSED,
+    sed:          Option[UnnormalizedSED],
     brightnesses: SortedMap[Band, BrightnessMeasure[T]]
   ) extends SpectralDefinition[T] {
     lazy val bands: List[Band] = brightnesses.keys.toList
@@ -70,7 +70,7 @@ object SpectralDefinition {
       Eq.by(x => (x.sed, x.brightnesses))
 
     /** @group Optics */
-    def sed[T]: Lens[BandNormalized[T], UnnormalizedSED] =
+    def sed[T]: Lens[BandNormalized[T], Option[UnnormalizedSED]] =
       Focus[BandNormalized[T]](_.sed)
 
     /** @group Optics */
@@ -148,7 +148,7 @@ object SpectralDefinition {
     GenPrism[SpectralDefinition[T], EmissionLines[T]]
 
   /** @group Optics */
-  def unnormalizedSED[T]: Optional[SpectralDefinition[T], UnnormalizedSED] =
+  def unnormalizedSED[T]: Optional[SpectralDefinition[T], Option[UnnormalizedSED]] =
     bandNormalized.andThen(BandNormalized.sed[T])
 
   /** @group Optics */

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Target.scala
@@ -3,18 +3,18 @@
 
 package lucuma.core.model
 
-import cats._
-import cats.implicits._
-import eu.timepit.refined.auto._
-import eu.timepit.refined.cats._
+import cats.*
+import cats.implicits.*
+import eu.timepit.refined.auto.*
+import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.Band
-import lucuma.core.math.BrightnessUnits._
-import lucuma.core.math._
-import lucuma.core.math.dimensional._
+import lucuma.core.math.BrightnessUnits.*
+import lucuma.core.math.*
+import lucuma.core.math.dimensional.*
 import lucuma.core.util.WithGid
-import lucuma.refined._
+import lucuma.refined.*
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
@@ -32,7 +32,7 @@ sealed trait Target extends Product with Serializable {
 
 object Target extends WithGid('t'.refined) with TargetOptics {
 
-  final case class Sidereal(
+  case class Sidereal(
     name:          NonEmptyString,
     tracking:      SiderealTracking,
     sourceProfile: SourceProfile,
@@ -40,7 +40,7 @@ object Target extends WithGid('t'.refined) with TargetOptics {
   ) extends Target
 
   object Sidereal extends SiderealOptics {
-    implicit val eqSidereal: Eq[Sidereal] =
+    given Eq[Sidereal] =
       Eq.by(x => (x.name, x.tracking, x.sourceProfile, x.catalogInfo))
 
     /**
@@ -59,14 +59,14 @@ object Target extends WithGid('t'.refined) with TargetOptics {
     val NameOrder: Order[Sidereal] = Order.by(x => (x.name, x.tracking))
   }
 
-  final case class Nonsidereal(
+  case class Nonsidereal(
     name:          NonEmptyString,
     ephemerisKey:  EphemerisKey,
     sourceProfile: SourceProfile
   ) extends Target
 
   object Nonsidereal extends NonsiderealOptics {
-    implicit val eqNonsidereal: Eq[Nonsidereal] =
+    given Eq[Nonsidereal] =
       Eq.by(x => (x.name, x.ephemerisKey, x.sourceProfile))
 
     /**
@@ -84,7 +84,7 @@ object Target extends WithGid('t'.refined) with TargetOptics {
     val NameOrder: Order[Nonsidereal] = Order.by(x => (x.name, x.ephemerisKey))
   }
 
-  implicit val TargetEq: Eq[Target] = Eq.instance {
+  given Eq[Target] = Eq.instance {
     case (a @ Sidereal(_, _, _, _), b @ Sidereal(_, _, _, _)) => a === b
     case (a @ Nonsidereal(_, _, _), b @ Nonsidereal(_, _, _)) => a === b
     case _                                                    => false
@@ -204,7 +204,7 @@ object Target extends WithGid('t'.refined) with TargetOptics {
       sourceProfile.andThen(SourceProfile.surfaceEmissionLinesSpectralDefinition)
 
     /** @group Optics */
-    val unnormalizedSED: Optional[Sidereal, UnnormalizedSED] =
+    val unnormalizedSED: Optional[Sidereal, Option[UnnormalizedSED]] =
       sourceProfile.andThen(SourceProfile.unnormalizedSED)
 
     /** @group Optics */
@@ -323,7 +323,7 @@ object Target extends WithGid('t'.refined) with TargetOptics {
       sourceProfile.andThen(SourceProfile.surfaceEmissionLinesSpectralDefinition)
 
     /** @group Optics */
-    val unnormalizedSED: Optional[Nonsidereal, UnnormalizedSED] =
+    val unnormalizedSED: Optional[Nonsidereal, Option[UnnormalizedSED]] =
       sourceProfile.andThen(SourceProfile.unnormalizedSED)
 
     /** @group Optics */
@@ -458,7 +458,7 @@ trait TargetOptics { this: Target.type =>
     sourceProfile.andThen(SourceProfile.surfaceEmissionLinesSpectralDefinition)
 
   /** @group Optics */
-  val unnormalizedSED: Optional[Target, UnnormalizedSED] =
+  val unnormalizedSED: Optional[Target, Option[UnnormalizedSED]] =
     sourceProfile.andThen(SourceProfile.unnormalizedSED)
 
   /** @group Optics */

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSourceProfile.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSourceProfile.scala
@@ -4,31 +4,31 @@
 package lucuma.core.model
 package arb
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import lucuma.core.math.Angle
 import lucuma.core.math.BrightnessUnits
 import lucuma.core.math.arb.ArbAngle
 import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck._
+import org.scalacheck.*
 
 trait ArbSourceProfile {
-  import ArbAngle._
-  import ArbEnumerated._
-  import BrightnessUnits._
-  import ArbSpectralDefinition._
+  import ArbAngle.*
+  import ArbEnumerated.*
+  import BrightnessUnits.*
+  import ArbSpectralDefinition.given
 
-  implicit val arbPointSourceProfile: Arbitrary[SourceProfile.Point] =
+  given Arbitrary[SourceProfile.Point] =
     Arbitrary(
       arbitrary[SpectralDefinition[Integrated]].map(SourceProfile.Point(_))
     )
 
-  implicit val arbUniformSourceProfile: Arbitrary[SourceProfile.Uniform] =
+  given Arbitrary[SourceProfile.Uniform] =
     Arbitrary(
       arbitrary[SpectralDefinition[Surface]].map(SourceProfile.Uniform(_))
     )
 
-  implicit val arbGaussianSourceProfile: Arbitrary[SourceProfile.Gaussian] =
+  given Arbitrary[SourceProfile.Gaussian] =
     Arbitrary {
       for {
         a <- arbitrary[Angle]
@@ -36,7 +36,7 @@ trait ArbSourceProfile {
       } yield SourceProfile.Gaussian(a, d)
     }
 
-  implicit val arbSourceProfile: Arbitrary[SourceProfile] =
+  given Arbitrary[SourceProfile] =
     Arbitrary {
       Gen.oneOf(
         arbitrary[SourceProfile.Point],
@@ -45,16 +45,16 @@ trait ArbSourceProfile {
       )
     }
 
-  implicit val cogPointSourceProfile: Cogen[SourceProfile.Point] =
+  given Cogen[SourceProfile.Point] =
     Cogen[SpectralDefinition[Integrated]].contramap(_.spectralDefinition)
 
-  implicit val cogUniformSourceProfile: Cogen[SourceProfile.Uniform] =
+  given Cogen[SourceProfile.Uniform] =
     Cogen[SpectralDefinition[Surface]].contramap(_.spectralDefinition)
 
-  implicit val cogenGaussianSourceProfile: Cogen[SourceProfile.Gaussian] =
+  given Cogen[SourceProfile.Gaussian] =
     Cogen[(Angle, SpectralDefinition[Integrated])].contramap(x => (x.fwhm, x.spectralDefinition))
 
-  implicit val cogSourceProfile: Cogen[SourceProfile] =
+  given Cogen[SourceProfile] =
     Cogen[
       Either[SourceProfile.Point, Either[SourceProfile.Uniform, SourceProfile.Gaussian]]
     ]

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSpectralDefinition.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbSpectralDefinition.scala
@@ -3,51 +3,51 @@
 
 package lucuma.core.model.arb
 
-import cats.Order._
-import cats.syntax.all._
+import cats.Order.*
+import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.enums.Band
 import lucuma.core.math.BrightnessUnits
 import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbRefined
 import lucuma.core.math.arb.ArbWavelength
-import lucuma.core.math.dimensional._
+import lucuma.core.math.dimensional.*
 import lucuma.core.math.dimensional.arb.ArbMeasure
 import lucuma.core.model.EmissionLine
 import lucuma.core.model.SpectralDefinition
 import lucuma.core.model.UnnormalizedSED
 import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck._
+import org.scalacheck.*
 
 import scala.collection.immutable.SortedMap
 
 trait ArbSpectralDefinition {
-  import ArbUnnormalizedSED._
-  import ArbEnumerated._
-  import SpectralDefinition._
-  import BrightnessUnits._
-  import ArbMeasure._
-  import ArbEmissionLine._
-  import ArbRefined._
-  import ArbWavelength._
+  import ArbUnnormalizedSED.given
+  import ArbEnumerated.*
+  import SpectralDefinition.*
+  import BrightnessUnits.*
+  import ArbMeasure.*
+  import ArbEmissionLine.*
+  import ArbRefined.*
+  import ArbWavelength.*
 
-  implicit def arbBandNormalizedSpectralDefinition[T](implicit
+  given arbBandNormalizedSpectralDefinition[T](using
     arbUnit: Arbitrary[Units Of Brightness[T]]
   ): Arbitrary[BandNormalized[T]] =
     Arbitrary {
       for {
-        s <- arbitrary[UnnormalizedSED]
+        s <- arbitrary[Option[UnnormalizedSED]]
         b <- arbitrary[SortedMap[Band, BrightnessMeasure[T]]]
       } yield BandNormalized(s, b)
     }
 
-  implicit def cogBandNormalizedSpectralDefinition[T]: Cogen[BandNormalized[T]] =
-    Cogen[(UnnormalizedSED, Map[Band, BrightnessMeasure[T]])].contramap(x =>
+  given cogBandNormalizedSpectralDefinition[T]: Cogen[BandNormalized[T]] =
+    Cogen[(Option[UnnormalizedSED], Map[Band, BrightnessMeasure[T]])].contramap(x =>
       (x.sed, x.brightnesses)
     )
 
-  implicit def arbEmissionLines[T](implicit
+  given arbEmissionLines[T](using
     arbLineFluxUnit:             Arbitrary[Units Of LineFlux[T]],
     arbFluxDensityContinuumUnit: Arbitrary[Units Of FluxDensityContinuum[T]]
   ): Arbitrary[EmissionLines[T]] =
@@ -58,12 +58,12 @@ trait ArbSpectralDefinition {
       } yield EmissionLines[T](l, c)
     }
 
-  implicit def cogEmissionLines[T]: Cogen[EmissionLines[T]] =
+  given cogEmissionLines[T]: Cogen[EmissionLines[T]] =
     Cogen[(Map[Wavelength, EmissionLine[T]], Measure[PosBigDecimal])].contramap(x =>
       (x.lines, x.fluxDensityContinuum)
     )
 
-  implicit def arbSpectralDefinition[T](implicit
+  given arbSpectralDefinition[T](using
     arbBrightnessUnit: Arbitrary[Units Of Brightness[T]],
     arbLineUnit:       Arbitrary[Units Of LineFlux[T]],
     arbContinuumUnit:  Arbitrary[Units Of FluxDensityContinuum[T]]
@@ -72,7 +72,7 @@ trait ArbSpectralDefinition {
       Gen.oneOf(arbitrary[BandNormalized[T]], arbitrary[EmissionLines[T]])
     )
 
-  implicit def cogSpectralDefinition[T]: Cogen[SpectralDefinition[T]] =
+  given cogSpectralDefinition[T]: Cogen[SpectralDefinition[T]] =
     Cogen[Either[BandNormalized[T], EmissionLines[T]]].contramap {
       case d @ BandNormalized(_, _) => d.asLeft
       case d @ EmissionLines(_, _)  => d.asRight

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTarget.scala
@@ -17,7 +17,7 @@ trait ArbTarget {
   import ArbEphemerisKey.*
   import ArbSiderealTracking.given
   import ArbEnumerated.*
-  import ArbSourceProfile.*
+  import ArbSourceProfile.given
   import ArbCatalogInfo.*
 
   given Arbitrary[Target.Sidereal] =

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbUnnormalizedSED.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbUnnormalizedSED.scala
@@ -5,97 +5,97 @@ package lucuma.core.model
 package arb
 
 import cats.data.NonEmptyMap
-import cats.implicits._
-import cats.laws.discipline.arbitrary._
+import cats.implicits.*
+import cats.laws.discipline.arbitrary.*
 import coulomb.*
 import coulomb.syntax.*
 import coulomb.units.si.Kelvin
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
 import eu.timepit.refined.types.numeric.PosBigDecimal
-import lucuma.core.enums._
+import lucuma.core.enums.*
 import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbRefined
 import lucuma.core.math.arb.ArbWavelength
-import lucuma.core.math.units._
+import lucuma.core.math.units.*
 import lucuma.core.util.arb.ArbEnumerated
-import lucuma.refined._
+import lucuma.refined.*
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck._
+import org.scalacheck.*
 
 trait ArbUnnormalizedSED {
-  import ArbEnumerated._
-  import UnnormalizedSED._
-  import ArbRefined._
-  import ArbWavelength._
+  import ArbEnumerated.*
+  import UnnormalizedSED.*
+  import ArbRefined.*
+  import ArbWavelength.*
 
-  implicit val arbStellarLibrary: Arbitrary[StellarLibrary] =
+  given Arbitrary[StellarLibrary] =
     Arbitrary(arbitrary[StellarLibrarySpectrum].map(StellarLibrary(_)))
 
-  implicit val cogStellarLibrary: Cogen[StellarLibrary] =
+  given Cogen[StellarLibrary] =
     Cogen[StellarLibrarySpectrum].contramap(_.librarySpectrum)
 
-  implicit val arbCoolStarModel: Arbitrary[CoolStarModel] =
+  given Arbitrary[CoolStarModel] =
     Arbitrary(arbitrary[CoolStarTemperature].map(CoolStarModel(_)))
 
-  implicit val cogCoolStarModel: Cogen[CoolStarModel] =
+  given Cogen[CoolStarModel] =
     Cogen[BigDecimal].contramap(_.temperature.temperature.value.value)
 
-  implicit val arbGalaxy: Arbitrary[Galaxy] =
+  given Arbitrary[Galaxy] =
     Arbitrary(arbitrary[GalaxySpectrum].map(Galaxy(_)))
 
-  implicit val cogGalaxy: Cogen[Galaxy] =
+  given Cogen[Galaxy] =
     Cogen[GalaxySpectrum].contramap(_.galaxySpectrum)
 
-  implicit val arbPlanet: Arbitrary[Planet] =
+  given Arbitrary[Planet] =
     Arbitrary(arbitrary[PlanetSpectrum].map(Planet(_)))
 
-  implicit val cogPlanet: Cogen[Planet] =
+  given Cogen[Planet] =
     Cogen[PlanetSpectrum].contramap(_.planetSpectrum)
 
-  implicit val arbQuasar: Arbitrary[Quasar] =
+  given Arbitrary[Quasar] =
     Arbitrary(arbitrary[QuasarSpectrum].map(Quasar(_)))
 
-  implicit val cogQuasar: Cogen[Quasar] =
+  given Cogen[Quasar] =
     Cogen[QuasarSpectrum].contramap(_.quasarSpectrum)
 
-  implicit val arbHIIRegion: Arbitrary[HIIRegion] =
+  given Arbitrary[HIIRegion] =
     Arbitrary(arbitrary[HIIRegionSpectrum].map(HIIRegion(_)))
 
-  implicit val cogHIIRegion: Cogen[HIIRegion] =
+  given Cogen[HIIRegion] =
     Cogen[HIIRegionSpectrum].contramap(_.hiiRegionSpectrum)
 
-  implicit val arbPlanetaryNebula: Arbitrary[PlanetaryNebula] =
+  given Arbitrary[PlanetaryNebula] =
     Arbitrary(arbitrary[PlanetaryNebulaSpectrum].map(PlanetaryNebula(_)))
 
-  implicit val cogPlanetaryNebula: Cogen[PlanetaryNebula] =
+  given Cogen[PlanetaryNebula] =
     Cogen[PlanetaryNebulaSpectrum].contramap(_.planetaryNebulaSpectrum)
 
-  implicit val arbPowerLaw: Arbitrary[PowerLaw] =
+  given Arbitrary[PowerLaw] =
     Arbitrary(arbitrary[BigDecimal].map(PowerLaw(_)))
 
-  implicit val cogPowerLaw: Cogen[PowerLaw] =
+  given Cogen[PowerLaw] =
     Cogen[BigDecimal].contramap(_.index)
 
-  implicit val arbBlackBody: Arbitrary[BlackBody] =
+  given Arbitrary[BlackBody] =
     Arbitrary(
       Gen
         .choose(1, 10000)
         .map(a => BlackBody(refineV[Positive](a).toOption.get.withUnit[Kelvin]))
     )
 
-  implicit val cogBlackBody: Cogen[BlackBody] =
+  given Cogen[BlackBody] =
     Cogen[BigDecimal].contramap(_.temperature.value.value)
 
-  implicit val arbUserDefined: Arbitrary[UserDefined] =
+  given Arbitrary[UserDefined] =
     Arbitrary(
       arbitrary[NonEmptyMap[Wavelength, PosBigDecimal]].map(UserDefined(_))
     )
 
-  implicit val cogUserDefined: Cogen[UserDefined] =
+  given Cogen[UserDefined] =
     Cogen[Map[Wavelength, PosBigDecimal]].contramap(_.fluxDensities.toSortedMap)
 
-  implicit def arbSpectralDistribution[T]: Arbitrary[UnnormalizedSED] =
+  given Arbitrary[UnnormalizedSED] =
     Arbitrary(
       Gen.oneOf(
         arbitrary[StellarLibrary],
@@ -111,7 +111,7 @@ trait ArbUnnormalizedSED {
       )
     )
 
-  implicit def cogSpectralDistribution[T]: Cogen[UnnormalizedSED] =
+  given Cogen[UnnormalizedSED] =
     Cogen[Either[
       StellarLibrary,
       Either[

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SourceProfileSuite.scala
@@ -5,6 +5,7 @@ package lucuma.core.model
 
 import cats.Order.*
 import cats.kernel.laws.discipline.*
+import cats.syntax.all.*
 import coulomb.*
 import coulomb.syntax.*
 import eu.timepit.refined.cats.*
@@ -32,16 +33,16 @@ final class SourceProfileSuite extends DisciplineSuite {
   import ArbEnumerated.*
   import ArbMeasure.*
   import ArbRefined.*
-  import ArbSourceProfile.*
-  import ArbSpectralDefinition.*
-  import ArbUnnormalizedSED.*
+  import ArbSourceProfile.given
+  import ArbSpectralDefinition.given
+  import ArbUnnormalizedSED.given
   import ArbWavelength.*
   import ArbCollection.*
 
   // Conversions
   val sd1Integrated: SpectralDefinition[Integrated] =
     SpectralDefinition.BandNormalized(
-      UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
+      UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I).some,
       SortedMap(
         Band.R -> Band.R.defaultUnits[Integrated].withValueTagged(BigDecimal(10.0))
       )
@@ -49,7 +50,7 @@ final class SourceProfileSuite extends DisciplineSuite {
 
   val sd1Surface: SpectralDefinition[Surface] =
     SpectralDefinition.BandNormalized(
-      UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
+      UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I).some,
       SortedMap(
         Band.R -> Band.R.defaultUnits[Surface].withValueTagged(BigDecimal(10.0))
       )

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/SpectralDefinitionSuite.scala
@@ -3,11 +3,12 @@
 
 package lucuma.core.model
 
-import cats.Order._
-import cats.kernel.laws.discipline._
+import cats.Order.*
+import cats.kernel.laws.discipline.*
+import cats.syntax.all.*
 import coulomb.*
 import coulomb.syntax.*
-import eu.timepit.refined.cats._
+import eu.timepit.refined.cats.*
 import lucuma.core.enums.Band
 import lucuma.core.enums.StellarLibrarySpectrum
 import lucuma.core.math.BrightnessUnits
@@ -15,30 +16,30 @@ import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbRefined
 import lucuma.core.math.arb.ArbWavelength
 import lucuma.core.math.dimensional.arb.ArbMeasure
-import lucuma.core.math.units._
-import lucuma.core.model.arb._
+import lucuma.core.math.units.*
+import lucuma.core.model.arb.*
 import lucuma.core.util.arb.ArbCollection
 import lucuma.core.util.arb.ArbEnumerated
-import monocle.law.discipline._
-import munit._
+import monocle.law.discipline.*
+import munit.*
 
 import scala.collection.immutable.SortedMap
 
 final class SpectralDefinitionSuite extends DisciplineSuite {
-  import ArbUnnormalizedSED._
-  import ArbEnumerated._
-  import BrightnessUnits._
-  import ArbSpectralDefinition._
-  import ArbRefined._
-  import ArbMeasure._
-  import ArbEmissionLine._
-  import ArbCollection._
-  import ArbWavelength._
+  import ArbUnnormalizedSED.given
+  import ArbEnumerated.*
+  import BrightnessUnits.*
+  import ArbSpectralDefinition.given
+  import ArbRefined.*
+  import ArbMeasure.*
+  import ArbEmissionLine.*
+  import ArbCollection.*
+  import ArbWavelength.*
 
   // Brightness type conversions
   val sd1Integrated: SpectralDefinition[Integrated] =
     SpectralDefinition.BandNormalized(
-      UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
+      UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I).some,
       SortedMap(
         Band.R -> Band.R.defaultUnits[Integrated].withValueTagged(BigDecimal(10.0))
       )
@@ -46,7 +47,7 @@ final class SpectralDefinitionSuite extends DisciplineSuite {
 
   val sd1Surface: SpectralDefinition[Surface] =
     SpectralDefinition.BandNormalized(
-      UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I),
+      UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.A0I).some,
       SortedMap(
         Band.R -> Band.R.defaultUnits[Surface].withValueTagged(BigDecimal(10.0))
       )

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -20,7 +20,7 @@ import munit.*
 
 final class TargetSuite extends DisciplineSuite {
   import ArbTarget.given
-  import ArbSourceProfile.*
+  import ArbSourceProfile.given
   import ArbSiderealTracking.given
   import ArbEphemerisKey.*
   import ArbParallax.*
@@ -35,9 +35,9 @@ final class TargetSuite extends DisciplineSuite {
   import ArbCatalogInfo.*
   import Target.*
   import ArbEmissionLine.*
-  import ArbSpectralDefinition.*
+  import ArbSpectralDefinition.given
   import ArbAngle.*
-  import ArbUnnormalizedSED.*
+  import ArbUnnormalizedSED.given
   import ArbRefined.*
   import ArbMeasure.*
   import ArbCollection.*

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/UnnormalizedSEDSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/UnnormalizedSEDSuite.scala
@@ -16,7 +16,7 @@ import munit.*
 
 final class UnnormalizedSEDSuite extends DisciplineSuite {
   import UnnormalizedSED.*
-  import ArbUnnormalizedSED.*
+  import ArbUnnormalizedSED.given
   import ArbEnumerated.*
   import ArbQuantity.given
   import ArbRefined.*


### PR DESCRIPTION
Currently we require an SED which in many cases we don't know and thus we default to e.g. A0V which is missleading