### PR TITLE
ValidFilter + value in errors

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/units.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/units.scala
@@ -142,6 +142,8 @@ trait units {
 
   given ValueConversion[Parallax.LongParallaxμas, Rational] = Rational(_)
 
+  given refinedValueConversion[V, P]: ValueConversion[V Refined P, V] = _.value
+
   inline given [UF, UT]: TruncatingUnitConversion[PosInt, UF, UT] = v =>
     refineV[Positive](coulomb.conversion.standard.unit.ctx_TUC_Int(v))
       .getOrElse(1.refined[Positive])

--- a/modules/core/shared/src/main/scala/lucuma/core/model/validation/ModelValidators.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/validation/ModelValidators.scala
@@ -20,7 +20,7 @@ object ModelValidators {
       .truncatedBigDecimal(decimals = 1.refined)
       .andThen(
         ValidSplitEpi
-          .forRefined[String, BigDecimal, ElevationRange.AirMass.Value](airMassErrorMsg)
+          .forRefined[String, BigDecimal, ElevationRange.AirMass.Value](_ => airMassErrorMsg)
           .toErrorsValidSplitEpiUnsafe
       )
 
@@ -29,7 +29,7 @@ object ModelValidators {
       .truncatedBigDecimal(decimals = 1.refined)
       .andThen(
         ValidSplitEpi
-          .forRefined[String, BigDecimal, ElevationRange.HourAngle.Hour](hourAngleErrorMsg)
+          .forRefined[String, BigDecimal, ElevationRange.HourAngle.Hour](_ => hourAngleErrorMsg)
           .toErrorsValidSplitEpiUnsafe
       )
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/ValidFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/ValidFilter.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.optics
+
+import cats.Order
+import cats.data.Validated
+import cats.syntax.all.*
+import monocle.Iso
+import monocle.Prism
+
+/**
+ * A validating one-way endomorphic optic. `getValid` wraps a function that validates a value
+ * without modifying it. `reverseGet` is always `identity`.
+ * 
+ * No laws are necessary for this optic.
+ */
+case class ValidFilter[E, A](filter: A => IsValid[E]) extends ValidFormat[E, A, A] with Serializable { self =>
+  final val getValid: A => Either[E, A] = 
+    a => filter(a) match
+      case IsValid.Valid => a.asRight
+      case IsValid.Invalid(e) => e.asLeft
+    
+  final val reverseGet: A => A = identity
+
+  /** Always return a single instance of `E` in case of an invalid `T`. */
+  def withError(e: E): ValidFilter[E, A] =
+    ValidFilter(filter.andThen(_.mapError(_ => e)))
+
+  /** Build a `ValidSplitEpi` with the same functionality. */
+  def asValidSplitEpi: ValidSplitEpi[E, A, A] =
+    ValidSplitEpi(getValid, reverseGet)
+
+  /** Build a `ValidWedge` with the same functionality. */
+  def asValidWedge: ValidWedge[E, A, A] =
+    ValidWedge(getValid, reverseGet)
+
+  /** Build a `Format` with the same funcionality, discarding the `E` instances. */
+  def toFormat: Format[A, A] =
+    Format(getValid.andThen(_.toOption), reverseGet)
+
+  /** Build a `Prism` with the same funcionality, discarding the `E` instances. */
+  def toPrism: Prism[A, A] =
+    Prism(getValid.andThen(_.toOption))(reverseGet)
+
+  /** Compose with a `ValidSplitEpi`. */
+  def andThen[B](f: ValidSplitEpi[E, A, B]): ValidSplitEpi[E, A, B] =
+    asValidSplitEpi.andThen(f)
+}
+
+object ValidFilter:
+  /**
+   * Build optic from getValid and reverseGet functions.
+   */
+  def apply[E, A](filter: A => Boolean, error: A => E): ValidFilter[E, A] =
+    ValidFilter[E, A](a => if(filter(a)) IsValid.Valid else IsValid.Invalid(error(a)))
+
+  def apply[E]: Applied[E] = new Applied[E] {}
+
+  trait Applied[E]:
+    def gt[A: Order](bound: A, error: A => E): ValidFilter[E, A] =
+      ValidFilter[E, A](_ > bound, error)
+
+    def lt[A: Order](bound: A, error: A => E): ValidFilter[E, A] =
+      ValidFilter[E, A](_ < bound, error)
+
+    def gte[A: Order](bound: A, error: A => E): ValidFilter[E, A] =
+      ValidFilter[E, A](_ >= bound, error)
+
+    def lte[A: Order](bound: A, error: A => E): ValidFilter[E, A] =
+      ValidFilter[E, A](_ <= bound, error)
+
+    

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/ValidFormat.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/ValidFormat.scala
@@ -13,4 +13,10 @@ trait ValidFormat[E, A, B] {
   val getValid: A => Either[E, B]
 
   val reverseGet: B => A
+
+  /** Like getValid, but throws IllegalArgumentException when Invalid. */
+  def unsafeGet(a: A): B =
+    getValid(a).getOrElse {
+      throw new IllegalArgumentException(s"unsafeGet failed: $a")
+    }
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/package.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.core
+package lucuma.core.optics
 
 import coulomb.*
 import coulomb.syntax.*
@@ -11,12 +11,19 @@ import eu.timepit.refined.refineV
 import monocle.Iso
 import monocle.Prism
 
-package object optics {
+/** Prism from `A` into `A` with refined predicate `P`. */
+def refinedPrism[A, P](implicit v: Validate[A, P]): Prism[A, A Refined P] =
+  Prism[A, A Refined P](i => refineV[P](i).toOption)(_.value)
 
-  /** Prism from `A` into `A` with refined predicate `P`. */
-  def refinedPrism[A, P](implicit v: Validate[A, P]): Prism[A, A Refined P] =
-    Prism[A, A Refined P](i => refineV[P](i).toOption)(_.value)
+/** Iso for coulomb quantities */
+def quantityIso[N, U] = Iso[Quantity[N, U], N](_.value)(_.withUnit[U])
 
-  /** Iso for coulomb quantities */
-  def quantityIso[N, U] = Iso[Quantity[N, U], N](_.value)(_.withUnit[U])
-}
+sealed trait IsValid[+E]:
+  def mapError[E0](f: E => E0): IsValid[E0]
+
+object IsValid:
+  case object Valid extends IsValid[Nothing]:
+    override def mapError[E0](f: Nothing => E0): IsValid[E0] = this
+    
+  case class Invalid[E](error: E) extends IsValid[E]:
+    override def mapError[E0](f: E => E0): IsValid[E0] = Invalid(f(error))

--- a/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidSplitEpi.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidSplitEpi.scala
@@ -79,13 +79,13 @@ object InputValidSplitEpi {
   def refinedString[P](implicit
     v: RefinedValidate[String, P]
   ): InputValidSplitEpi[String Refined P] =
-    id.refined[P](NonEmptyChain("Invalid value".refined))
+    id.refined[P](_ => NonEmptyChain("Invalid value".refined))
 
   /**
    * `InputValidSplitEpi` for `NonEmptyString`
    */
   val nonEmptyString: InputValidSplitEpi[NonEmptyString] =
-    refinedString[NonEmpty].withErrorMessage("Must be defined".refined)
+    refinedString[NonEmpty].withErrorMessage(_ => "Must be defined".refined)
 
   /**
    * `InputValidSplitEpi` for `Int`
@@ -100,7 +100,7 @@ object InputValidSplitEpi {
    * Build a `InputValidSplitEpi` for `Int Refined P`
    */
   def refinedInt[P](implicit v: RefinedValidate[Int, P]): InputValidSplitEpi[Int Refined P] =
-    int.refined[P](NonEmptyChain("Invalid format".refined))
+    int.refined[P](_ => NonEmptyChain("Invalid format".refined))
 
   /**
    * `InputValidSplitEpi` for `PosInt`
@@ -126,7 +126,7 @@ object InputValidSplitEpi {
   def refinedBigDecimal[P](implicit
     v: RefinedValidate[BigDecimal, P]
   ): InputValidSplitEpi[BigDecimal Refined P] =
-    bigDecimal.refined[P](NonEmptyChain("Invalid format".refined))
+    bigDecimal.refined[P](_ => NonEmptyChain("Invalid format".refined))
 
   /**
    * `InputValidSplitEpi` for `PosBigDecimal`
@@ -150,7 +150,7 @@ object InputValidSplitEpi {
   def refinedBigDecimalWithScientificNotation[P](implicit
     v: RefinedValidate[BigDecimal, P]
   ): InputValidSplitEpi[BigDecimal Refined P] =
-    bigDecimalWithScientificNotation.refined[P](NonEmptyChain("Invalid format".refined))
+    bigDecimalWithScientificNotation.refined[P](_ => NonEmptyChain("Invalid format".refined))
 
   /**
    * `InputValidSplitEpi` for `PosBigDecimal`, formatting with only one integer digit.

--- a/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidWedge.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidWedge.scala
@@ -88,7 +88,7 @@ object InputValidWedge {
   def truncatedPosBigDecimal(decimals: DigitCount): InputValidWedge[PosBigDecimal] = {
     val base     = truncatedBigDecimal(decimals).andThen(
       ValidWedge.forRefined[NonEmptyChain[NonEmptyString], BigDecimal, Positive](
-        NonEmptyChain("Invalid format".refined)
+        _ => NonEmptyChain("Invalid format".refined)
       )
     )
     val minValue = "0." + "0" * (decimals.value - 1) + "1"

--- a/modules/core/shared/src/main/scala/lucuma/core/validation/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/validation/package.scala
@@ -69,8 +69,8 @@ package object validation {
       )
 
   extension[A](self: InputValidWedge[A])
-    def withErrorMessage(msg: NonEmptyString): InputValidWedge[A] =
-      self.withError(NonEmptyChain(msg))
+    def withErrorMessage(msg: String => NonEmptyString): InputValidWedge[A] =
+      self.withError(str => NonEmptyChain(msg(str)))
 
     /**
      * Build an `InputValidWedge[NonEmptyList[A]]` given a `InputValidWedge[A]`
@@ -85,8 +85,8 @@ package object validation {
       )
 
   extension[A](self: InputValidSplitEpi[A])
-    def withErrorMessage(msg: NonEmptyString): InputValidSplitEpi[A] =
-      self.withError(NonEmptyChain(msg))
+    def withErrorMessage(msg: String => NonEmptyString): InputValidSplitEpi[A] =
+      self.withError(str => NonEmptyChain(msg(str)))
 
     /**
      * Build an `InputValidSplitEpi[NonEmptyList[A]]` given a `InputValidSplitEpi[A]`


### PR DESCRIPTION
- Introduce a `ValidFilter` optic, composable with `ValidWedge` and `ValidSplitEpi`, to perform simple validations without transforming the value. Allows composing a `ValidSplitEpi` parser validator with, for example, checking that a parsed numeric value is within certain bounds.
- Add the input value as a parameter to the error instances. Allows error messages like `Value XXX is out of bounds`.