### PR TITLE
Planned time model classes

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ConfigChangeEstimate.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ConfigChangeEstimate.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.Order
+import cats.data.NonEmptyList
+import lucuma.core.data.Zipper
+import lucuma.core.util.TimeSpan
+
+/**
+ * Time required for a particular configuration change, as
+ * indicated by name and description.
+ */
+case class ConfigChangeEstimate(
+  name:        String,
+  description: String,
+  estimate:    TimeSpan
+)
+
+object ConfigChangeEstimate {
+
+  /**
+   * Order primarily by the time estimate itself.
+   */
+  given Order[ConfigChangeEstimate] =
+    Order.by { e => (
+      e.estimate,
+      e.name,
+      e.description
+    )}
+
+  /**
+   * Selects the maximum ConfigChangeEstimate from a list, keeping up with all
+   * the remaining items as well.  Multiple config changes happen in parallel,
+   * so the maximum cost is the cost for the lot of them.
+   */
+  def zipMax(estimates: NonEmptyList[ConfigChangeEstimate]): Zipper[ConfigChangeEstimate] =
+    Zipper.fromNel(estimates).focusMax
+
+}
+

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/DatasetEstimate.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/DatasetEstimate.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.Monoid
+import cats.Order
+import lucuma.core.util.TimeSpan
+
+import scala.annotation.targetName
+
+/**
+ * Time required to produce an individual dataset.  This consists of the
+ * exposure itself, followed by detector readout and then write to permanent store.
+ */
+case class DatasetEstimate(
+  exposure: TimeSpan,
+  readout:  TimeSpan,
+  write:    TimeSpan
+) {
+
+  /**
+   * Sum of the exposure, readout, and write time.
+   */
+  def estimate: TimeSpan =
+    exposure +| readout +| write
+
+  /**
+   * Adds two DatasetEstimates by combining the two exposure times, the two
+   * readouts, and the two writes.
+   */
+  @targetName("boundedAdd")
+  def +|(other: DatasetEstimate): DatasetEstimate =
+    DatasetEstimate(
+      exposure +| other.exposure,
+      readout  +| other.readout,
+      write    +| other.write
+    )
+}
+
+object DatasetEstimate {
+
+  val Zero: DatasetEstimate =
+    DatasetEstimate(TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero)
+
+  /**
+   * Order primarily  by the total time estimate.
+   */
+  given Order[DatasetEstimate] =
+    Order.by { e => (
+      e.estimate,
+      e.exposure,
+      e.readout,
+      e.write
+    )}
+
+  given Monoid[DatasetEstimate] =
+    Monoid.instance(Zero, _ +| _)
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/DetectorEstimate.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/DetectorEstimate.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.Order
+import cats.data.NonEmptyList
+import eu.timepit.refined.types.numeric.NonNegInt
+import lucuma.core.data.Zipper
+import lucuma.core.util.TimeSpan
+
+/**
+ * Time required for an individual detector to produce its datasets for a given
+ * step.  Many instruments (like GMOS-N and GMOS-S) have a single detector that
+ * produces a single dataset per step.  Newer instruments (like GHOST's blue
+ * red detectors) have multiple detectors and each may produce multiple
+ * datasets.
+ */
+case class DetectorEstimate(
+  name:        String,
+  description: String,
+  dataset:     DatasetEstimate,
+  count:       NonNegInt
+) {
+
+  /**
+   * Time for this detector to produce `count` datasets.
+   */
+  lazy val estimate: TimeSpan =
+    dataset.estimate *| count.value
+
+}
+
+object DetectorEstimate {
+
+  def zero(name: String, description: String): DetectorEstimate =
+    DetectorEstimate(name, description, DatasetEstimate.Zero, NonNegInt.unsafeFrom(0))
+
+  given Order[DetectorEstimate] =
+    Order.by { e => (
+      e.dataset,
+      e.count.value,
+      e.name,
+      e.description
+    )}
+
+  /**
+   * Selects the maximum DetectorEstimate from a list, keeping up with all
+   * the remaining items as well.  When there are multiple detectors in use,
+   * the time for the step as a whole is the time for the one that takes the
+   * longest to produce all its datasets.
+   */
+  def zipMax(estimates: NonEmptyList[DetectorEstimate]): Zipper[DetectorEstimate] =
+    Zipper.fromNel(estimates).focusMax
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/PlannedTime.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/PlannedTime.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.Eq
+import cats.Monoid
+import cats.implicits.catsKernelOrderingForOrder
+import cats.syntax.eq.*
+import cats.syntax.foldable.*
+import cats.syntax.functor.*
+import cats.syntax.semigroup.*
+import lucuma.core.enums.ChargeClass
+import lucuma.core.enums.ObserveClass
+import lucuma.core.util.TimeSpan
+
+import scala.annotation.targetName
+import scala.collection.immutable.SortedMap
+
+opaque type PlannedTime = SortedMap[ChargeClass, TimeSpan]
+
+/**
+ * Planned time broken down by charge class.
+ */
+object PlannedTime {
+
+  val Zero: PlannedTime =
+    SortedMap.empty
+
+  def apply(charges: (ChargeClass, TimeSpan)*): PlannedTime =
+    SortedMap(charges*)
+
+  def from(it: IterableOnce[(ChargeClass, TimeSpan)]): PlannedTime =
+    SortedMap.from(it)
+
+  /**
+   * Creates a `PlannedTime` instance where the entirety of the step estimate
+   * is associated with the `ObserveClass`'s `ChargeClass`.
+   */
+  def fromStep(observeClass: ObserveClass, stepEstimate: StepEstimate): PlannedTime =
+    apply(observeClass.chargeClass -> stepEstimate.total)
+
+  extension (pt: PlannedTime) {
+
+    /**
+     * Gets the time charged for the given charge class (or TimeSpan.Zero if no
+     * charge is recorded).  Alias for `getOrZero`.
+     */
+    def apply(chargeClass: ChargeClass): TimeSpan =
+      getOrZero(chargeClass)
+
+    // N.B., if you refer to `apply` within this extensions object, it will
+    // find the Map apply :-/ For that reason I added `getOrZero`.
+
+    /**
+     * Gets the time charged for the given charge class (or TimeSpan.Zero if no
+     * charge is recorded).
+     */
+    def getOrZero(chargeClass: ChargeClass): TimeSpan =
+      pt.getOrElse(chargeClass, TimeSpan.Zero)
+
+    /**
+     * Returns `true` if there are no charges for any charge class.
+     */
+    def isZero: Boolean =
+      pt.forall(_._2.toMicroseconds === 0)
+
+    /**
+     * Returns `true` if there are is a charge for at least one charge class.
+     */
+    def nonZero: Boolean =
+      !isZero
+
+    /**
+     * Returns an updated PlannedTime value, changing the charge associated
+     * with `chargeClass` to `time`.
+     */
+    def updated(chargeClass: ChargeClass, time: TimeSpan): PlannedTime =
+      pt.updated(chargeClass, time)
+
+    /**
+     * Sums the current charge associated with `chargeClass` with the given
+     * `time`, returning a new PlannedTime value.
+     */
+    def sumCharge(chargeClass: ChargeClass, time: TimeSpan): PlannedTime =
+      pt.updated(chargeClass, getOrZero(chargeClass) +| time)
+
+    /**
+     * Sums all the charges regardless of charge class.
+     */
+    def sum: TimeSpan =
+      ChargeClass.values.toList.foldMap(getOrZero)
+
+    /**
+     * Lists the charge classes and their time value.
+     */
+    def charges: List[(ChargeClass, TimeSpan)] =
+      ChargeClass.values.toList.fproduct(getOrZero)
+
+    /**
+     * Adds the corresponding charges for two PlannedTime values.
+     */
+    @targetName("boundedAdd")
+    def +|(other: PlannedTime): PlannedTime =
+      other.charges.foldLeft(pt) { case (res, (chargeClass, time)) =>
+        res.sumCharge(chargeClass, time)
+      }
+  }
+
+  given Monoid[PlannedTime] =
+    Monoid.instance(Zero, _ +| _)
+
+  given Eq[PlannedTime] =
+    Eq.by(_.charges)
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/StepEstimate.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/StepEstimate.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.Eq
+import cats.data.NonEmptyList
+import cats.syntax.foldable.*
+import cats.syntax.monoid.*
+import lucuma.core.data.Zipper
+import lucuma.core.util.TimeSpan
+
+case class StepEstimate(
+  configChange: Option[Zipper[ConfigChangeEstimate]],
+  detector:     Option[Zipper[DetectorEstimate]]
+) {
+
+  /**
+   * Total time estimate for the selected configuration change (if any) and
+   * the selected detector estimate (if any).
+   */
+  lazy val total: TimeSpan =
+    configChange.foldMap(_.focus.estimate) |+| detector.foldMap(_.focus.estimate)
+
+}
+
+object StepEstimate {
+
+  val Zero: StepEstimate =
+    StepEstimate(None, None)
+
+  def fromMax(
+    configChange: List[ConfigChangeEstimate],
+    detector:     List[DetectorEstimate]
+  ): StepEstimate =
+    StepEstimate(
+      Zipper.fromList(configChange).map(_.focusMax),
+      Zipper.fromList(detector).map(_.focusMax)
+    )
+
+  given Eq[StepEstimate] =
+    Eq.by { a => (
+      a.configChange,
+      a.detector
+    )}
+
+}

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbConfigChangeEstimate.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbConfigChangeEstimate.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+package arb
+
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.arb.ArbTimeSpan
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbConfigChangeEstimate {
+
+  import ArbTimeSpan.given
+
+  given Arbitrary[ConfigChangeEstimate] =
+    Arbitrary {
+      for {
+        n <- arbitrary[String]
+        d <- arbitrary[String]
+        e <- arbitrary[TimeSpan]
+      } yield ConfigChangeEstimate(n, d, e)
+    }
+
+  given Cogen[ConfigChangeEstimate] =
+    Cogen[(String, String, TimeSpan)].contramap { a =>
+      (a.name, a.description, a.estimate)
+    }
+}
+
+object ArbConfigChangeEstimate extends ArbConfigChangeEstimate

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbDatasetEstimate.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbDatasetEstimate.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+package arb
+
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.arb.ArbTimeSpan
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+
+trait ArbDatasetEstimate {
+  import ArbTimeSpan.given
+
+  given Arbitrary[DatasetEstimate] =
+    Arbitrary {
+      for {
+        e <- arbitrary[TimeSpan]
+        r <- arbitrary[TimeSpan]
+        w <- arbitrary[TimeSpan]
+      } yield DatasetEstimate(e, r, w)
+    }
+
+  given Cogen[DatasetEstimate] =
+    Cogen[(TimeSpan, TimeSpan, TimeSpan)].contramap { a =>
+      (a.exposure, a.readout, a.write)
+    }
+
+}
+
+object ArbDatasetEstimate extends ArbDatasetEstimate

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbDetectorEstimate.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbDetectorEstimate.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+package arb
+
+import eu.timepit.refined.types.numeric.NonNegInt
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+
+trait ArbDetectorEstimate {
+  import ArbDatasetEstimate.given
+
+  given Arbitrary[DetectorEstimate] =
+    Arbitrary {
+      for {
+        n <- arbitrary[String]
+        d <- arbitrary[String]
+        e <- arbitrary[DatasetEstimate]
+        c <- Gen.chooseNum(0, Int.MaxValue)
+      } yield DetectorEstimate(n, d, e, NonNegInt.unsafeFrom(c))
+    }
+
+  given Cogen[DetectorEstimate] =
+    Cogen[(String, String, DatasetEstimate, Int)].contramap { a =>
+      (a.name, a.description, a.dataset, a.count.value)
+    }
+
+}
+
+object ArbDetectorEstimate extends ArbDetectorEstimate

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbPlannedTime.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbPlannedTime.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+package arb
+
+import lucuma.core.enums.ChargeClass
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.arb.ArbTimeSpan
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbPlannedTime {
+
+  import ArbTimeSpan.given
+  import ArbEnumerated._
+
+  given Arbitrary[PlannedTime] =
+    Arbitrary {
+      arbitrary[Set[(ChargeClass, TimeSpan)]].map(PlannedTime.from)
+    }
+
+  given Cogen[PlannedTime] =
+    Cogen[List[(ChargeClass, TimeSpan)]].contramap(_.charges)
+
+}
+
+object ArbPlannedTime extends ArbPlannedTime

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbStepEstimate.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbStepEstimate.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+package arb
+
+import cats.syntax.option.*
+import lucuma.core.data.Zipper
+import lucuma.core.data.arb.ArbZipper
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbStepEstimate {
+
+  import ArbConfigChangeEstimate.given
+  import ArbDetectorEstimate.given
+  import ArbZipper.arbZipper
+
+  private given [A: Arbitrary]: Arbitrary[Zipper[A]] =
+    Arbitrary {arbitrary(arbZipper[A](3))}
+
+  private given [A: Cogen]: Cogen[Zipper[A]] =
+    ArbZipper.given_Cogen_Zipper
+
+  given Arbitrary[StepEstimate] =
+    Arbitrary {
+      for {
+        c <- arbitrary[Option[Zipper[ConfigChangeEstimate]]]
+        d <- arbitrary[Option[Zipper[DetectorEstimate]]]
+      } yield StepEstimate(c, d)
+    }
+
+  given Cogen[StepEstimate] =
+    Cogen[(
+      Option[Zipper[ConfigChangeEstimate]],
+      Option[Zipper[DetectorEstimate]]
+    )].contramap { a =>
+      (a.configChange, a.detector)
+    }
+
+}
+
+object ArbStepEstimate extends ArbStepEstimate

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/ConfigChangeEstimateSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/ConfigChangeEstimateSuite.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.kernel.laws.discipline.*
+import cats.laws.discipline.arbitrary.*
+import lucuma.core.model.sequence.arb.ArbConfigChangeEstimate
+import munit.*
+
+final class ConfigChangeEstimateSuite extends DisciplineSuite {
+
+  import ArbConfigChangeEstimate.given
+
+  checkAll("Order[ConfigChangeEstimate]", OrderTests[ConfigChangeEstimate].order)
+
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DatasetEstimateSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DatasetEstimateSuite.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.kernel.laws.discipline.*
+import cats.laws.discipline.arbitrary.*
+import lucuma.core.model.sequence.arb.ArbDatasetEstimate
+import munit.*
+
+final class DatasetEstimateSuite extends DisciplineSuite {
+
+  import ArbDatasetEstimate.given
+
+  checkAll("Order[DatasetEstimate]", OrderTests[DatasetEstimate].order)
+  checkAll("Monoid[DatasetEstimate", MonoidTests[DatasetEstimate].monoid)
+
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DetectorEstimateSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DetectorEstimateSuite.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.kernel.laws.discipline.*
+import cats.laws.discipline.arbitrary.*
+import lucuma.core.model.sequence.arb.ArbDetectorEstimate
+import munit.*
+
+final class DetectorEstimateSuite extends DisciplineSuite {
+
+  import ArbDetectorEstimate.given
+
+  checkAll("Order[DetectorEstimate]", OrderTests[DetectorEstimate].order)
+
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/PlannedTimeSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/PlannedTimeSuite.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.kernel.laws.discipline.*
+import cats.laws.discipline.arbitrary.*
+import cats.syntax.monoid.*
+import lucuma.core.enums.ChargeClass
+import lucuma.core.model.sequence.arb.ArbPlannedTime
+import munit.*
+import org.scalacheck.Prop.forAll
+
+final class PlannedTimeSuite extends DisciplineSuite {
+
+  import ArbPlannedTime.given
+
+  checkAll("Eq[PlannedTime]",     EqTests[PlannedTime].eqv)
+  checkAll("Monoid[PlannedTime]", MonoidTests[PlannedTime].monoid)
+
+  test("monoid") {
+    forAll { (a: PlannedTime, b: PlannedTime) =>
+      val c = a |+| b
+      val d = a.charges.foldLeft(b) { case (r, (cc, ts)) =>
+        r.sumCharge(cc, ts)
+      }
+      assertEquals(c, d)
+    }
+  }
+
+  test("apply") {
+    forAll { (a: PlannedTime) =>
+      assertEquals(a(ChargeClass.Program), a.getOrZero(ChargeClass.Program))
+    }
+  }
+
+}


### PR DESCRIPTION
This is a collection of model classes for keeping up with time estimates during the planned time calculation. At this point, none of these objects are used in the codebase but they will be referenced in the sequence model in the next PR (and ultimately computed in the database).

__`StepEstimate`__ Contains detailed time estimation information for a single step.  This will replace the simplistic `StepTime`.  In particular, a step estimate contains a collection of `ConfigChangeEstimate` and a collection of `DetectorEstimate`.  In each case, the maximum time element in the collection is taken as the overall "config change" or "detector" time.  This is because configuration changes and detectors are read in parallel so there's no need to sum them. To hold the collection along with the selection, a `Zipper` is employed.

As an example, if step requires an offset that takes 7 seconds, and also moves the filter wheel requiring 20 seconds, you only need to figure that the configuration change as a whole is 20 seconds.

* __`ConfigChangeEstimate`__ An individual configuration change.  For example, to hold the cost of moving the science fold in order to perform a calibration.

* __`DetectorEstimate`__ A detector can produce a number of datasets per step, each of which is individually estimated in a `DatasetEstimate`.  An instrument can have multiple detectors, so the step has a collection of `DetectorEstimate`.  In the case of GMOS, this will always be one and it will always produce a single dataset per step.

* __`DatasetEstimate`__ The exposure, read and write times for a single dataset.

__`PlannedTime`__ Planned time breaks a time amount across `ChargeClass`es.  Each step/observe is associated with an `ObserveClass` which in turn has a corresponding `ChargeClass`.  The planned time for a single step, then, is all associated with a single `ChargeClass`.  `PlannedTime` can be summed though, such that the planned time for an `Atom` is the sum of the planned times for its steps and each step may have a different `ObserveClass`.  Similarly the planned time for a `Sequence` is the sum of the planned time for its atoms.

