### PR TITLE
Planned time enums

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ChargeClass.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ChargeClass.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+/**
+ * Indication of which entity (if any) is to be charged for program execution time.
+ */
+enum ChargeClass(val tag: String, val name: String, val description: String) derives Enumerated {
+
+  case NonCharged extends ChargeClass("nonCharged", "Non Charged", "Time that is not charged.")
+  case Partner    extends ChargeClass("partner",    "Partner",     "Time charged to a partner country / entity.")
+  case Program    extends ChargeClass("program",    "Program",     "Time charged to the science program.")
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObserveClass.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObserveClass.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import cats.Monoid
+import cats.syntax.order.*
+import lucuma.core.util.Enumerated
+
+/**
+ * The class of an individual observe and (considering all the observes in an
+ * observation) of the observation itself.
+ */
+enum ObserveClass(
+  val tag:          String,
+  val name:         String,
+  val abbreviation: String,
+
+  /**
+   * Which entity (if any) is charged for the time associated with the
+   * observe's dataset(s).
+   */
+  val chargeClass:  ChargeClass,
+
+  /**
+   * Are the datasets associated with this observe considered to be
+   * calibration datasets.
+   */
+  val isCalibration: Boolean,
+
+  /**
+   * Whether the datasets produced by the corresponding observe respect the
+   * overall proprietary period (or are instead immediately made public).
+   */
+  val respectsProprietaryPeriod: Boolean
+
+) derives Enumerated {
+
+  case Science extends ObserveClass(
+    "science",
+    "Science",
+    "SCI",
+    ChargeClass.Program,
+    isCalibration             = false,
+    respectsProprietaryPeriod = true
+  )
+
+  case ProgramCal extends ObserveClass(
+    "programCal",
+    "Nighttime Program Calibration",
+    "NCAL",
+    ChargeClass.Program,
+    isCalibration             = true,
+    respectsProprietaryPeriod = false
+  )
+
+  case PartnerCal extends ObserveClass(
+    "partnerCal",
+    "Nighttime Partner Calibration",
+    "PCAL",
+    ChargeClass.Partner,
+    isCalibration             = true,
+    respectsProprietaryPeriod = false
+  )
+
+  case Acquisition extends ObserveClass(
+    "acquisition",
+    "Acquisition",
+    "ACQ",
+    ChargeClass.Program,
+    isCalibration             = false,
+    respectsProprietaryPeriod = true
+  )
+
+  case AcquisitionCal extends ObserveClass(
+    "acquisitionCal",
+    "Acquisition Calibration",
+    "ACAL",
+    ChargeClass.Partner,
+    isCalibration             = true,
+    respectsProprietaryPeriod = false
+  )
+
+  case DayCal extends ObserveClass(
+    "dayCal",
+    "Daytime Calibration",
+    "DCAL",
+    ChargeClass.NonCharged,
+    isCalibration             = true,
+    respectsProprietaryPeriod = false
+  )
+
+}
+
+object ObserveClass {
+
+  given Monoid[ObserveClass] with {
+    def empty: ObserveClass =
+      ObserveClass.DayCal
+
+    def combine(c0: ObserveClass, c1: ObserveClass): ObserveClass =
+      c0 min c1
+  }
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObserveClass.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObserveClass.scala
@@ -9,7 +9,9 @@ import lucuma.core.util.Enumerated
 
 /**
  * The class of an individual observe and (considering all the observes in an
- * observation) of the observation itself.
+ * observation) of the observation itself.  The observe classes are listed in
+ * priority order.  For example, if one step is a `ProgramCal` and another is
+ * a `Science` step, the atom that contains them both is considered `Science`.
  */
 enum ObserveClass(
   val tag:          String,

--- a/modules/tests/shared/src/test/scala/lucuma/core/enums/ObserveClassSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enums/ObserveClassSuite.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import cats.kernel.laws.discipline.MonoidTests
+import monocle.law.discipline.IsoTests
+import munit.DisciplineSuite
+
+final class ObserveClassSuite extends DisciplineSuite {
+
+  import lucuma.core.util.arb.ArbEnumerated._
+
+  checkAll("Monoid[ObserveClass]", MonoidTests[ObserveClass].monoid)
+
+}


### PR DESCRIPTION
Adds a couple of enums that will be needed for planned time calculation.  Instrument features like available filters will ultimately defined in the database, but I believe these enums are of a kind that belong in code.