### PR TITLE
Fix issue 780

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/Dataset.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/Dataset.scala
@@ -67,7 +67,7 @@ object Dataset {
       Option.when(localDate.getYear >= 0 && localDate.getYear <= 9999)(Filename(site, localDate, index))
 
     private val DateFormatter: DateTimeFormatter =
-      DateTimeFormatter.ofPattern("yyyyMMdd")
+      DateTimeFormatter.ofPattern("uuuuMMdd")
 
     private val parseSiteChar: Site => Char = {
       case Site.GN => 'N'

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DatasetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DatasetSuite.scala
@@ -4,6 +4,7 @@
 package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
+import cats.syntax.option.*
 import lucuma.core.model.sequence.arb.*
 import monocle.law.discipline.*
 import munit.*
@@ -15,4 +16,13 @@ final class DatasetSuite extends DisciplineSuite {
   checkAll("Order[Dataset.Filename]", OrderTests[Dataset.Filename].order)
 
   checkAll("Dataset.Filename.FromString", PrismTests(Dataset.Filename.FromString))
+
+  test("issue #780") {
+    import eu.timepit.refined.types.numeric.PosInt
+    import lucuma.core.enums.Site
+    import java.time.LocalDate
+
+    val f = Dataset.Filename.from(Site.GS, LocalDate.of(0, 12, 16), PosInt.unsafeFrom(1701874008)).get
+    assertEquals(Dataset.Filename.FromString.getOption(f.format), f.some)
+  }
 }


### PR DESCRIPTION
Fixes #780.  Format pattern `yyyy` switches year 0 to year 1 for some very good reason.