### PR TITLE
Dataset Id

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.87"
+ThisBuild / tlBaseVersion                         := "0.88"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ids.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ids.scala
@@ -7,7 +7,6 @@ import lucuma.core.util.WithGid
 import lucuma.refined.*
 
 object Configuration  extends WithGid('c'.refined)
-object Dataset        extends WithGid('d'.refined)
 object Group          extends WithGid('g'.refined)
 object ExecutionEvent extends WithGid('e'.refined)
 object ObsAttachment  extends WithGid('a'.refined)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/Dataset.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/Dataset.scala
@@ -6,11 +6,11 @@ package lucuma.core.model.sequence
 import cats.Order
 import cats.Show
 import cats.syntax.option.*
-import cats.syntax.show.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.PosInt
-import eu.timepit.refined.types.numeric.PosShort
 import lucuma.core.enums.Site
+import lucuma.core.util.WithGid
+import lucuma.refined.*
 import monocle.Prism
 import org.typelevel.cats.time.*
 
@@ -19,26 +19,7 @@ import java.time.format.DateTimeFormatter
 import scala.util.control.Exception.allCatch
 import scala.util.matching.Regex
 
-object Dataset {
-
-  /**
-   * Dataset ID, identifying the corresponding step and an index within the
-   * step.
-   */
-  case class Id(
-    stepId: Step.Id,
-    index:  PosShort
-  )
-
-  object Id {
-    given Order[Id] =
-      Order.by(a => (a.stepId, a.index))
-
-    given Show[Id] with {
-      def show(id: Id): String =
-        s"(${id.stepId.show}, ${id.index.value})"
-    }
-  }
+object Dataset extends WithGid('d'.refined) {
 
   // N.B., This conforms to today's filename but I'm not confident it will
   // remain unchanged.

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbDataset.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbDataset.scala
@@ -6,10 +6,8 @@ package arb
 
 import eu.timepit.refined.scalacheck.all.*
 import eu.timepit.refined.types.numeric.PosInt
-import eu.timepit.refined.types.numeric.PosShort
 import lucuma.core.enums.Site
 import lucuma.core.util.arb.ArbEnumerated
-import lucuma.core.util.arb.ArbUid
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.*
 import org.scalacheck.Cogen
@@ -21,21 +19,6 @@ import scala.util.control.Exception.allCatch
 
 trait ArbDataset {
   import ArbEnumerated.*
-  import ArbUid.*
-
-  given Arbitrary[Dataset.Id] =
-    Arbitrary {
-      for {
-        s <- arbitrary[Step.Id]
-        i <- arbitrary[PosShort]
-      } yield Dataset.Id(s, i)
-    }
-
-  given Cogen[Dataset.Id] =
-    Cogen[(Step.Id, PosShort)].contramap { a => (
-      a.stepId,
-      a.index
-    )}
 
   given Arbitrary[Dataset.Filename] =
     Arbitrary {

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/IdsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/IdsSuite.scala
@@ -3,6 +3,7 @@
 
 package lucuma.core.model
 
+import lucuma.core.model.sequence.Dataset
 import lucuma.core.util.arb.*
 import lucuma.core.util.laws.GidTests
 import munit.DisciplineSuite

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DatasetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DatasetSuite.scala
@@ -6,11 +6,13 @@ package lucuma.core.model.sequence
 import cats.kernel.laws.discipline.*
 import cats.syntax.option.*
 import lucuma.core.model.sequence.arb.*
+import lucuma.core.util.arb.ArbGid
 import monocle.law.discipline.*
 import munit.*
 
 final class DatasetSuite extends DisciplineSuite {
   import ArbDataset.given
+  import ArbGid.*
 
   checkAll("Order[Dataset.Id]",       OrderTests[Dataset.Id].order)
   checkAll("Order[Dataset.Filename]", OrderTests[Dataset.Filename].order)


### PR DESCRIPTION
Switches `Dataset.Id` to a GID and fixes an oversight in which there were conflicting definitions for the dataset id.  I'd originally defined the dataset id as a combination step + index but this was quite challenging in Grackle / GraphQL and I'm no longer sure what I was hoping to buy with that anyway.  A simple GID seems to work fine.