### PR TITLE
fix crash in AirMass class init

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.61"
+ThisBuild / tlBaseVersion                         := "0.62"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ElevationRange.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ElevationRange.scala
@@ -37,7 +37,7 @@ object ElevationRange {
 
     type Value        = Interval.Closed[MinValue.type, MaxValue.type]
     type DecimalValue = BigDecimal Refined Value
-    object DecimalValue extends RefinedTypeOps[DecimalValue, BigDecimal]
+    val DecimalValue = new RefinedTypeOps[DecimalValue, BigDecimal]
 
     val DefaultMin: DecimalValue = DecimalValue.unsafeFrom(BigDecimal(1.0))
     val DefaultMax: DecimalValue = DecimalValue.unsafeFrom(BigDecimal(2.0))


### PR DESCRIPTION
This fixes an initialization order problem that was crashing the ODB:

```
sbt:root> coreJVM/console
Welcome to Scala 3.2.1 (11.0.11, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                 
scala> import lucuma.core.model.ElevationRange.AirMass
                                                                                                                                                 
scala> AirMass.DecimalValue.unsafeFrom(1);
java.lang.NullPointerException
  at lucuma.core.model.ElevationRange$AirMass$.<clinit>(ElevationRange.scala:42)
  at lucuma.core.model.ElevationRange$AirMass$DecimalValue$.<init>(ElevationRange.scala:40)
  at lucuma.core.model.ElevationRange$AirMass$DecimalValue$.<clinit>(ElevationRange.scala:40)
  ... 66 elided
```
     
After the fix:

```
sbt:root> coreJVM/console
Welcome to Scala 3.2.1 (11.0.11, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                 
scala> import lucuma.core.model.ElevationRange.AirMass
                                                                                                                                                 
scala> AirMass.DecimalValue.unsafeFrom(1);
val res0: lucuma.core.model.ElevationRange.AirMass.DecimalValue = 1
```
