### PR TITLE
Limit arbitrary atom and sequence size

### DIFF
--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbAtom.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbAtom.scala
@@ -16,22 +16,26 @@ trait ArbAtom {
   import ArbUid._
   import ArbStep._
 
-  implicit val arbAtomGmosNorth: Arbitrary[Atom.GmosNorth] = Arbitrary(
+  private def genBoundedAtom[A: Arbitrary, B](limit: Int, f: (Atom.Id, List[A]) => B): Gen[B] =
     for {
       id    <- arbitrary[Atom.Id]
-      steps <- arbitrary[List[Step.GmosNorth]]
-    } yield Atom.GmosNorth(id, steps)
-  )
+      steps <- genBoundedList[A](limit)
+    } yield f(id, steps)
+
+  def genBoundedAtomGmosNorth(limit: Int): Gen[Atom.GmosNorth] =
+    genBoundedAtom[Step.GmosNorth, Atom.GmosNorth](limit, Atom.GmosNorth.apply)
+
+  implicit val arbAtomGmosNorth: Arbitrary[Atom.GmosNorth] =
+    Arbitrary(genBoundedAtomGmosNorth(10))
 
   implicit val cogAtomGmosNorth: Cogen[Atom.GmosNorth] =
     Cogen[(Atom.Id, List[Step.GmosNorth])].contramap(a => (a.id, a.steps))
 
-  implicit val arbAtomGmosSouth: Arbitrary[Atom.GmosSouth] = Arbitrary(
-    for {
-      id    <- arbitrary[Atom.Id]
-      steps <- arbitrary[List[Step.GmosSouth]]
-    } yield Atom.GmosSouth(id, steps)
-  )
+  def genBoundedAtomGmosSouth(limit: Int): Gen[Atom.GmosSouth] =
+    genBoundedAtom[Step.GmosSouth, Atom.GmosSouth](limit, Atom.GmosSouth.apply)
+
+  implicit val arbAtomGmosSouth: Arbitrary[Atom.GmosSouth] =
+    Arbitrary(genBoundedAtomGmosSouth(10))
 
   implicit val cogAtomGmosSouth: Cogen[Atom.GmosSouth] =
     Cogen[(Atom.Id, List[Step.GmosSouth])].contramap(a => (a.id, a.steps))

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbExecutionSequence.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbExecutionSequence.scala
@@ -16,22 +16,26 @@ trait ArbExecutionSequence {
   import ArbUid._
   import ArbAtom._
 
-  implicit val arbExecutionSequenceGmosNorth: Arbitrary[ExecutionSequence.GmosNorth] = Arbitrary(
+  private def genBoundedExecutionSequence[A: Arbitrary, B](limit: Int, f: (A, List[A]) => B): Gen[B] =
     for {
-      nextAtom       <- arbitrary[Atom.GmosNorth]
-      possibleFuture <- arbitrary[List[Atom.GmosNorth]]
-    } yield ExecutionSequence.GmosNorth(nextAtom, possibleFuture)
-  )
+      nextAtom       <- arbitrary[A]
+      possibleFuture <- genBoundedList[A](limit)
+    } yield f(nextAtom, possibleFuture)
+
+  def genBoundedExecutionSequenceGmosNorth(limit: Int): Gen[ExecutionSequence.GmosNorth] =
+    genBoundedExecutionSequence[Atom.GmosNorth, ExecutionSequence.GmosNorth](limit, ExecutionSequence.GmosNorth.apply)
+
+  implicit val arbExecutionSequenceGmosNorth: Arbitrary[ExecutionSequence.GmosNorth] =
+    Arbitrary(genBoundedExecutionSequenceGmosNorth(10))
 
   implicit val cogExecutionSequenceGmosNorth: Cogen[ExecutionSequence.GmosNorth] =
     Cogen[(Atom.GmosNorth, List[Atom.GmosNorth])].contramap(s => (s.nextAtom, s.possibleFuture))
 
-  implicit val arbExecutionSequenceGmosSouth: Arbitrary[ExecutionSequence.GmosSouth] = Arbitrary(
-    for {
-      nextAtom       <- arbitrary[Atom.GmosSouth]
-      possibleFuture <- arbitrary[List[Atom.GmosSouth]]
-    } yield ExecutionSequence.GmosSouth(nextAtom, possibleFuture)
-  )
+  def genBoundedExecutionSequenceGmosSouth(limit: Int): Gen[ExecutionSequence.GmosSouth] =
+    genBoundedExecutionSequence[Atom.GmosSouth, ExecutionSequence.GmosSouth](limit, ExecutionSequence.GmosSouth.apply)
+
+  implicit val arbExecutionSequenceGmosSouth: Arbitrary[ExecutionSequence.GmosSouth] =
+    Arbitrary(genBoundedExecutionSequenceGmosSouth(10))
 
   implicit val cogExecutionSequenceGmosSouth: Cogen[ExecutionSequence.GmosSouth] =
     Cogen[(Atom.GmosSouth, List[Atom.GmosSouth])].contramap(s => (s.nextAtom, s.possibleFuture))

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/util.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/util.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.arb
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+
+def genBoundedList[A: Arbitrary](limit: Int): Gen[List[A]] =
+  Gen.choose(0, limit).flatMap(sz => Gen.listOfN(sz, arbitrary[A]))
+

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/AtomSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/AtomSuite.scala
@@ -9,15 +9,12 @@ import lucuma.core.util.arb._
 import lucuma.core.util.laws.UidTests
 import monocle.law.discipline._
 import munit._
-import org.scalacheck.Test
 
 final class AtomSuite extends DisciplineSuite {
   import ArbStep._
   import ArbEnumerated._
   import ArbUid._
   import ArbAtom._
-
-  override val scalaCheckTestParameters = Test.Parameters.default.withMaxSize(20)
 
   checkAll("Eq[Atom.GmosNorth]", EqTests[Atom.GmosNorth].eqv)
   checkAll("Atom.GmosNorth.id", LensTests(Atom.GmosNorth.id))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/ExecutionSequenceSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/ExecutionSequenceSuite.scala
@@ -7,13 +7,10 @@ import cats.kernel.laws.discipline._
 import lucuma.core.model.sequence.arb._
 import monocle.law.discipline._
 import munit._
-import org.scalacheck.Test
 
 final class ExecutionSequenceSuite extends DisciplineSuite {
   import ArbAtom._
   import ArbExecutionSequence._
-
-  override val scalaCheckTestParameters = Test.Parameters.default.withMaxSize(10)
 
   checkAll("Eq[ExecutionSequence.GmosNorth]", EqTests[ExecutionSequence.GmosNorth].eqv)
   checkAll("ExecutionSequence.GmosNorth.nextAtom", LensTests(ExecutionSequence.GmosNorth.nextAtom))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/FutureExecutionConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/FutureExecutionConfigSuite.scala
@@ -8,7 +8,6 @@ import lucuma.core.model.sequence.arb._
 import lucuma.core.util.arb._
 import monocle.law.discipline._
 import munit._
-import org.scalacheck.Test
 
 final class FutureExecutionConfigSuite extends DisciplineSuite {
   import ArbEnumerated._
@@ -16,8 +15,6 @@ final class FutureExecutionConfigSuite extends DisciplineSuite {
   import ArbStaticConfig._
   import ArbFutureExecutionConfig._
   import ArbExecutionSequence._
-
-  override val scalaCheckTestParameters = Test.Parameters.default.withMaxSize(10)
 
   checkAll("Eq[FutureExecutionConfig.GmosNorth]", EqTests[FutureExecutionConfig.GmosNorth].eqv)
   checkAll("FutureExecutionConfig.GmosNorth.static",


### PR DESCRIPTION
Currently arbitrary atoms contain an arbitrarily sized list of steps and arbitrary sequences contain an arbitrarily sized list of atoms.  The combination can get quite big, especially for the `FutureExecutionConfig` which contains two sequences.  Since this impacts test run time considerably the goal is to limit these sizes to something more manageable.