### PR TITLE
Allow SignalToNoise to be zero

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ lazy val testkit = crossProject(JVMPlatform, JSPlatform)
       "dev.optics"        %%% "monocle-law"        % monocleVersion,
       "org.typelevel"     %%% "spire-laws"         % spireVersion,
       "eu.timepit"        %%% "refined-scalacheck" % refinedVersion,
-      "io.circe"          %%% "circe-testing"      % circeVersion,
+      "io.circe"          %%% "circe-testing"      % circeVersion,  
       "io.chrisdavenport" %%% "cats-scalacheck"    % catsScalacheckVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.74"
+ThisBuild / tlBaseVersion                         := "0.75"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/SignalToNoise.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/SignalToNoise.scala
@@ -6,7 +6,7 @@ package lucuma.core.math
 import cats.Order
 import cats.Show
 import cats.syntax.all.*
-import eu.timepit.refined.types.numeric.PosBigDecimal
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.JsonNumber
@@ -30,10 +30,10 @@ object SignalToNoise {
     9_999_999_999L
 
   /**
-   * Minimum supported signal-to-noise value: 0.001.
+   * Minimum supported signal-to-noise value: 0.000.
    */
   val Min: SignalToNoise =
-    1L
+    0L
 
   extension (s2n: SignalToNoise) {
 
@@ -45,10 +45,10 @@ object SignalToNoise {
       BigDecimal(s2n, 3)
 
     /**
-     * Converts this SignalToNoise value to a `PosBigDecimal`.
+     * Converts this SignalToNoise value to a `NonNegBigDecimal`.
      */
-    def toPosBigDecimal: PosBigDecimal =
-      PosBigDecimal.unsafeFrom(toBigDecimal)
+    def toNonNegBigDecimal: NonNegBigDecimal =
+      NonNegBigDecimal.unsafeFrom(toBigDecimal)
 
   }
 
@@ -74,15 +74,15 @@ object SignalToNoise {
     Prism[BigDecimal, SignalToNoise](bd => fromMilliDecimal(bd * 1000))(_.toBigDecimal)
 
   /**
-   * Creates a `SignalToNoise` value assuming from a PosBigDecimal that is in
+   * Creates a `SignalToNoise` value assuming from a NonNegBigDecimal that is in
    * range [Min, Max] and does not have a finer scale than milli-sn.
    *
    * @group Optics
    */
-  val FromPosBigDecimalExact: Prism[PosBigDecimal, SignalToNoise] =
-    Prism[PosBigDecimal, SignalToNoise](bd =>
+  val FromNonNegBigDecimalExact: Prism[NonNegBigDecimal, SignalToNoise] =
+    Prism[NonNegBigDecimal, SignalToNoise](bd =>
       SignalToNoise.FromBigDecimalExact.getOption(bd.value)
-    )(_.toPosBigDecimal)
+    )(_.toNonNegBigDecimal)
 
   /**
    * Creates a `SignalToNoise` value assuming that the given BigDecimal is in
@@ -100,18 +100,18 @@ object SignalToNoise {
     )
 
   /**
-   * Creates a `SignalToNoise` value assuming that the given PosBigDecimal is in
+   * Creates a `SignalToNoise` value assuming that the given NonNegBigDecimal is in
    * range [Min, Max].  Rounds finer scale values to milli-sn.
    *
    * @group Optics
    */
-  val FromPosBigDecimalRounding: ValidSplitEpiNec[String, PosBigDecimal, SignalToNoise] =
+  val FromNonNegBigDecimalRounding: ValidSplitEpiNec[String, NonNegBigDecimal, SignalToNoise] =
     ValidSplitEpiNec(
       bd =>
         fromMilliDecimal((bd.value * 1000)
           .setScale(0, BigDecimal.RoundingMode.HALF_UP))
           .toRightNec("Invalid SignalToNoise value $bd"),
-      _.toPosBigDecimal)
+      _.toNonNegBigDecimal)
   /**
    * Formats to the canonical String representation for SignalToNoise.
    *

--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbSignalToNoise.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/ArbSignalToNoise.scala
@@ -4,9 +4,9 @@
 package lucuma.core.math
 package arb
 
-import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.numeric.NonNegative
 import eu.timepit.refined.refineV
-import eu.timepit.refined.types.numeric.PosBigDecimal
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
 import lucuma.core.math.arb.ArbRefined.given
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.*
@@ -23,25 +23,25 @@ trait ArbSignalToNoise {
 
   private val validBigDecimalSignalToNoise: Gen[BigDecimal] =
     Gen
-      .choose(1L, 9_999_999_999L)
+      .choose(0L, 9_999_999_999L)
       .map(BigDecimal(_, 3))
 
-  private val validPosBigDecimalSignalToNoise: Gen[PosBigDecimal] =
-    validBigDecimalSignalToNoise.map(refineV[Positive](_).getOrElse(throw new RuntimeException))
+  private val validNonNegBigDecimalSignalToNoise: Gen[NonNegBigDecimal] =
+    validBigDecimalSignalToNoise.map(refineV[NonNegative](_).getOrElse(throw new RuntimeException))
 
   private val coverageExamples: Gen[BigDecimal] =
     Gen
-      .choose(1L, 9_999_999_999_999L)
+      .choose(0L, 9_999_999_999_999L)
       .map(BigDecimal(_, 6))
 
-  private val coverageExamplesPosBigDecimal: Gen[PosBigDecimal] =
-    coverageExamples.map(refineV[Positive](_).getOrElse(throw new RuntimeException))
+  private val coverageExamplesNonNegBigDecimal: Gen[NonNegBigDecimal] =
+    coverageExamples.map(refineV[NonNegative](_).getOrElse(throw new RuntimeException))
 
   val bigDecimalSignalToNoise: Gen[BigDecimal] =
     Gen.oneOf(validBigDecimalSignalToNoise, coverageExamples, arbitrary[BigDecimal])
 
-  val posBigDecimalSignalToNoise: Gen[PosBigDecimal] =
-    Gen.oneOf(validPosBigDecimalSignalToNoise, coverageExamplesPosBigDecimal, arbitrary[PosBigDecimal])
+  val nonNegBigDecimalSignalToNoise: Gen[NonNegBigDecimal] =
+    Gen.oneOf(validNonNegBigDecimalSignalToNoise, coverageExamplesNonNegBigDecimal, validNonNegBigDecimalSignalToNoise)
 
   val stringSignalToNoise: Gen[String] = {
     val v = validBigDecimalSignalToNoise.map(_.toString)

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/SignalToNoiseSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/SignalToNoiseSuite.scala
@@ -39,8 +39,8 @@ final class SignalToNoiseSuite extends munit.DisciplineSuite {
   checkAll("FromBigDecimalExact",       PrismTests(SignalToNoise.FromBigDecimalExact))
   checkAll("FromBigDecimalRounding",
     ValidSplitEpiTests(SignalToNoise.FromBigDecimalRounding).validSplitEpiWith(bigDecimalSignalToNoise))
-  checkAll("FromPosBigDecimalExact",    PrismTests(SignalToNoise.FromNonNegBigDecimalExact))
-  checkAll("FromPosBigDecimalRounding",
+  checkAll("FromNonNegBigDecimalExact", PrismTests(SignalToNoise.FromNonNegBigDecimalExact))
+  checkAll("FromNonNegBigDecimalRounding",
     ValidSplitEpiTests(SignalToNoise.FromNonNegBigDecimalRounding).validSplitEpiWith(nonNegBigDecimalSignalToNoise)
   )
   checkAll("FromString",                FormatTests(SignalToNoise.FromString).formatWith(stringSignalToNoise))

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/SignalToNoiseSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/SignalToNoiseSuite.scala
@@ -6,7 +6,10 @@ package lucuma.core.math
 import cats.Order
 import cats.kernel.laws.discipline.OrderTests
 import eu.timepit.refined.cats.*
-import eu.timepit.refined.scalacheck.all.*
+import eu.timepit.refined.numeric.NonNegative
+import eu.timepit.refined.refineV
+import eu.timepit.refined.scalacheck.numeric.*
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
 import io.circe.testing.CodecTests
 import io.circe.testing.instances.*
 import lucuma.core.math.arb.ArbRefined.given
@@ -15,6 +18,8 @@ import lucuma.core.optics.Format
 import lucuma.core.optics.laws.discipline.FormatTests
 import lucuma.core.optics.laws.discipline.ValidSplitEpiTests
 import monocle.law.discipline.*
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import org.scalacheck.Prop.*
 
 
@@ -22,17 +27,21 @@ final class SignalToNoiseSuite extends munit.DisciplineSuite {
 
   import ArbSignalToNoise.given
   import ArbSignalToNoise.bigDecimalSignalToNoise
-  import ArbSignalToNoise.posBigDecimalSignalToNoise
+  import ArbSignalToNoise.nonNegBigDecimalSignalToNoise
   import ArbSignalToNoise.stringSignalToNoise
+
+  given Arbitrary[NonNegBigDecimal] = Arbitrary {
+    Gen.posNum[BigDecimal].map(refineV[NonNegative](_).getOrElse(throw new RuntimeException))
+  }
 
   checkAll("Order",                     OrderTests[SignalToNoise].order)
   checkAll("JSON Codec",                CodecTests[SignalToNoise].codec)
   checkAll("FromBigDecimalExact",       PrismTests(SignalToNoise.FromBigDecimalExact))
   checkAll("FromBigDecimalRounding",
     ValidSplitEpiTests(SignalToNoise.FromBigDecimalRounding).validSplitEpiWith(bigDecimalSignalToNoise))
-  checkAll("FromPosBigDecimalExact",    PrismTests(SignalToNoise.FromPosBigDecimalExact))
+  checkAll("FromPosBigDecimalExact",    PrismTests(SignalToNoise.FromNonNegBigDecimalExact))
   checkAll("FromPosBigDecimalRounding",
-    ValidSplitEpiTests(SignalToNoise.FromPosBigDecimalRounding).validSplitEpiWith(posBigDecimalSignalToNoise)
+    ValidSplitEpiTests(SignalToNoise.FromNonNegBigDecimalRounding).validSplitEpiWith(nonNegBigDecimalSignalToNoise)
   )
   checkAll("FromString",                FormatTests(SignalToNoise.FromString).formatWith(stringSignalToNoise))
 


### PR DESCRIPTION
Turns out there are edge cases where SignalToNoise can be 0
You can have an all noise picture for example and the ITC returns 0 in some edge cases (extremely faint stars, or odd component combinations)