### PR TITLE
SignalToNoise

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.72"
+ThisBuild / tlBaseVersion                         := "0.73"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/SignalToNoise.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/SignalToNoise.scala
@@ -1,0 +1,128 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.math
+
+import cats.Order
+import cats.Show
+import eu.timepit.refined.types.numeric.PosBigDecimal
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.JsonNumber
+import lucuma.core.optics.Format
+import monocle.Prism
+
+import scala.util.control.Exception.catching
+
+// Signal-to-noise stored as milli-signal to noise Long capped at 9,999,999,999
+// so that it fits in a database numeric(10, 3).
+
+opaque type SignalToNoise = Long
+
+object SignalToNoise {
+
+  /**
+   * Maximum supported signal-to-noise value: 9,999,999.999.
+   */
+  val Max: SignalToNoise =
+    9_999_999_999L
+
+  /**
+   * Minimum supported signal-to-noise value: 0.001.
+   */
+  val Min: SignalToNoise =
+    1L
+
+  extension (s2n: SignalToNoise) {
+
+    /**
+     * Converts this SignalToNoise value to a `BigDecimal`, which is guaranteed
+     * to be positive.
+     */
+    def toBigDecimal: BigDecimal =
+      BigDecimal(s2n, 3)
+
+    /**
+     * Converts this SignalToNoise value to a `PosBigDecimal`.
+     */
+    def toPosBigDecimal: PosBigDecimal =
+      PosBigDecimal.unsafeFrom(toBigDecimal)
+
+  }
+
+  private def fromMilliLong(msn: Long): Option[SignalToNoise] =
+    Option.when(msn >= Min && msn <= Max)(msn)
+
+  private def fromMilliDecimal(msn: BigDecimal): Option[SignalToNoise] =
+    Option.when(msn.isValidLong)(msn.longValue).flatMap(fromMilliLong)
+
+  private def errorMessage(sn: BigDecimal): String =
+    s"Signal-to-noise is limited to [${Min.toBigDecimal}, ${Max.toBigDecimal}), got $sn"
+
+  private def error(sn: BigDecimal): Nothing =
+    sys.error(errorMessage(sn))
+
+  /**
+   * Creates a `SignalToNoise` value assuming that the given BigDecimal is in
+   * range [Min, Max] and does not have a finer scale than milli-sn.
+   *
+   * @group Optics
+   */
+  val FromBigDecimalExact: Prism[BigDecimal, SignalToNoise] =
+    Prism[BigDecimal, SignalToNoise](bd => fromMilliDecimal(bd * 1000))(_.toBigDecimal)
+
+  /**
+   * Creates a `SignalToNoise` value assuming that the given BigDecimal is in
+   * range [Min, Max].  Rounds finer scale values to milli-sn.
+   *
+   * @group Optics
+   */
+  val FromBigDecimalRounding: Format[BigDecimal, SignalToNoise] =
+    Format(bd => fromMilliDecimal((bd * 1000).setScale(0, BigDecimal.RoundingMode.HALF_UP)), _.toBigDecimal)
+
+  /**
+   * Formats to the canonical String representation for SignalToNoise.
+   *
+   * @group Optics
+   */
+  val FromString: Format[String, SignalToNoise] = {
+    def parse(s: String): Option[SignalToNoise] =
+      (catching(classOf[NumberFormatException]) opt BigDecimal.exact(s)).flatMap(FromBigDecimalExact.getOption)
+
+    def show(sn: SignalToNoise): String =
+      sn.toBigDecimal.underlying.toPlainString
+
+    Format(parse, show)
+  }
+
+  /**
+   * Creates a `SignalToNoise` value from the given integer assuming it is
+   * positive non-zero and less than 10,000,000.
+   */
+  def fromInt(sn: Int):  Option[SignalToNoise] =
+    fromMilliLong(sn * 1000L)
+
+  /**
+   * Constructs a SignalToNoise from a BigDecimal, assuming it is in range and representable in 3 decimal places.
+   * Otherwise throws an exception.
+   */
+  def unsafeFromBigDecimalExact(sn: BigDecimal): SignalToNoise =
+    FromBigDecimalExact.getOption(sn).getOrElse(error(sn))
+
+  given Order[SignalToNoise] =
+    Order.fromLessThan(_ < _)
+
+  given Decoder[SignalToNoise] =
+    Decoder.decodeJsonNumber.emap { jNum =>
+      for {
+        bd <- jNum.toBigDecimal.toRight(s"Signal-to-noise values must be parsable as a decimal, not: $jNum")
+        sn <- FromBigDecimalExact.getOption(bd).toRight(errorMessage(bd))
+      } yield sn
+    }
+
+  given Encoder[SignalToNoise] =
+    Encoder.encodeJsonNumber.contramap[SignalToNoise] { sn =>
+      JsonNumber.fromDecimalStringUnsafe(FromString.reverseGet(sn))
+    }
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ExposureTimeMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ExposureTimeMode.scala
@@ -7,7 +7,7 @@ import cats.Eq
 import cats.syntax.all.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.NonNegInt
-import eu.timepit.refined.types.numeric.PosBigDecimal
+import lucuma.core.math.SignalToNoise
 import lucuma.core.model.NonNegDuration
 import lucuma.core.model.given
 import lucuma.core.util.TimeSpan
@@ -21,65 +21,65 @@ sealed trait ExposureTimeMode extends Product with Serializable
 
 object ExposureTimeMode {
 
-  final case class SignalToNoise(value: PosBigDecimal)             extends ExposureTimeMode
-  final case class FixedExposure(count: NonNegInt, time: TimeSpan) extends ExposureTimeMode
+  final case class SignalToNoiseMode(value: SignalToNoise)             extends ExposureTimeMode
+  final case class FixedExposureMode(count: NonNegInt, time: TimeSpan) extends ExposureTimeMode
 
   given Eq[ExposureTimeMode] =
     Eq.instance {
-      case (SignalToNoise(a), SignalToNoise(b))           => a === b
-      case (FixedExposure(ac, ad), FixedExposure(bc, bd)) => ac === bc && ad === bd
+      case (SignalToNoiseMode(a), SignalToNoiseMode(b))           => a === b
+      case (FixedExposureMode(ac, ad), FixedExposureMode(bc, bd)) => ac === bc && ad === bd
       case _                                              => false
     }
 
-  val signalToNoise: Prism[ExposureTimeMode, SignalToNoise] =
-    GenPrism[ExposureTimeMode, SignalToNoise]
+  val signalToNoise: Prism[ExposureTimeMode, SignalToNoiseMode] =
+    GenPrism[ExposureTimeMode, SignalToNoiseMode]
 
-  val fixedExposure: Prism[ExposureTimeMode, FixedExposure] =
-    GenPrism[ExposureTimeMode, FixedExposure]
+  val fixedExposure: Prism[ExposureTimeMode, FixedExposureMode] =
+    GenPrism[ExposureTimeMode, FixedExposureMode]
 
-  val signalToNoiseValue: Optional[ExposureTimeMode, PosBigDecimal] =
-    Optional[ExposureTimeMode, PosBigDecimal] {
-      case SignalToNoise(value) => value.some
-      case FixedExposure(_, _)  => none
+  val signalToNoiseValue: Optional[ExposureTimeMode, SignalToNoise] =
+    Optional[ExposureTimeMode, SignalToNoise] {
+      case SignalToNoiseMode(value) => value.some
+      case FixedExposureMode(_, _)  => none
     } { nnd =>
       {
-        case s @ SignalToNoise(_)    => SignalToNoise.value.replace(nnd)(s)
-        case f @ FixedExposure(_, _) => f
+        case s @ SignalToNoiseMode(_)    => SignalToNoiseMode.value.replace(nnd)(s)
+        case f @ FixedExposureMode(_, _) => f
       }
     }
 
   val exposureCount: Optional[ExposureTimeMode, NonNegInt] =
     Optional[ExposureTimeMode, NonNegInt] {
-      case FixedExposure(count, _) => count.some
-      case SignalToNoise(_)        => none
+      case FixedExposureMode(count, _) => count.some
+      case SignalToNoiseMode(_)        => none
     } { nni =>
       {
-        case f @ FixedExposure(_, _) => FixedExposure.count.replace(nni)(f)
-        case s @ SignalToNoise(_)    => s
+        case f @ FixedExposureMode(_, _) => FixedExposureMode.count.replace(nni)(f)
+        case s @ SignalToNoiseMode(_)    => s
       }
     }
 
   val exposureTime: Optional[ExposureTimeMode, TimeSpan] =
     Optional[ExposureTimeMode, TimeSpan] {
-      case FixedExposure(_, time) => time.some
-      case SignalToNoise(_)       => none
+      case FixedExposureMode(_, time) => time.some
+      case SignalToNoiseMode(_)       => none
     } { pbd =>
       {
-        case f @ FixedExposure(_, _) => FixedExposure.time.replace(pbd)(f)
-        case s @ SignalToNoise(_)    => s
+        case f @ FixedExposureMode(_, _) => FixedExposureMode.time.replace(pbd)(f)
+        case s @ SignalToNoiseMode(_)    => s
       }
     }
 
-  object SignalToNoise {
-    val value: Lens[SignalToNoise, PosBigDecimal] = Focus[SignalToNoise](_.value)
+  object SignalToNoiseMode {
+    val value: Lens[SignalToNoiseMode, SignalToNoise] = Focus[SignalToNoiseMode](_.value)
 
-    given Eq[SignalToNoise] = Eq.by(_.value)
+    given Eq[SignalToNoiseMode] = Eq.by(_.value)
   }
 
-  object FixedExposure {
-    val count: Lens[FixedExposure, NonNegInt] = Focus[FixedExposure](_.count)
-    val time: Lens[FixedExposure, TimeSpan]   = Focus[FixedExposure](_.time)
+  object FixedExposureMode {
+    val count: Lens[FixedExposureMode, NonNegInt] = Focus[FixedExposureMode](_.count)
+    val time: Lens[FixedExposureMode, TimeSpan]   = Focus[FixedExposureMode](_.time)
 
-    given Eq[FixedExposure] = Eq.by(f => (f.count, f.time))
+    given Eq[FixedExposureMode] = Eq.by(f => (f.count, f.time))
   }
 }

--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbSignalToNoise.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbSignalToNoise.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.math
+package arb
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck._
+
+trait ArbSignalToNoise {
+
+  given Arbitrary[SignalToNoise] =
+    Arbitrary {
+      validBigDecimalSignalToNoise.map(SignalToNoise.unsafeFromBigDecimalExact)
+    }
+
+  given Cogen[SignalToNoise] =
+    Cogen[BigDecimal].contramap(_.toBigDecimal)
+
+  private val validBigDecimalSignalToNoise: Gen[BigDecimal] =
+    Gen
+      .choose(1L, 9_999_999_999L)
+      .map(BigDecimal(_, 3))
+
+  private val coverageExamples: Gen[BigDecimal] =
+    Gen
+      .choose(1L, 9_999_999_999_999L)
+      .map(BigDecimal(_, 6))
+
+  val bigDecimalSignalToNoise: Gen[BigDecimal] =
+    Gen.oneOf(validBigDecimalSignalToNoise, coverageExamples, arbitrary[BigDecimal])
+
+  val stringSignalToNoise: Gen[String] = {
+    val v = validBigDecimalSignalToNoise.map(_.toString)
+    Gen.oneOf(
+      v,
+      v.map(s => s"${s}0"),
+      arbitrary[String]
+    )
+  }
+
+}
+
+object ArbSignalToNoise extends ArbSignalToNoise

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExposureTimeMode.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExposureTimeMode.scala
@@ -7,7 +7,9 @@ package arb
 import eu.timepit.refined.scalacheck.all.*
 import eu.timepit.refined.types.all.NonNegInt
 import eu.timepit.refined.types.all.PosBigDecimal
+import lucuma.core.math.SignalToNoise
 import lucuma.core.math.arb.ArbRefined
+import lucuma.core.math.arb.ArbSignalToNoise
 import lucuma.core.model.NonNegDuration
 import lucuma.core.model.arb.ArbNonNegDuration
 import lucuma.core.util.TimeSpan
@@ -17,26 +19,27 @@ import org.scalacheck.*
 
 trait ArbExposureTimeMode {
   import ExposureTimeMode.*
-  import ArbTimeSpan.given
   import ArbRefined.given
+  import ArbSignalToNoise.given
+  import ArbTimeSpan.given
 
-  given Arbitrary[SignalToNoise] =
+  given Arbitrary[SignalToNoiseMode] =
     Arbitrary {
-      arbitrary[PosBigDecimal].map(SignalToNoise(_))
+      arbitrary[SignalToNoise].map(SignalToNoiseMode(_))
     }
 
-  given Cogen[SignalToNoise] =
-    Cogen[PosBigDecimal].contramap(_.value)
+  given Cogen[SignalToNoiseMode] =
+    Cogen[SignalToNoise].contramap(_.value)
 
-  given Arbitrary[FixedExposure] =
+  given Arbitrary[FixedExposureMode] =
     Arbitrary {
       for {
         c <- arbitrary[NonNegInt]
         t <- arbitrary[TimeSpan]
-      } yield FixedExposure(c, t)
+      } yield FixedExposureMode(c, t)
     }
 
-  given Cogen[FixedExposure] =
+  given Cogen[FixedExposureMode] =
     Cogen[
       (
         NonNegInt,
@@ -51,14 +54,14 @@ trait ArbExposureTimeMode {
 
   given Arbitrary[ExposureTimeMode] =
     Arbitrary {
-      Gen.oneOf(arbitrary[FixedExposure], arbitrary[FixedExposure])
+      Gen.oneOf(arbitrary[FixedExposureMode], arbitrary[FixedExposureMode])
     }
 
   given Cogen[ExposureTimeMode] =
     Cogen[
       (
-        Option[SignalToNoise],
-        Option[FixedExposure]
+        Option[SignalToNoiseMode],
+        Option[FixedExposureMode]
       )
     ].contramap { in =>
       (

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/SignalToNoiseSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/SignalToNoiseSuite.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.math
+
+import cats.Order
+import cats.kernel.laws.discipline.OrderTests
+import io.circe.testing.CodecTests
+import io.circe.testing.instances.*
+import lucuma.core.math.arb.ArbSignalToNoise
+import lucuma.core.optics.Format
+import lucuma.core.optics.laws.discipline.FormatTests
+import monocle.law.discipline.*
+import org.scalacheck.Prop.*
+
+
+final class SignalToNoiseSuite extends munit.DisciplineSuite {
+
+  import ArbSignalToNoise.given
+  import ArbSignalToNoise.bigDecimalSignalToNoise
+  import ArbSignalToNoise.stringSignalToNoise
+
+  checkAll("Order",                  OrderTests[SignalToNoise].order)
+  checkAll("JSON Codec",             CodecTests[SignalToNoise].codec)
+  checkAll("FromBigDecimalExact",    PrismTests(SignalToNoise.FromBigDecimalExact))
+  checkAll("FromBigDecimalRounding", FormatTests(SignalToNoise.FromBigDecimalRounding).formatWith(bigDecimalSignalToNoise))
+  checkAll("FromString",             FormatTests(SignalToNoise.FromString).formatWith(stringSignalToNoise))
+
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/ExposureTimeModeSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/ExposureTimeModeSuite.scala
@@ -7,6 +7,7 @@ import cats.kernel.laws.discipline.EqTests
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.scalacheck.all.*
 import lucuma.core.math.arb.ArbRefined
+import lucuma.core.math.arb.ArbSignalToNoise
 import lucuma.core.model.arb.ArbExposureTimeMode
 import lucuma.core.model.given
 import lucuma.core.util.arb.ArbTimeSpan
@@ -16,9 +17,10 @@ import monocle.law.discipline.PrismTests
 import munit.DisciplineSuite
 
 class ExposureTimeModeSuite extends DisciplineSuite {
-  import ArbTimeSpan.given
   import ArbExposureTimeMode.given
   import ArbRefined.given
+  import ArbSignalToNoise.given
+  import ArbTimeSpan.given
 
   checkAll("Eq[ExposureTimeMode]", EqTests[ExposureTimeMode].eqv)
   checkAll("ExposureTimeMode.signalToNoise", PrismTests(ExposureTimeMode.signalToNoise))
@@ -29,10 +31,10 @@ class ExposureTimeModeSuite extends DisciplineSuite {
   checkAll("ExposureTimeMode.exposureCount", OptionalTests(ExposureTimeMode.exposureCount))
   checkAll("ExposureTimeMode.exposureTime", OptionalTests(ExposureTimeMode.exposureTime))
 
-  checkAll("Eq[SignalToNoise]", EqTests[ExposureTimeMode.SignalToNoise].eqv)
-  checkAll("SignalToNoise.value", LensTests(ExposureTimeMode.SignalToNoise.value))
+  checkAll("Eq[SignalToNoise]", EqTests[ExposureTimeMode.SignalToNoiseMode].eqv)
+  checkAll("SignalToNoise.value", LensTests(ExposureTimeMode.SignalToNoiseMode.value))
 
-  checkAll("Eq[FixedExposure]", EqTests[ExposureTimeMode.FixedExposure].eqv)
-  checkAll("FixedExposure.count", LensTests(ExposureTimeMode.FixedExposure.count))
-  checkAll("FixedExposure.time", LensTests(ExposureTimeMode.FixedExposure.time))
+  checkAll("Eq[FixedExposure]", EqTests[ExposureTimeMode.FixedExposureMode].eqv)
+  checkAll("FixedExposure.count", LensTests(ExposureTimeMode.FixedExposureMode.count))
+  checkAll("FixedExposure.time", LensTests(ExposureTimeMode.FixedExposureMode.time))
 }


### PR DESCRIPTION
Adds a `SignalToNoise` value that can be precisely mapped to the database.  In other words, if you can make a `SignalToNoise` it can be stored and then an exact `Eq` value can be retrieved.

After updating the schema (in a separate PR), this will address an issue in which we allow any `PosBigDecimal` to be passed in as a signal-to-noise value but can only actually store a subset of them.