### PR TITLE
Remove digest artifacts from sequence

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.81"
+ThisBuild / tlBaseVersion                         := "0.82"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ExecutionConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ExecutionConfig.scala
@@ -18,20 +18,8 @@ import monocle.Lens
 case class ExecutionConfig[S, D](
   static:        S,
   acquisition:   Option[ExecutionSequence[D]],
-  science:       Option[ExecutionSequence[D]],
-  setup:         SetupTime
-) {
-
-  /**
-   * Execution summary computed from the sequences.
-   */
-  def executionDigest: ExecutionDigest =
-    ExecutionDigest(
-      setup,
-      acquisition.fold(SequenceDigest.Zero)(_.digest),
-      science.fold(SequenceDigest.Zero)(_.digest)
-    )
-}
+  science:       Option[ExecutionSequence[D]]
+)
 
 object ExecutionConfig {
 
@@ -39,8 +27,7 @@ object ExecutionConfig {
     Eq.by { a => (
       a.static,
       a.acquisition,
-      a.science,
-      a.setup
+      a.science
     )}
 
   /** @group Optics */
@@ -54,9 +41,5 @@ object ExecutionConfig {
   /** @group Optics */
   def science[S, D]: Lens[ExecutionConfig[S, D], Option[ExecutionSequence[D]]] =
     Focus[ExecutionConfig[S, D]](_.science)
-
-  /** @group Optics */
-  def setup[S, D]: Lens[ExecutionConfig[S, D], SetupTime] =
-    Focus[ExecutionConfig[S, D]](_.setup)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ExecutionSequence.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ExecutionSequence.scala
@@ -26,16 +26,12 @@ import monocle.Lens
  * @param atomCount      number of atoms that we may expect, including the next
  *                       atom, the possible future, and any that haven't been
  *                       included in the possible future
- * @param digest         compilation of attributes about the sequence as a
- *                       whole, including `possibleFuture` and all expected
- *                       subsequent atoms
  */
 case class ExecutionSequence[D](
   nextAtom:       Atom[D],
   possibleFuture: List[Atom[D]],
   hasMore:        Boolean,
-  atomCount:      PosInt,
-  digest:         SequenceDigest
+  atomCount:      PosInt
 )
 
 object ExecutionSequence {
@@ -56,17 +52,12 @@ object ExecutionSequence {
   def atomCount[D]: Lens[ExecutionSequence[D], PosInt] =
     Focus[ExecutionSequence[D]](_.atomCount)
 
-  /** @group Optics */
-  def digest[D]: Lens[ExecutionSequence[D], SequenceDigest] =
-    Focus[ExecutionSequence[D]](_.digest)
-
   given [D](using Eq[D]): Eq[ExecutionSequence[D]] =
     Eq.by { a => (
       a.nextAtom,
       a.possibleFuture,
       a.hasMore,
-      a.atomCount.value,
-      a.digest
+      a.atomCount.value
     )}
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ExecutionSequence.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ExecutionSequence.scala
@@ -5,7 +5,6 @@ package lucuma.core.model.sequence
 
 import cats.Eq
 import cats.syntax.all.*
-import eu.timepit.refined.types.numeric.PosInt
 import monocle.Focus
 import monocle.Lens
 
@@ -23,15 +22,11 @@ import monocle.Lens
  *                       not include all potential future atoms that are known
  *                       at the time of creation)
  * @param hasMore        whether the `possibleFuture` is incomplete
- * @param atomCount      number of atoms that we may expect, including the next
- *                       atom, the possible future, and any that haven't been
- *                       included in the possible future
  */
 case class ExecutionSequence[D](
   nextAtom:       Atom[D],
   possibleFuture: List[Atom[D]],
-  hasMore:        Boolean,
-  atomCount:      PosInt
+  hasMore:        Boolean
 )
 
 object ExecutionSequence {
@@ -48,16 +43,11 @@ object ExecutionSequence {
   def hasMore[D]: Lens[ExecutionSequence[D], Boolean] =
     Focus[ExecutionSequence[D]](_.hasMore)
 
-  /** @group Optics */
-  def atomCount[D]: Lens[ExecutionSequence[D], PosInt] =
-    Focus[ExecutionSequence[D]](_.atomCount)
-
   given [D](using Eq[D]): Eq[ExecutionSequence[D]] =
     Eq.by { a => (
       a.nextAtom,
       a.possibleFuture,
-      a.hasMore,
-      a.atomCount.value
+      a.hasMore
     )}
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/InstrumentExecutionConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/InstrumentExecutionConfig.scala
@@ -14,7 +14,6 @@ import monocle.macros.GenPrism
  */
 sealed trait InstrumentExecutionConfig {
   def instrument: Instrument
-  def executionDigest: ExecutionDigest
 }
 
 object InstrumentExecutionConfig {
@@ -24,9 +23,6 @@ object InstrumentExecutionConfig {
   ) extends InstrumentExecutionConfig {
     def instrument: Instrument =
       Instrument.GmosNorth
-
-    def executionDigest: ExecutionDigest =
-      executionConfig.executionDigest
   }
 
   object GmosNorth {
@@ -42,9 +38,6 @@ object InstrumentExecutionConfig {
   ) extends InstrumentExecutionConfig {
     def instrument: Instrument =
       Instrument.GmosSouth
-
-    def executionDigest: ExecutionDigest =
-      executionConfig.executionDigest
   }
 
   object GmosSouth {

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbExecutionConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbExecutionConfig.scala
@@ -11,7 +11,6 @@ import org.scalacheck.Cogen
 
 trait ArbExecutionConfig {
   import ArbExecutionSequence.given
-  import ArbSetupTime.given
 
   given [S: Arbitrary, D: Arbitrary]: Arbitrary[ExecutionConfig[S, D]] =
     Arbitrary {
@@ -19,13 +18,12 @@ trait ArbExecutionConfig {
         s <- arbitrary[S]
         a <- arbitrary[Option[ExecutionSequence[D]]]
         n <- arbitrary[Option[ExecutionSequence[D]]]
-        t <- arbitrary[SetupTime]
-      } yield ExecutionConfig(s, a, n, t)
+      } yield ExecutionConfig(s, a, n)
     }
 
   given [S: Cogen, D: Cogen]: Cogen[ExecutionConfig[S, D]] =
-    Cogen[(S, Option[ExecutionSequence[D]], Option[ExecutionSequence[D]], SetupTime)].contramap { a =>
-      (a.static, a.acquisition, a.science, a.setup)
+    Cogen[(S, Option[ExecutionSequence[D]], Option[ExecutionSequence[D]])].contramap { a =>
+      (a.static, a.acquisition, a.science)
     }
 
 }

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbExecutionSequence.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbExecutionSequence.scala
@@ -4,13 +4,10 @@
 package lucuma.core.model.sequence
 package arb
 
-import cats.syntax.all.*
-import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.util.arb.ArbBoundedCollection
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen
-import org.scalacheck.Gen
 
 trait ArbExecutionSequence {
   import ArbAtom.given
@@ -21,21 +18,18 @@ trait ArbExecutionSequence {
       for {
         as <- genBoundedNonEmptyList[Atom[D]](BoundedCollectionLimit)
         m  <- arbitrary[Boolean]
-        n  <- Gen.posNum[Int].map(_ max as.length).map(PosInt.unsafeFrom)
-      } yield ExecutionSequence(as.head, as.tail, m, n)
+      } yield ExecutionSequence(as.head, as.tail, m)
     }
 
   given [D: Cogen]: Cogen[ExecutionSequence[D]] =
     Cogen[(
       Atom[D],
       List[Atom[D]],
-      Boolean,
-      Int
+      Boolean
     )].contramap { a => (
       a.nextAtom,
       a.possibleFuture,
-      a.hasMore,
-      a.atomCount.value
+      a.hasMore
     )}
 
 }

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbExecutionSequence.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbExecutionSequence.scala
@@ -15,7 +15,6 @@ import org.scalacheck.Gen
 trait ArbExecutionSequence {
   import ArbAtom.given
   import ArbBoundedCollection.*
-  import ArbSequenceDigest.given
 
   given [D: Arbitrary]: Arbitrary[ExecutionSequence[D]] =
     Arbitrary {
@@ -23,8 +22,7 @@ trait ArbExecutionSequence {
         as <- genBoundedNonEmptyList[Atom[D]](BoundedCollectionLimit)
         m  <- arbitrary[Boolean]
         n  <- Gen.posNum[Int].map(_ max as.length).map(PosInt.unsafeFrom)
-        d  <- arbitrary[SequenceDigest]
-      } yield ExecutionSequence(as.head, as.tail, m, n, d)
+      } yield ExecutionSequence(as.head, as.tail, m, n)
     }
 
   given [D: Cogen]: Cogen[ExecutionSequence[D]] =
@@ -32,14 +30,12 @@ trait ArbExecutionSequence {
       Atom[D],
       List[Atom[D]],
       Boolean,
-      Int,
-      SequenceDigest
+      Int
     )].contramap { a => (
       a.nextAtom,
       a.possibleFuture,
       a.hasMore,
-      a.atomCount.value,
-      a.digest
+      a.atomCount.value
     )}
 
 }

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbSequenceDigest.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbSequenceDigest.scala
@@ -5,6 +5,8 @@ package lucuma.core.model.sequence
 package arb
 
 import cats.Order.catsKernelOrderingForOrder
+import eu.timepit.refined.scalacheck.all.*
+import eu.timepit.refined.types.numeric.NonNegInt
 import lucuma.core.enums.ObserveClass
 import lucuma.core.math.Offset
 import lucuma.core.math.arb.ArbOffset
@@ -26,18 +28,21 @@ trait ArbSequenceDigest {
         c  <- arbitrary[ObserveClass]
         t  <- arbitrary[PlannedTime]
         o  <- arbitrary[SortedSet[Offset]]
-      } yield SequenceDigest(c, t, o)
+        n  <- arbitrary[NonNegInt]
+      } yield SequenceDigest(c, t, o, n)
     }
 
   given Cogen[SequenceDigest] =
     Cogen[(
       ObserveClass,
       PlannedTime,
-      Set[Offset]
+      Set[Offset],
+      NonNegInt
     )].contramap { a => (
       a.observeClass,
       a.plannedTime,
-      a.offsets
+      a.offsets,
+      a.atomCount
     )}
 
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/ExecutionConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/ExecutionConfigSuite.scala
@@ -19,7 +19,6 @@ final class ExecutionConfigSuite extends DisciplineSuite {
   import ArbDynamicConfig.*
   import ArbExecutionConfig.given
   import ArbExecutionSequence.given
-  import ArbSetupTime.given
   import ArbStaticConfig.*
 
   override val scalaCheckTestParameters = Test.Parameters.default.withMaxSize(4)
@@ -28,5 +27,4 @@ final class ExecutionConfigSuite extends DisciplineSuite {
   checkAll("ExecutionConfig.static",        LensTests(ExecutionConfig.static[StaticConfig.GmosNorth, DynamicConfig.GmosNorth]))
   checkAll("ExecutionConfig.acquisition",   LensTests(ExecutionConfig.acquisition[StaticConfig.GmosNorth, DynamicConfig.GmosNorth]))
   checkAll("ExecutionConfig.science",       LensTests(ExecutionConfig.science[StaticConfig.GmosNorth, DynamicConfig.GmosNorth]))
-  checkAll("ExecutionConfig.setup",         LensTests(ExecutionConfig.setup[StaticConfig.GmosNorth, DynamicConfig.GmosNorth]))
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/SequenceDigestSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/SequenceDigestSuite.scala
@@ -4,13 +4,23 @@
 package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.scalacheck.all.*
+import lucuma.core.model.sequence.arb.ArbPlannedTime
 import lucuma.core.model.sequence.arb.ArbSequenceDigest
+import lucuma.core.util.arb.ArbEnumerated
+import monocle.law.discipline.*
 import munit.*
 
 final class SequenceDigestSuite extends DisciplineSuite {
 
+  import ArbEnumerated.*
+  import ArbPlannedTime.given
   import ArbSequenceDigest.given
 
-  checkAll("Eq[SequenceDigest]",     EqTests[SequenceDigest].eqv)
-  checkAll("Monoid[SequenceDigest]", MonoidTests[SequenceDigest].monoid)
+  checkAll("Eq[SequenceDigest]",          EqTests[SequenceDigest].eqv)
+  checkAll("SequenceDigest.observeClass", LensTests(SequenceDigest.observeClass))
+  checkAll("SequenceDigest.plannedTime",  LensTests(SequenceDigest.plannedTime))
+  checkAll("SequenceDigest.atomCount",    LensTests(SequenceDigest.atomCount))
+
 }


### PR DESCRIPTION
The ODB API will be updated to provide `execution` / `digest` and `execution` / `config` queries.  The former (`digest`) returns summary information for which it is required to examine the entire sequence (a fold over all the atoms).  The later (`config`) returns the familiar `nextAtom`, `possibleFuture`, and `hasMore` for each of the `acquisition` and `science` sequences.  This enables the `digest` information to be neatly cached while the expanded `config` can be quickly computed upon request thanks to the tight `futureLimit` that is imposed upon the sequences.

This PR enables the pending ODB update by moving the `atomCount` (and `setupTime`) to the digest.