### PR TITLE
Avoid errors and warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.71"
+ThisBuild / tlBaseVersion                         := "0.72"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/units.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/units.scala
@@ -144,7 +144,7 @@ trait units {
 
   given refinedValueConversion[V, P]: ValueConversion[V Refined P, V] = _.value
 
-  inline given [UF, UT]: TruncatingUnitConversion[PosInt, UF, UT] = v =>
+  given [UF, UT]: TruncatingUnitConversion[PosInt, UF, UT] = v =>
     refineV[Positive](coulomb.conversion.standard.unit.ctx_TUC_Int(v))
       .getOrElse(1.refined[Positive])
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ElevationRange.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ElevationRange.scala
@@ -79,7 +79,8 @@ object ElevationRange {
 
     type Hour        = Interval.Closed[MinHour.type, MaxHour.type]
     type DecimalHour = BigDecimal Refined Hour
-    object DecimalHour extends RefinedTypeOps[DecimalHour, BigDecimal]
+    // An object here seems to confuse the 3.2.2 compiler, resulting in a null in runtime.
+    lazy val DecimalHour = new RefinedTypeOps[DecimalHour, BigDecimal]
 
     val DefaultMin = DecimalHour.unsafeFrom(MinHour)
     val DefaultMax = DecimalHour.unsafeFrom(MaxHour)


### PR DESCRIPTION
We're throwing an NPE when attempting to access `ElevationRange.HourAngle.DecimalHour` on Scala 3.2.2, so hoping that changing from an `object` to `lazy val` will fix that.

Also, we get a warning for `inline given` defined as a function in newer versions, so removing the `inline` there.