### PR TITLE
objectUrl in CatalogInfo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.69"
+ThisBuild / tlBaseVersion                         := "0.70"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/CatalogInfo.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/CatalogInfo.scala
@@ -13,15 +13,24 @@ import lucuma.core.enums.CatalogName
 import monocle.Focus
 import monocle.Lens
 
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import scala.util.Try
+
 final case class CatalogInfo(
   catalog:    CatalogName,
   id:         NonEmptyString,
   objectType: Option[NonEmptyString]
-)
+):
+  val objectUrl: Option[URI] = catalog match
+    case CatalogName.Simbad => 
+      Try(URI(s"https://simbad.cds.unistra.fr/simbad/sim-id?Ident=${URLEncoder.encode(id.value, StandardCharsets.UTF_8)}")).toOption
+    case _ => none
+  
 
 object CatalogInfo {
-  implicit val orderCatalogInfo: Order[CatalogInfo] =
-    Order.by(x => (x.catalog, x.id, x.objectType))
+  given Order[CatalogInfo] = Order.by(x => (x.catalog, x.id, x.objectType))
 
   def apply(
     catalog:    CatalogName,


### PR DESCRIPTION
I'm not sure if it's of interest to make this generally available in core.

Otherwise, we can make it an extension method in `lucuma-ui` if it's going to be shared by multiple UIs, or just in `explore`, where we actually need it for the time being.