### PR TITLE
GMOS binning calculation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.85"
+ThisBuild / tlBaseVersion                         := "0.86"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/binning.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/binning.scala
@@ -1,0 +1,137 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.gmos
+
+import cats.Order
+import cats.syntax.all.*
+import coulomb.Quantity
+import eu.timepit.refined.types.numeric.PosDouble
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.GmosNorthDetector
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosSouthDetector
+import lucuma.core.enums.GmosSouthFpu
+import lucuma.core.enums.GmosSouthGrating
+import lucuma.core.enums.GmosXBinning
+import lucuma.core.enums.GmosYBinning
+import lucuma.core.enums.ImageQuality
+import lucuma.core.math.Angle
+import lucuma.core.math.Wavelength
+import lucuma.core.math.units.NanometersPerPixel
+import lucuma.core.model.SourceProfile
+import spire.math.Rational
+
+import java.math.RoundingMode.HALF_UP
+
+/**
+ * Optimal GMOS spectral and spatial binning calculations.
+ *
+ * See https://docs.google.com/document/d/1P8_pXLRVomUSvofyVkAniOyGROcAtiJ7EMYt9wWXB0o.
+ */
+object binning {
+
+  val DefaultSampling: PosDouble =
+    PosDouble.unsafeFrom(2.5)
+
+  /**
+   * Object angular size estimate based on source profile and image quality.
+   */
+  def objectSize(p: SourceProfile, iq: ImageQuality): Angle =
+    p match {
+      case SourceProfile.Point(_)          => iq.toAngle
+      case SourceProfile.Uniform(_)        => Angle.Angle180
+      case SourceProfile.Gaussian(fwhm, _) => fwhm
+    }
+
+  extension (λ: Angle) {
+    def arcsec: BigDecimal =
+      Angle.decimalArcseconds.get(λ)
+  }
+
+  /**
+   * Minimum of the slit and object size.
+   */
+  def effectiveWidth(
+    slitWidth:  Angle,
+    srcProfile: SourceProfile,
+    iq:         ImageQuality
+  ): Angle = {
+    given Order[Angle] = Angle.AngleOrder
+    slitWidth min objectSize(srcProfile, iq)
+  }
+
+  def spectralBinning(
+    slitWidth:  Angle,
+    srcProfile: SourceProfile,
+    iq:         ImageQuality,
+    dispersion: Quantity[Rational, NanometersPerPixel],
+    resolution: PosInt,
+    blaze:      Wavelength,
+    sampling:   PosDouble = DefaultSampling
+  ): GmosXBinning = {
+
+    // Effective resolution of slit
+    val effRes = resolution.value.toDouble / 2.0 / effectiveWidth(slitWidth, srcProfile, iq).arcsec
+
+    // Unbinned sampling
+    val nPix   = blaze.toNanometers.value.value/effRes/dispersion.value.toBigDecimal(4, HALF_UP)
+
+    // The maximum binning that gives the required sampling (<npix)
+    GmosXBinning.all.tail.reverse.find { bin =>
+      sampling.value < (nPix / bin.count)
+    }.getOrElse(GmosXBinning.One)
+  }
+
+  def northSpectralBinning(
+    fpu:        GmosNorthFpu,
+    srcProfile: SourceProfile,
+    iq:         ImageQuality,
+    grating:    GmosNorthGrating,
+    sampling:   PosDouble = DefaultSampling
+  ): GmosXBinning =
+    spectralBinning(fpu.effectiveSlitWidth, srcProfile, iq, grating.dispersion, grating.referenceResolution, grating.blazeWavelength, sampling)
+
+  def southSpectralBinning(
+    fpu:        GmosSouthFpu,
+    srcProfile: SourceProfile,
+    iq:         ImageQuality,
+    grating:    GmosSouthGrating,
+    sampling:   PosDouble = DefaultSampling
+  ): GmosXBinning =
+    spectralBinning(fpu.effectiveSlitWidth, srcProfile, iq, grating.dispersion, grating.referenceResolution, grating.blazeWavelength, sampling)
+
+  def spatialBinning(
+    srcProfile: SourceProfile,
+    iq:         ImageQuality,
+    pixelScale: Angle,
+    sampling:   PosDouble = DefaultSampling
+  ): GmosYBinning = {
+
+    // Number of unbinned pixels to sample the slit width
+    val npix = objectSize(srcProfile, iq).arcsec / (pixelScale.arcsec * sampling.value)
+
+    // The maximum binning that gives the required sampling (<npix)
+    GmosYBinning.all.tail.reverse.find { bin =>
+      (bin.count - npix) <= 0.0
+    }.getOrElse(GmosYBinning.One)
+  }
+
+  def northSpatialBinning(
+    srcProfile: SourceProfile,
+    iq:         ImageQuality,
+    detector:   GmosNorthDetector = GmosNorthDetector.Hamamatsu,
+    sampling:   PosDouble         = DefaultSampling
+  ): GmosYBinning =
+    spatialBinning(srcProfile, iq, detector.pixelSize, sampling)
+
+  def southSpatialBinning(
+    srcProfile: SourceProfile,
+    iq:         ImageQuality,
+    detector:   GmosSouthDetector = GmosSouthDetector.Hamamatsu,
+    sampling:   PosDouble         = DefaultSampling
+  ): GmosYBinning =
+    spatialBinning(srcProfile, iq, detector.pixelSize, sampling)
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/binning.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/binning.scala
@@ -114,7 +114,7 @@ object binning {
 
     // The maximum binning that gives the required sampling (<npix)
     GmosYBinning.all.tail.reverse.find { bin =>
-      (bin.count - npix) <= 0.0
+      bin.count <= npix
     }.getOrElse(GmosYBinning.One)
   }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/longslit/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/longslit/package.scala
@@ -1,25 +1,25 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.core.model.sequence.gmos.longslit
+package lucuma.core.model.sequence.gmos
+package longslit
 
-import cats.Order
-import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosDouble
 import lucuma.core.enums.GmosAmpCount
 import lucuma.core.enums.GmosAmpGain
 import lucuma.core.enums.GmosAmpReadMode
 import lucuma.core.enums.GmosNorthDetector
 import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosNorthGrating
 import lucuma.core.enums.GmosRoi
 import lucuma.core.enums.GmosSouthDetector
 import lucuma.core.enums.GmosSouthFpu
+import lucuma.core.enums.GmosSouthGrating
 import lucuma.core.enums.GmosXBinning
 import lucuma.core.enums.GmosYBinning
 import lucuma.core.enums.ImageQuality
-import lucuma.core.enums.Site
-import lucuma.core.math.Angle
 import lucuma.core.model.SourceProfile
+
 
 val DefaultAmpReadMode: GmosAmpReadMode =
   GmosAmpReadMode.Slow
@@ -30,69 +30,33 @@ val DefaultAmpGain: GmosAmpGain =
 val DefaultRoi: GmosRoi =
   GmosRoi.FullFrame
 
-val DefaultYBinning: GmosYBinning =
-  GmosYBinning.Two
-
 val DefaultAmpCount: GmosAmpCount =
   GmosAmpCount.Twelve
 
-private given Order[Angle] =
-  Angle.AngleOrder
-
-private val DescendingXBinning: List[GmosXBinning] =
-  GmosXBinning.all.sortBy(b => -b.count)
-
 /**
-  * Object angular size estimate based on source profile alone.
+ * Optimal GMOS binning calculation for longslit.
   */
-def objectSize(p: SourceProfile): Angle =
-  p match {
-    case SourceProfile.Point(_)          => Angle.Angle0
-    case SourceProfile.Uniform(_)        => Angle.Angle180
-    case SourceProfile.Gaussian(fwhm, _) => fwhm
-  }
+def northBinning(
+  fpu:        GmosNorthFpu,
+  srcProfile: SourceProfile,
+  iq:         ImageQuality,
+  grating:    GmosNorthGrating,
+  detector:   GmosNorthDetector = GmosNorthDetector.Hamamatsu,
+  sampling:   PosDouble         = binning.DefaultSampling
+): (GmosXBinning, GmosYBinning) =
+  (binning.northSpectralBinning(fpu, srcProfile, iq, grating, sampling),
+   binning.northSpatialBinning(srcProfile, iq, detector, sampling))
 
 /**
-  * Effective size of a target with the given source profile and image quality.
+ * Optimal GMOS binning calculation for longslit.
   */
-def effectiveSize(p: SourceProfile, iq: ImageQuality): Angle =
-  objectSize(p) max iq.toAngle
-
-def effectiveSlitWidth(p: SourceProfile, iq: ImageQuality, slitWidth: Angle): Angle =
-  slitWidth min effectiveSize(p, iq)
-
-def pixelSize(site: Site): Angle =
-  site match {
-      case Site.GN => GmosNorthDetector.Hamamatsu.pixelSize
-      case Site.GS => GmosSouthDetector.Hamamatsu.pixelSize
-    }
-
-private def xbin(site: Site, slitWidth: Angle, sampling: PosDouble): GmosXBinning = {
-  val npix = slitWidth.toMicroarcseconds.toDouble / pixelSize(site).toMicroarcseconds.toDouble
-  DescendingXBinning.find(b => npix / b.count.toDouble >= sampling.value).getOrElse(GmosXBinning.One)
-}
-
-/**
-* Calculates the best `GmosXBinning` value to use for GMOS North long slit observing for
-* the desired sampling.
-*
-* @param fpu      GMOS North FPU
-* @param p        SourceProfile of the target
-* @param iq       expected/required ImageQuality
-* @param sampling desired sampling rate
-*/
-def xbinNorth(fpu: GmosNorthFpu, p: SourceProfile, iq: ImageQuality, sampling: PosDouble): GmosXBinning =
-  xbin(Site.GN, fpu.effectiveSlitWidth min effectiveSize(p, iq), sampling)
-
-/**
-* Calculates the best `GmosXBinning` value to use for GMOS South long slit observing for
-* the desired sampling.
-*
-* @param fpu      GMOS South FPU
-* @param p        SourceProfile of the target
-* @param iq       expected/required ImageQuality
-* @param sampling desired sampling rate
-*/
-def xbinSouth(fpu: GmosSouthFpu, p: SourceProfile, iq: ImageQuality, sampling: PosDouble): GmosXBinning =
-  xbin(Site.GS, fpu.effectiveSlitWidth min effectiveSize(p, iq), sampling)
-
+def southBinning(
+  fpu:        GmosSouthFpu,
+  srcProfile: SourceProfile,
+  iq:         ImageQuality,
+  grating:    GmosSouthGrating,
+  detector:   GmosSouthDetector = GmosSouthDetector.Hamamatsu,
+  sampling:   PosDouble         = binning.DefaultSampling
+): (GmosXBinning, GmosYBinning) =
+  (binning.southSpectralBinning(fpu, srcProfile, iq, grating, sampling),
+   binning.southSpatialBinning(srcProfile, iq, detector, sampling))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
@@ -10,7 +10,6 @@ import lucuma.core.enums.GmosXBinning
 import lucuma.core.enums.GmosYBinning
 import lucuma.core.enums.ImageQuality
 import lucuma.core.math.Angle
-import lucuma.core.math.BrightnessUnits.Integrated
 import lucuma.core.model.SourceProfile
 import lucuma.core.model.SpectralDefinition.BandNormalized
 import munit.FunSuite
@@ -19,7 +18,7 @@ import scala.collection.immutable.SortedMap
 
 final class BinningSuite extends FunSuite {
 
-  val bandNormalized: BandNormalized[Integrated] =
+  def bandNormalized[T]: BandNormalized[T] =
     BandNormalized(none, SortedMap.empty)
 
   //  Examples with B600
@@ -68,6 +67,17 @@ final class BinningSuite extends FunSuite {
       ImageQuality.PointOne,
       GmosNorthGrating.B600_G5307,
       GmosXBinning.Four,
+      GmosYBinning.Four
+    )
+  }
+
+  test("longslit, B600, slit=0.50, Uniform:  2 4") {
+    testLongslit(
+      GmosNorthFpu.LongSlit_0_50,
+      SourceProfile.Uniform(bandNormalized),
+      ImageQuality.PointOne,
+      GmosNorthGrating.B600_G5307,
+      GmosXBinning.Two,
       GmosYBinning.Four
     )
   }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.gmos
+
+import cats.syntax.option.*
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosXBinning
+import lucuma.core.enums.GmosYBinning
+import lucuma.core.enums.ImageQuality
+import lucuma.core.math.Angle
+import lucuma.core.math.BrightnessUnits.Integrated
+import lucuma.core.model.SourceProfile
+import lucuma.core.model.SpectralDefinition.BandNormalized
+import munit.FunSuite
+
+import scala.collection.immutable.SortedMap
+
+final class BinningSuite extends FunSuite {
+
+  val bandNormalized: BandNormalized[Integrated] =
+    BandNormalized(none, SortedMap.empty)
+
+  //  Examples with B600
+  //  slit=0.50, fwhm=0.6: 2 2
+  //  slit=0.75, fwhm=1.0: 2 4
+  //  slit=1.00, fwhm=1.5: 4 4
+
+  private def testLongslit(
+    fpu:        GmosNorthFpu,
+    srcProfile: SourceProfile,
+    iq:         ImageQuality,
+    grating:    GmosNorthGrating,
+    expectX:    GmosXBinning,
+    expectY:    GmosYBinning
+  ): Unit = {
+    val xy = longslit.northBinning(fpu, srcProfile, iq, grating)
+    assertEquals(xy, (expectX, expectY))
+  }
+
+  test("longslit, B600, slit=0.50, fwhm=0.6: 2 2") {
+    testLongslit(
+      GmosNorthFpu.LongSlit_0_50,
+      SourceProfile.Gaussian(Angle.microarcseconds.reverseGet(600_000L), bandNormalized),
+      ImageQuality.PointOne,
+      GmosNorthGrating.B600_G5307,
+      GmosXBinning.Two,
+      GmosYBinning.Two
+    )
+  }
+
+  test("longslit, B600, slit=0.75, fwhm=1.0: 2 4") {
+    testLongslit(
+      GmosNorthFpu.LongSlit_0_75,
+      SourceProfile.Gaussian(Angle.microarcseconds.reverseGet(1_000_000L), bandNormalized),
+      ImageQuality.PointOne,
+      GmosNorthGrating.B600_G5307,
+      GmosXBinning.Two,
+      GmosYBinning.Four
+    )
+  }
+
+  test("longslit, B600, slit=1.00, fwhm=1.5: 4 4") {
+    testLongslit(
+      GmosNorthFpu.LongSlit_1_00,
+      SourceProfile.Gaussian(Angle.microarcseconds.reverseGet(1_500_000L), bandNormalized),
+      ImageQuality.PointOne,
+      GmosNorthGrating.B600_G5307,
+      GmosXBinning.Four,
+      GmosYBinning.Four
+    )
+  }
+
+}


### PR DESCRIPTION
Updates to GMOS binning calculations based on [the latest specification](https://docs.google.com/document/d/1P8_pXLRVomUSvofyVkAniOyGROcAtiJ7EMYt9wWXB0o).  This will imply changes to the sequence generation code in the ODB, not the least of which will be to update the default Y bin to use the calculation instead of a constant.