### PR TITLE
Limited precision values for BrightnessValue

### DIFF
--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbBrightnessValue.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbBrightnessValue.scala
@@ -8,7 +8,7 @@ import lucuma.core.math.BrightnessValue
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
 
-trait ArbBrightnessValue:
+trait ArbBrightnessValue extends LimitedBigDecimals:
   given Arbitrary[BrightnessValue] = newTypeArbitrary(BrightnessValue)
   given Cogen[BrightnessValue] = newTypeCogen(BrightnessValue)
 

--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/LimitedBigDecimals.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/LimitedBigDecimals.scala
@@ -1,23 +1,22 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.core.validation
+package lucuma.core.math.arb
 
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import org.scalacheck.Arbitrary
 
 trait LimitedBigDecimals:
-  // The scientific notation formatters use `java.text.DecimalFormat` which in Scala.js seems
-  // to have trouble formatting BigDecimals with very high absolute scale or precision.
+  // Scala.js seems to have trouble formatting BigDecimals with very high absolute scale or precision.
   // We therefore use these bounded arbitraries.
-  implicit lazy val arbBigDecimalLimitedPrecision: Arbitrary[BigDecimal] =
+  implicit protected lazy val arbBigDecimalLimitedPrecision: Arbitrary[BigDecimal] =
     Arbitrary(
       org.scalacheck.Arbitrary.arbBigDecimal.arbitrary.suchThat(x =>
         x.scale.abs < 100 && x.precision <= 15
       )
     )
 
-  implicit lazy val arbPosBigDecimalLimitedPrecision: Arbitrary[PosBigDecimal] =
+  implicit protected lazy val arbPosBigDecimalLimitedPrecision: Arbitrary[PosBigDecimal] =
     Arbitrary(
       arbBigDecimalLimitedPrecision.arbitrary
         .map(_.abs)

--- a/modules/tests/shared/src/test/scala/lucuma/core/validation/InputValidSplitEpiInstancesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/validation/InputValidSplitEpiInstancesSuite.scala
@@ -6,6 +6,7 @@ package lucuma.core.validation
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.scalacheck.all.*
 import eu.timepit.refined.types.numeric.PosBigDecimal
+import lucuma.core.math.arb.LimitedBigDecimals
 import lucuma.core.optics.laws.discipline.ValidSplitEpiTests
 import munit.DisciplineSuite
 import org.scalacheck.Arbitrary


### PR DESCRIPTION
Make `LimitedBigDecimals` available in testkit too.