### PR TITLE
TimeSpan math ops

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/refined/numeric.scala
@@ -10,8 +10,13 @@ import eu.timepit.refined.generic.Equal
 import shapeless.nat._0
 
 object numeric {
-  type NonZeroInt  = Int Refined Not[Equal[_0]]
+  type NonZero = Not[Equal[_0]]
+
+  type NonZeroInt  = Int Refined NonZero
   object NonZeroInt extends RefinedTypeOps.Numeric[NonZeroInt, Int]
+
+  type NonZeroBigDecimal = BigDecimal Refined NonZero
+  object NonZeroBigDecimal extends RefinedTypeOps[NonZeroBigDecimal, BigDecimal]
 }
 
 

--- a/modules/core/shared/src/main/scala/lucuma/core/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/refined/numeric.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.api.RefinedTypeOps
+import eu.timepit.refined.boolean.Not
+import eu.timepit.refined.generic.Equal
+import shapeless.nat._0
+
+object numeric {
+  type NonZeroInt  = Int Refined Not[Equal[_0]]
+  object NonZeroInt extends RefinedTypeOps.Numeric[NonZeroInt, Int]
+}
+
+

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
@@ -11,6 +11,7 @@ import cats.syntax.order.*
 import eu.timepit.refined.types.numeric.NonNegLong
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.optics.Format
+import lucuma.core.refined.numeric.NonZeroInt
 import monocle.Iso
 import monocle.Prism
 
@@ -174,8 +175,8 @@ object TimeSpan {
      * Divides a TimeSpan by a non-negative integer, via integer division.
      */
     @targetName("divide")
-    def /(divisor: PosInt): TimeSpan =
-      TimeSpan.unsafeFromMicroseconds(timeSpan.toMicroseconds / divisor.value)
+    def /|(divisor: NonZeroInt): TimeSpan =
+      TimeSpan.fromMicroseconds(timeSpan.toMicroseconds / divisor.value).getOrElse(Min)
 
   }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
@@ -8,7 +8,6 @@ import cats.Order
 import cats.Order.catsKernelOrderingForOrder
 import cats.syntax.option.*
 import cats.syntax.order.*
-import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.NonNegLong
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.optics.Format
@@ -160,16 +159,15 @@ object TimeSpan {
       fromMicroseconds(timeSpan.toMicroseconds - other.toMicroseconds).getOrElse(Min)
 
     /**
-     * Multiplies a TimeSpan by a non-negative integer, capping the resulting
-     * value at `Max`.
+     * Multiplies a TimeSpan by an integer, limiting the resulting value to the
+     * range (`Min`, `Max`).
      */
     @targetName("boundedMultiply")
-    def *|(multiplier: NonNegInt): TimeSpan = {
-      val big = BigInt(timeSpan.toMicroseconds) * multiplier.value
-      Option
-        .when(big <= Max.toMicroseconds)(fromMicroseconds(big.longValue))
-        .flatten
-        .getOrElse(Max)
+    def *|(multiplier: Int): TimeSpan = {
+      val big = BigInt(timeSpan.toMicroseconds) * multiplier
+      if (big < Min.toMicroseconds) Min
+      else if (big > Max.toMicroseconds) Max
+      else unsafeFromMicroseconds(big.longValue)
     }
 
     /**

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
@@ -174,7 +174,7 @@ object TimeSpan {
     /**
      * Divides a TimeSpan by a non-negative integer, via integer division.
      */
-    @targetName("divide")
+    @targetName("boundedDivide")
     def /|(divisor: NonZeroInt): TimeSpan =
       TimeSpan.fromMicroseconds(timeSpan.toMicroseconds / divisor.value).getOrElse(Min)
 

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
@@ -175,8 +175,8 @@ object TimeSpan {
     /**
      * Divides a TimeSpan by a non-negative integer, via integer division.
      */
-    @targetName("boundedDivide")
-    def /|(divisor: PosInt): TimeSpan =
+    @targetName("divide")
+    def /(divisor: PosInt): TimeSpan =
       TimeSpan.unsafeFromMicroseconds(timeSpan.toMicroseconds / divisor.value)
 
   }


### PR DESCRIPTION
While it's true that you cannot arbitrarily add two `TimeSpan`s and expect to get a valid `TimeSpan` result, it's still useful to be able to add, subtract, multiply and divide them without worrying about it in most situations.  A `TimeSpan.Max` is essentially infinity for our purposes, and treating it as the bounds of math operations makes the 99% (or better) case easier. For example, if exposure time takes `TimeSpan.Max` then the fact that detector readout and write to permanent storage require some additional amount of time is not very useful anyway. 

The pipe,`|`,  in `t0 +| t1` etc. is meant to be suggestive of a hitting a wall or bounds.  `TimeSpan` forms a `Monoid` under `+|` which is also useful.

I don't know.  Is all of this dumb?