### PR TITLE
NonEmptyList / Zipper syntax

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/NonEmpty.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/NonEmpty.scala
@@ -13,20 +13,27 @@ import scala.annotation.tailrec
 
 trait NonEmptyOps {
 
-  extension [A: Order](self: NonEmptyList[A]) {
+  extension [A](self: NonEmptyList[A]) {
+
+    /**
+     * Creates a Zipper from a NonEmptyList.  The first element of the NEL
+     * becomes the focus.
+     */
+    def toZipper: Zipper[A] =
+      Zipper.fromNel(self)
 
     /**
      * Creates a Zipper from the NonEmptyList where the focused element is the
      * minimum according to the `Order` instance for `A`.
      */
-    def focusMin: Zipper[A] =
+    def toZipperMin(implicit ev: Order[A]): Zipper[A] =
       focusCompare(_ < _)
 
     /**
      * Creates a Zipper from the NonEmptyList where the focused element is the
      * maximum according to the `Order` instance for `A`.
      */
-    def focusMax: Zipper[A] =
+    def toZipperMax(implicit ev: Order[A]): Zipper[A] =
       focusCompare(_ > _)
 
     private def focusCompare(f: (A, A) => Boolean) = {

--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/NonEmpty.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/NonEmpty.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.syntax
+
+import cats.Order
+import cats.data.NonEmptyList
+import cats.syntax.foldable.*
+import cats.syntax.order.*
+import lucuma.core.data.Zipper
+
+import scala.annotation.tailrec
+
+trait NonEmptyOps {
+
+  extension [A: Order](self: NonEmptyList[A]) {
+
+    /**
+     * Creates a Zipper from the NonEmptyList where the focused element is the
+     * minimum according to the `Order` instance for `A`.
+     */
+    def focusMin: Zipper[A] =
+      focusCompare(_ < _)
+
+    /**
+     * Creates a Zipper from the NonEmptyList where the focused element is the
+     * maximum according to the `Order` instance for `A`.
+     */
+    def focusMax: Zipper[A] =
+      focusCompare(_ > _)
+
+    private def focusCompare(f: (A, A) => Boolean) = {
+
+      @tailrec
+      def go(cur: Zipper[A], res: Zipper[A]): Zipper[A] =
+        cur.next match {
+          case None    => res
+          case Some(n) => if (f(n.focus, res.focus)) go(n, n) else go(n, res)
+        }
+
+      val init = Zipper.fromNel(self)
+      go(init, init)
+    }
+
+  }
+
+}
+
+object nonempty extends NonEmptyOps

--- a/modules/core/shared/src/main/scala/lucuma/core/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/syntax/package.scala
@@ -13,7 +13,8 @@ import lucuma.core.optics.syntax.ToPrismOps
  */
 package object syntax {
   object all
-      extends ToDisplayOps
+      extends NonEmptyOps
+      with ToDisplayOps
       with TimeOps
       with ToEnumeratedOps
       with ToIntOps

--- a/modules/tests/shared/src/test/scala/lucuma/core/syntax/NonEmptySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/syntax/NonEmptySuite.scala
@@ -12,7 +12,7 @@ import nonempty.*
 
 class NonEmptySuite extends munit.ScalaCheckSuite {
 
-  test("focusMax") {
+  test("toZipperMax") {
     forAll { (h: Int, t: List[Int]) =>
       val nel = NonEmptyList(h, t)
       val z   = nel.toZipperMax
@@ -21,7 +21,7 @@ class NonEmptySuite extends munit.ScalaCheckSuite {
     }
   }
 
-  test("focusMin") {
+  test("toZipperMin") {
     forAll { (h: Int, t: List[Int]) =>
       val nel = NonEmptyList(h, t)
       val z   = nel.toZipperMin

--- a/modules/tests/shared/src/test/scala/lucuma/core/syntax/NonEmptySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/syntax/NonEmptySuite.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma
+package core
+package syntax
+
+import cats.data.NonEmptyList
+import org.scalacheck.Prop._
+
+import nonempty.*
+
+class NonEmptySuite extends munit.ScalaCheckSuite {
+
+  test("focusMax") {
+    forAll { (h: Int, t: List[Int]) =>
+      val nel = NonEmptyList(h, t)
+      val z   = nel.focusMax
+      assertEquals(z.focus, nel.toList.max)
+      assertEquals(z.toNel, nel)
+    }
+  }
+
+  test("focusMin") {
+    forAll { (h: Int, t: List[Int]) =>
+      val nel = NonEmptyList(h, t)
+      val z   = nel.focusMin
+      assertEquals(z.focus, nel.toList.min)
+      assertEquals(z.toNel, nel)
+    }
+  }
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/syntax/NonEmptySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/syntax/NonEmptySuite.scala
@@ -15,7 +15,7 @@ class NonEmptySuite extends munit.ScalaCheckSuite {
   test("focusMax") {
     forAll { (h: Int, t: List[Int]) =>
       val nel = NonEmptyList(h, t)
-      val z   = nel.focusMax
+      val z   = nel.toZipperMax
       assertEquals(z.focus, nel.toList.max)
       assertEquals(z.toNel, nel)
     }
@@ -24,7 +24,7 @@ class NonEmptySuite extends munit.ScalaCheckSuite {
   test("focusMin") {
     forAll { (h: Int, t: List[Int]) =>
       val nel = NonEmptyList(h, t)
-      val z   = nel.focusMin
+      val z   = nel.toZipperMin
       assertEquals(z.focus, nel.toList.min)
       assertEquals(z.toNel, nel)
     }


### PR DESCRIPTION
Adds a bit of syntax to create `Zipper`s from `NonEmptyList` where the focused element is a min or max according to `Order`.  I suppose this could alternatively just be added to the `Zipper` companion.