### PR TITLE
Fix BoundedInterval constructor, tests, duration for Instant

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/BoundedInterval.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BoundedInterval.scala
@@ -23,7 +23,7 @@ opaque type BoundedInterval[A] = Bounded[A] | Point[A]
 
 object BoundedInterval:
   def fromInterval[A: Order](interval: Interval[A]): Option[BoundedInterval[A]] =
-    interval.some.filterNot(_.isEmpty).map(_.asInstanceOf[BoundedInterval[A]])
+    interval.some.filterNot(_.isEmpty).filter(_.isBounded).map(_.asInstanceOf[BoundedInterval[A]])
 
   def closed[A: Order](lower: A, upper: A): Option[BoundedInterval[A]] = 
     fromInterval(Interval.closed(lower, upper))

--- a/modules/core/shared/src/main/scala/lucuma/core/math/BoundedInterval.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BoundedInterval.scala
@@ -7,6 +7,7 @@ import algebra.ring.AdditiveMonoid
 import cats.Eq
 import cats.Order
 import cats.syntax.all.*
+import lucuma.core.optics.Format
 import spire.math.Bounded
 import spire.math.Empty
 import spire.math.Interval
@@ -163,3 +164,33 @@ object BoundedInterval:
   extension (self: IntervalSeq.type)
     def apply[T: Order](i: BoundedInterval[T]): IntervalSeq[T] =
       self(i.toInterval)
+
+   /**
+   * Makes a best-effort attempt to convert the tuple (a, b) into interval [a, b) or [b, a).
+   *
+   * It's a Format to contemplate the case of tuple (a, a).
+   */
+  def openUpperFromTuple[A: Order]: Format[(A, A), BoundedInterval[A]] =
+    Format[(A, A), BoundedInterval[A]](
+      { case (start, end) =>
+        if (start < end)(BoundedInterval.unsafeOpenUpper(start, end)).some
+        else if (start > end)(BoundedInterval.unsafeOpenUpper(end, start)).some
+        else none
+      },
+      i => (i.lower, i.upper)
+    )
+
+  /**
+   * Makes a best-effort attempt to convert the tuple (a, b) into interval [a, b] or [b, a].
+   *
+   * It's a Format to contemplate the case of tuple (a, a).
+   */
+  def closedFromTuple[A: Order]: Format[(A, A), BoundedInterval[A]] =
+    Format[(A, A), BoundedInterval[A]](
+      { case (start, end) =>
+        if (start < end)(BoundedInterval.unsafeClosed(start, end)).some
+        else if (start > end)(BoundedInterval.unsafeClosed(end, start)).some
+        else none
+      },
+      i => (i.lower, i.upper)
+    )

--- a/modules/core/shared/src/main/scala/lucuma/core/math/skycalc/TwilightCalc.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/skycalc/TwilightCalc.scala
@@ -62,7 +62,7 @@ trait TwilightCalc extends SunCalc {
       case _                     => twilightType.horizonAngle.toAngle.toSignedDoubleDegrees
     }
 
-    calcTimes(angle, jdmid, place).flatMap(Spire.openUpperIntervalFromTuple[Instant].getOption)
+    calcTimes(angle, jdmid, place).flatMap(BoundedInterval.openUpperFromTuple[Instant].getOption)
   }
 
   def forBoundedInterval(
@@ -70,9 +70,8 @@ trait TwilightCalc extends SunCalc {
     interval:     BoundedInterval[Instant],
     place:        Place
   ): IntervalSeq[Instant] = {
-    val (start, end)      = Spire.openUpperIntervalFromTuple[Instant].reverseGet(interval)
-    val startDate         = start.atZone(place.timezone).toLocalDate
-    val endDate           = end.atZone(place.timezone).toLocalDate
+    val startDate         = interval.lower.atZone(place.timezone).toLocalDate
+    val endDate           = interval.upper.atZone(place.timezone).toLocalDate
     val dates             =
       List.unfold(startDate)(date => if (date <= endDate) (date, date.plusDays(1)).some else none)
     val twilightIntervals = dates.map(d => forDate(twilightType, d, place)).flattenOption

--- a/modules/core/shared/src/main/scala/lucuma/core/math/skycalc/solver/Samples.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/skycalc/solver/Samples.scala
@@ -10,7 +10,6 @@ import cats.Functor
 import cats.MonoidK
 import cats.syntax.all._
 import lucuma.core.math.BoundedInterval
-import lucuma.core.math.BoundedInterval.*
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Place
 import lucuma.core.optics.Spire
@@ -43,7 +42,7 @@ trait Samples[A] { outer =>
   def interval: Option[BoundedInterval[Instant]] =
     (data.headOption, data.lastOption)
       .bimap(_.map(_._1), _.map(_._1))
-      .mapN(Function.untupled(Spire.closedIntervalFromTuple[Instant].getOption))
+      .mapN(Function.untupled(BoundedInterval.closedFromTuple[Instant].getOption))
       .flatten
 
   /** The value at `i`, if any. */

--- a/modules/core/shared/src/main/scala/lucuma/core/math/skycalc/solver/Solver.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/skycalc/solver/Solver.scala
@@ -5,7 +5,6 @@ package lucuma.core.math.skycalc.solver
 
 import cats.syntax.all.*
 import lucuma.core.math.BoundedInterval
-import lucuma.core.math.BoundedInterval.*
 import lucuma.core.syntax.time.*
 import org.typelevel.cats.time.*
 import spire.math.Interval

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Night.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Night.scala
@@ -5,7 +5,6 @@ package lucuma.core.model
 
 import lucuma.core.enums.Site
 import lucuma.core.math.BoundedInterval
-import lucuma.core.math.BoundedInterval.*
 import lucuma.core.syntax.time._
 import org.typelevel.cats.time._
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ObservingNight.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ObservingNight.scala
@@ -7,7 +7,6 @@ import cats._
 import lucuma.core.enums.Site
 import lucuma.core.enums.TwilightType
 import lucuma.core.math.BoundedInterval
-import lucuma.core.math.BoundedInterval.*
 import monocle.Focus
 import monocle.Lens
 import org.typelevel.cats.time.*

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/Spire.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/Spire.scala
@@ -5,8 +5,6 @@ package lucuma.core.optics
 
 import cats.Order
 import cats.syntax.all._
-import lucuma.core.math.BoundedInterval
-import lucuma.core.math.BoundedInterval.*
 import lucuma.core.optics.Format
 import lucuma.core.optics.SplitEpi
 import monocle.Iso
@@ -48,36 +46,6 @@ object Spire {
 
   val numberNatural: Format[Number, Natural] =
     Format(n => Try(Natural(n.toBigInt)).toOption, Number.apply)
-
-  /**
-   * Makes a best-effort attempt to convert the tuple (a, b) into interval [a, b) or [b, a).
-   *
-   * It's a Format to contemplate the case of tuple (a, a).
-   */
-  def openUpperIntervalFromTuple[A: Order]: Format[(A, A), BoundedInterval[A]] =
-    Format[(A, A), BoundedInterval[A]](
-      { case (start, end) =>
-        if (start < end)(BoundedInterval.unsafeOpenUpper(start, end)).some
-        else if (start > end)(BoundedInterval.unsafeOpenUpper(end, start)).some
-        else none
-      },
-      i => (i.lower, i.upper)
-    )
-
-  /**
-   * Makes a best-effort attempt to convert the tuple (a, b) into interval [a, b] or [b, a].
-   *
-   * It's a Format to contemplate the case of tuple (a, a).
-   */
-  def closedIntervalFromTuple[A: Order]: Format[(A, A), BoundedInterval[A]] =
-    Format[(A, A), BoundedInterval[A]](
-      { case (start, end) =>
-        if (start < end)(BoundedInterval.unsafeClosed(start, end)).some
-        else if (start > end)(BoundedInterval.unsafeClosed(end, start)).some
-        else none
-      },
-      i => (i.lower, i.upper)
-    )
 
   /**
    * The union of any list of `Interval[A]`.

--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbInterval.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbInterval.scala
@@ -7,7 +7,6 @@ import cats.Order
 import cats.Order.*
 import cats.syntax.all.*
 import lucuma.core.math.BoundedInterval
-import lucuma.core.math.BoundedInterval.*
 import org.scalacheck.Arbitrary._
 import org.scalacheck._
 import spire.math.Bounded

--- a/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/TwilightCalcSuiteJVM.scala
+++ b/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/TwilightCalcSuiteJVM.scala
@@ -32,7 +32,7 @@ final class TwilightCalcSuiteJVM extends ScalaCheckSuite {
     forAll { (twilightType: TwilightType, localDate: LocalDate, site: Site) =>
       val (start, end) = TwilightCalc
         .forDate(twilightType, localDate, site.place)
-        .map(Spire.openUpperIntervalFromTuple[Instant].reverseGet.andThen(_.bimap(_.toEpochMilli, _.toEpochMilli)))
+        .map(boundedInterval => (boundedInterval.lower.toEpochMilli, boundedInterval.upper.toEpochMilli))
         .getOrElse((0L, 0L))
       val tbn          =
         TwilightBoundedNightTest.forDate(TwilightTypeJVM(twilightType),

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BoundedIntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BoundedIntervalSuite.scala
@@ -8,13 +8,20 @@ import lucuma.core.arb.ArbTime
 import lucuma.core.math.BoundedInterval
 import lucuma.core.math.arb.ArbInterval
 import lucuma.core.optics.Spire
+import lucuma.core.optics.laws.discipline.FormatTests
+import lucuma.core.optics.laws.discipline.SplitEpiTests
+import lucuma.core.syntax.time.*
+import lucuma.core.tests.ScalaCheckFlaky
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Prop.*
 import org.typelevel.cats.time.*
 import spire.math.Interval
 
+import java.time.Duration
 import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
 
 class BoundedIntervalSuite  extends munit.DisciplineSuite with IntervalGens {
   import ArbInterval.given
@@ -93,7 +100,7 @@ class BoundedIntervalSuite  extends munit.DisciplineSuite with IntervalGens {
       forAll(
         distinctZip(instantUntilEndOfInterval(i), instantFromStartOfInterval(i))
       ) { instants =>
-        Spire.openUpperIntervalFromTuple[Instant].getOption(instants).foreach { other =>
+        BoundedInterval.openUpperFromTuple[Instant].getOption(instants).foreach { other =>
           val join = i.join(other)
           assertEquals(join.map(_.lower), List(i.lower, other.lower).min.some)
           assertEquals(join.map(_.upper), List(i.upper, other.upper).max.some)
@@ -116,10 +123,35 @@ class BoundedIntervalSuite  extends munit.DisciplineSuite with IntervalGens {
       ) { instantsOpt =>
         assert(
           instantsOpt
-            .flatMap(Spire.openUpperIntervalFromTuple[Instant].getOption)
+            .flatMap(BoundedInterval.openUpperFromTuple[Instant].getOption)
             .forall(other => i.join(other).isEmpty)
         )
       }
     }
   }
+
+  test("ToFullDays".tag(ScalaCheckFlaky)) {
+    forAll { (i: BoundedInterval[Instant], z: ZoneId, t: LocalTime) =>
+      val allDay = i.toFullDays(z, t)
+      assert(i.isSubsetOf(allDay))
+      // We can't comparte LocalTimes directly since the LocalTime may not exist at
+      // the given day if there was a DST transition.
+      val start  = allDay.lower.atZone(z)
+      assertEquals(start, start.`with`(t))
+      val end    = allDay.upper.atZone(z)
+      assertEquals(end, end.`with`(t))
+      assert((allDay -- i).forall(_.asInstanceOf[BoundedInterval[Instant]].duration < Duration.ofDays(1)))
+    }
+  }
+
+  // Optics
+  checkAll(
+    "BoundedInterval.openUpperFromTuple",
+    FormatTests(BoundedInterval.openUpperFromTuple[Int]).format
+  )
+
+  checkAll(
+    "BoundedInterval.closedFromTuple",
+    FormatTests(BoundedInterval.closedFromTuple[Int]).format
+  )
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BoundedIntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BoundedIntervalSuite.scala
@@ -1,0 +1,125 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.math
+
+import cats.syntax.all.*
+import lucuma.core.arb.ArbTime
+import lucuma.core.math.BoundedInterval
+import lucuma.core.math.arb.ArbInterval
+import lucuma.core.optics.Spire
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Prop.*
+import org.typelevel.cats.time.*
+import spire.math.Interval
+
+import java.time.Instant
+
+class BoundedIntervalSuite  extends munit.DisciplineSuite with IntervalGens {
+  import ArbInterval.given
+  import ArbTime.*
+
+  test("fromInterval") {
+    forAll { (a: Int, b: Int) =>
+      assertEquals(BoundedInterval.fromInterval(Interval.closed(a, b)).isDefined, a <= b)
+      assertEquals(BoundedInterval.fromInterval(Interval.open(a, b)).isDefined, a < b)
+      assertEquals(BoundedInterval.fromInterval(Interval.openLower(a, b)).isDefined, a < b)
+      assertEquals(BoundedInterval.fromInterval(Interval.openUpper(a, b)).isDefined, a < b)
+      assertEquals(BoundedInterval.fromInterval(Interval.above(b)).isDefined, false)
+      assertEquals(BoundedInterval.fromInterval(Interval.atOrAbove(b)).isDefined, false)
+      assertEquals(BoundedInterval.fromInterval(Interval.below(a)).isDefined, false)
+      assertEquals(BoundedInterval.fromInterval(Interval.atOrBelow(a)).isDefined, false)
+      assertEquals(BoundedInterval.fromInterval(Interval.empty[Int]).isDefined, false)
+      assertEquals(BoundedInterval.fromInterval(Interval.all[Int]).isDefined, false)
+    }
+  }
+
+  test("closed") {
+    forAll { (a: Int, b: Int) =>
+      assertEquals(BoundedInterval.closed(a, b).isDefined, a <= b)
+    }
+  }
+
+  test("open") {
+    forAll { (a: Int, b: Int) =>
+      assertEquals(BoundedInterval.open(a, b).isDefined, a < b)
+    }
+  }
+
+
+  test("openLower") {
+    forAll { (a: Int, b: Int) =>
+      assertEquals(BoundedInterval.openLower(a, b).isDefined, a < b)
+    }
+  }
+
+  test("openUpper") {
+    forAll { (a: Int, b: Int) =>
+      assertEquals(BoundedInterval.openUpper(a, b).isDefined, a < b)
+    }
+  }
+
+  test("abuts") {
+    forAll { (i: BoundedInterval[Instant]) =>
+      forAll(
+        Gen.oneOf(
+          instantBeforeInterval(i).map(
+            _.map(s => BoundedInterval.unsafeOpenUpper(s, i.lower))
+          ),
+          instantAfterInterval(i)
+            .map(_.map(e => BoundedInterval.unsafeOpenUpper(i.upper, e)))
+        )
+      ) { i2Opt =>
+        assert(i2Opt.forall(i.abuts))
+      }
+    }
+  }
+
+  test("not abuts") {
+    forAll { (i: BoundedInterval[Instant]) =>
+      forAll(
+        arbitrary[BoundedInterval[Instant]]
+          .suchThat(i2 => i2.upper =!= i.lower)
+          .suchThat(i2 => i2.lower =!= i.upper)
+      ) { (i2: BoundedInterval[Instant]) =>
+        assert(!i.abuts(i2))
+      }
+    }
+  }
+
+  test("join") {
+    forAll { (i: BoundedInterval[Instant]) =>
+      forAll(
+        distinctZip(instantUntilEndOfInterval(i), instantFromStartOfInterval(i))
+      ) { instants =>
+        Spire.openUpperIntervalFromTuple[Instant].getOption(instants).foreach { other =>
+          val join = i.join(other)
+          assertEquals(join.map(_.lower), List(i.lower, other.lower).min.some)
+          assertEquals(join.map(_.upper), List(i.upper, other.upper).max.some)
+        }
+      }
+    }
+  }
+
+  test("empty join") {
+    forAll { (i: BoundedInterval[Instant]) =>
+      forAll(
+        Gen
+          .oneOf(
+            distinctZipOpt(instantBeforeInterval(i), instantBeforeInterval(i)),
+            distinctZipOpt(
+              instantAfterInterval(i),
+              instantAfterInterval(i)
+            )
+          )
+      ) { instantsOpt =>
+        assert(
+          instantsOpt
+            .flatMap(Spire.openUpperIntervalFromTuple[Instant].getOption)
+            .forall(other => i.join(other).isEmpty)
+        )
+      }
+    }
+  }
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalGens.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalGens.scala
@@ -7,7 +7,6 @@ import cats.Eq
 import cats.syntax.all.*
 import lucuma.core.arb.ArbTime
 import lucuma.core.math.BoundedInterval
-import lucuma.core.math.BoundedInterval.*
 import lucuma.core.optics.Spire
 import lucuma.core.syntax.time.*
 import org.scalacheck.Arbitrary.*
@@ -160,7 +159,7 @@ trait IntervalGens {
         .oneOf(schedule.intervals)
         .flatMap(i =>
           distinctZip(instantInInterval(i), instantInInterval(i))
-            .map(Spire.openUpperIntervalFromTuple[Instant].getOption)
+            .map(BoundedInterval.openUpperFromTuple[Instant].getOption)
         )
 
   // We define a "section" as a maximal interval either outside or inside the Schedule.

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/IntervalSuite.scala
@@ -3,53 +3,16 @@
 
 package lucuma.core.math
 
-import cats.Order.*
-import cats.syntax.all.*
-import lucuma.core.arb.ArbTime
-import lucuma.core.math.BoundedInterval
 import lucuma.core.math.arb.ArbInterval
-import lucuma.core.math.arb.*
 import lucuma.core.optics.Spire
-import lucuma.core.optics.laws.discipline.FormatTests
 import lucuma.core.optics.laws.discipline.SplitEpiTests
-import lucuma.core.syntax.time.*
-import lucuma.core.tests.ScalaCheckFlaky
-import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary.*
-import org.scalacheck.Gen
-import org.scalacheck.Prop.*
-import org.typelevel.cats.time.*
-
-import java.time.Duration
-import java.time.Instant
-import java.time.LocalTime
-import java.time.ZoneId
 
 final class IntervalSuite extends munit.DisciplineSuite {
   import ArbInterval.given
-  import ArbTime.*
+  // import ArbTime.*
 
-  // Optics
-  checkAll(
-    "Spire.openUpperIntervalFromTuple",
-    FormatTests(Spire.openUpperIntervalFromTuple[Int]).format
-  )
   checkAll(
     "Spire.intervalListUnion",
     SplitEpiTests(Spire.intervalListUnion[Int]).splitEpi
   )
-
-  test("ToFullDays".tag(ScalaCheckFlaky)) {
-    forAll { (i: BoundedInterval[Instant], z: ZoneId, t: LocalTime) =>
-      val allDay = i.toFullDays(z, t)
-      assert(i.isSubsetOf(allDay))
-      // We can't comparte LocalTimes directly since the LocalTime may not exist at
-      // the given day if there was a DST transition.
-      val start  = allDay.lower.atZone(z)
-      assertEquals(start, start.`with`(t))
-      val end    = allDay.upper.atZone(z)
-      assertEquals(end, end.`with`(t))
-      assert((allDay -- i).forall(_.asInstanceOf[BoundedInterval[Instant]].duration < Duration.ofDays(1)))
-    }
-  }
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/TwilightCalcSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/TwilightCalcSuite.scala
@@ -5,7 +5,6 @@ package lucuma.core.math.skycalc
 
 import lucuma.core.enums.Site
 import lucuma.core.enums.TwilightType
-import lucuma.core.math.BoundedInterval.*
 import munit.FunSuite
 
 import java.time.LocalDate

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/ConstraintSolverSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/ConstraintSolverSuite.scala
@@ -5,7 +5,6 @@ package lucuma.core.math.skycalc
 package solver
 
 import lucuma.core.enums.Site.GN
-import lucuma.core.math.BoundedInterval.*
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.HourAngle

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/SamplesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/skycalc/solver/SamplesSuite.scala
@@ -13,7 +13,6 @@ import lucuma.core.arb.ArbEval
 import lucuma.core.arb.ArbTime
 import lucuma.core.arb.*
 import lucuma.core.math.BoundedInterval
-import lucuma.core.math.BoundedInterval.*
 import lucuma.core.math.IntervalGens
 import lucuma.core.math.arb.ArbInterval
 import lucuma.core.math.arb.*


### PR DESCRIPTION
The constructor `BoundedInterval.fromInterval` had a bug when passing an `Above`, `Below` or `All`. It mistakenly constructed a `BoundedInterval` when it shouldn't.

The existence of `BoundedInterval` can now simplify code in a number of places.

Extension method `duration` for `IntervalSeq[Instant]` had a bug, where it called itself indefinitely.

Most tests that were in `IntervalSuite` are now in `BoundedIntervalSuite`.