### PR TITLE
Make Proposal.toOActivation optional

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.64"
+ThisBuild / tlBaseVersion                         := "0.65"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Proposal.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Proposal.scala
@@ -21,7 +21,7 @@ final case class Proposal(
   title:         Option[NonEmptyString],
   proposalClass: ProposalClass,
   category:      Option[TacCategory],
-  toOActivation: ToOActivation,
+  toOActivation: Option[ToOActivation],
   abstrakt:      Option[NonEmptyString],
   partnerSplits: SortedMap[Partner, IntPercent]
 )
@@ -35,7 +35,7 @@ object Proposal {
   val partnerSplits = Focus[Proposal](_.partnerSplits)
 
   val Default: Proposal =
-    Proposal(None, ProposalClass.Queue(80.refined), None, ToOActivation.None, None, SortedMap.empty)
+    Proposal(None, ProposalClass.Queue(80.refined), None, ToOActivation.None.some, None, SortedMap.empty)
 
   implicit val eqProposal: Eq[Proposal] = Eq.instance {
     case (Proposal(t1, pc1, c1, to1, a1, ps1), Proposal(t2, pc2, c2, to2, a2, ps2)) =>

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbProposal.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbProposal.scala
@@ -31,7 +31,7 @@ trait ArbProposal {
         title    <- arbitrary[Option[NonEmptyString]]
         pClass   <- arbitrary[ProposalClass]
         category <- arbitrary[Option[TacCategory]]
-        too      <- arbitrary[ToOActivation]
+        too      <- arbitrary[Option[ToOActivation]]
         abstrakt <- arbitrary[Option[NonEmptyString]]
         splits   <- arbitrary[SortedMap[Partner, IntPercent]]
       } yield Proposal(title, pClass, category, too, abstrakt, splits)
@@ -42,7 +42,7 @@ trait ArbProposal {
       (Option[NonEmptyString],
        ProposalClass,
        Option[TacCategory],
-       ToOActivation,
+       Option[ToOActivation],
        Option[NonEmptyString],
        SortedMap[Partner, IntPercent]
       )


### PR DESCRIPTION
`toOActivation` is (and has been) optional in the API, so it should be optional in the model as well. I just never noticed this before, because Explore always sends a value for it.