### PR TITLE
Zipper Updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.76"
+ThisBuild / tlBaseVersion                         := "0.77"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/data/EnumZipper.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/data/EnumZipper.scala
@@ -21,6 +21,9 @@ class EnumZipper[A] private (lefts: List[A], focus: A, rights: List[A])
   def withFocus(a: A)(implicit eq: Eq[A]): EnumZipper[A] =
     findFocus(_ === a)
       .getOrElse(unmodified) // This shouldn't happen. An EnumZipper contains all elements.
+
+  override protected def canEqual(other: Any): Boolean = other.isInstanceOf[EnumZipper[?]]
+
 }
 
 object EnumZipper extends ZipperFactory[EnumZipper] {

--- a/modules/testkit/src/main/scala/lucuma/core/data/ArbZipper.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/data/ArbZipper.scala
@@ -13,20 +13,22 @@ import org.scalacheck.Cogen
 import org.scalacheck.Gen
 
 trait ArbZipper {
-  implicit def arbZipper[A: Arbitrary]: Arbitrary[Zipper[A]] =
-    Arbitrary {
-      val MaxSideLength = 100
 
+  def arbZipper[A: Arbitrary](limit: Int): Arbitrary[Zipper[A]] =
+    Arbitrary {
       for {
         f  <- arbitrary[A]
-        ll <- Gen.choose(0, MaxSideLength)
+        ll <- Gen.choose(0, limit)
         l  <- Gen.listOfN(ll, arbitrary[A])
-        rl <- Gen.choose(0, MaxSideLength)
+        rl <- Gen.choose(0, limit)
         r  <- Gen.listOfN(rl, arbitrary[A])
       } yield Zipper(l, f, r)
     }
 
-  implicit def zipperCogen[A: Cogen]: Cogen[Zipper[A]] =
+  given[A: Arbitrary]: Arbitrary[Zipper[A]] =
+    arbZipper(100)
+
+  given[A: Cogen]: Cogen[Zipper[A]] =
     Cogen[(List[A], A, List[A])].contramap(z => (z.lefts, z.focus, z.rights))
 
 }


### PR DESCRIPTION
Adds a few updates to `Zipper`:

* `indexOfFocus` to get the list index of the focused element
* `focusIndex` to take a list index and make it the focus of the `Zipper`
* implements `equals` and `hashCode`.  we have an `Eq` instance but without `equals` comparing zippers (or anything that contains zippers) in a test case will fail
* implements `toString` for debugging
* adds a few trivial constructors