### PR TITLE
Add an `ObjectTracking` for tracking asterisms of more than one target

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.83"
+ThisBuild / tlBaseVersion                         := "0.84"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/syntax/TrackingOps.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/syntax/TrackingOps.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.syntax
+
+import cats.data.NonEmptyList
+import cats.syntax.all.given
+import lucuma.core.math.Coordinates
+import lucuma.core.model.SiderealTracking
+
+import java.time.Instant
+import scala.annotation.targetName
+
+trait ToTrackingOps {
+  extension(trackings: NonEmptyList[SiderealTracking])
+    // We calculate the coordinates at a given time by doing PM
+    // correction of each tracking and then finding the center
+    @targetName("TrackingList_centerOfAt")
+    def centerOfAt(i: Instant): Option[Coordinates] =
+      trackings
+        .map(_.at(i))
+        .sequence
+        .map(nel => Coordinates.centerOf(nel.toList))
+
+    @targetName("TrackingList_centerOf")
+    def centerOf: Coordinates =
+      val coords = trackings.map(_.baseCoordinates)
+      Coordinates.centerOf(coords.toList)
+    
+}
+
+object tracking extends ToTrackingOps

--- a/modules/core/shared/src/main/scala/lucuma/core/model/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/syntax/package.scala
@@ -4,5 +4,5 @@
 package lucuma.core.model
 
 package object syntax {
-  object all extends ToNonNegDurationOps
+  object all extends ToNonNegDurationOps with ToTrackingOps
 }


### PR DESCRIPTION
This is used to improve asterism tracking in Explore for guide stars and other things. It will also be used in ODB for the guide stars.