### PR TITLE
KeyDecoder/KeyEncoder for WithUid.Id/WithGid.Id

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/util/Gid.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Gid.scala
@@ -125,9 +125,6 @@ final class Gid[A](
   final override def apply(a: A): Json =
     fromString.reverseGet(a).asJson
 
-  given KeyDecoder[A] = KeyDecoder.instance(fromString.getOption)
-
-  given KeyEncoder[A] = KeyEncoder.instance(fromString.reverseGet)
 }
 
 object Gid {

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Gid.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Gid.scala
@@ -125,6 +125,9 @@ final class Gid[A](
   final override def apply(a: A): Json =
     fromString.reverseGet(a).asJson
 
+  given KeyDecoder[A] = KeyDecoder.instance(fromString.getOption)
+
+  given KeyEncoder[A] = KeyEncoder.instance(fromString.reverseGet)
 }
 
 object Gid {
@@ -158,5 +161,9 @@ class WithGid(idTag: Char Refined Letter) {
 
     /** Allow pattern match style parsing */
     def unapply[T](s: String): Option[Id] = parse(s)
+
+    given KeyDecoder[Id] = KeyDecoder.instance(GidId.fromString.getOption)
+
+    given KeyEncoder[Id] = KeyEncoder.instance(GidId.fromString.reverseGet)
   }
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Uid.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Uid.scala
@@ -104,6 +104,10 @@ class WithUid(idTag: Char Refined Letter) {
 
     def unapply[T](s: String): Option[Id] =
       parse(s)
+
+    given KeyDecoder[Id] = KeyDecoder.instance(UidId.fromString.getOption)
+
+    given KeyEncoder[Id] = KeyEncoder.instance(UidId.fromString.reverseGet)
   }
 
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/IdsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/IdsSuite.scala
@@ -3,6 +3,7 @@
 
 package lucuma.core.model
 
+import io.circe.testing.KeyCodecTests
 import lucuma.core.model.sequence.Dataset
 import lucuma.core.util.arb.*
 import lucuma.core.util.laws.GidTests
@@ -11,10 +12,17 @@ import munit.DisciplineSuite
 final class IdsSuite extends DisciplineSuite {
   import ArbGid.*
 
-  checkAll("Configuration.Id", GidTests[Configuration.Id].gid)
-  checkAll("Dataset.Id", GidTests[Dataset.Id].gid)
-  checkAll("ExecutionEvent.Id", GidTests[ExecutionEvent.Id].gid)
-  checkAll("Observation.Id", GidTests[Observation.Id].gid)
-  checkAll("Program.Id", GidTests[Program.Id].gid)
-  checkAll("Visit.Id", GidTests[Visit.Id].gid)
+  checkAll("Gid[Configuration.Id]", GidTests[Configuration.Id].gid)
+  checkAll("Gid[Dataset.Id]", GidTests[Dataset.Id].gid)
+  checkAll("Gid[ExecutionEvent.Id]", GidTests[ExecutionEvent.Id].gid)
+  checkAll("Gid[Observation.Id]", GidTests[Observation.Id].gid)
+  checkAll("Gid[Program.Id]", GidTests[Program.Id].gid)
+  checkAll("Gid[Visit.Id]", GidTests[Visit.Id].gid)
+  
+  checkAll("KeyCodec[Configuration.Id]", KeyCodecTests[Configuration.Id].keyCodec)
+  checkAll("KeyCodec[Dataset.Id]", KeyCodecTests[Dataset.Id].keyCodec)
+  checkAll("KeyCodec[ExecutionEvent.Id]", KeyCodecTests[ExecutionEvent.Id].keyCodec)
+  checkAll("KeyCodec[Observation.Id]", KeyCodecTests[Observation.Id].keyCodec)
+  checkAll("KeyCodec[Program.Id]", KeyCodecTests[Program.Id].keyCodec)
+  checkAll("KeyCodec[Visit.Id]", KeyCodecTests[Visit.Id].keyCodec)
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/AtomSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/AtomSuite.scala
@@ -5,6 +5,7 @@ package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
 import cats.laws.discipline.arbitrary.*
+import io.circe.testing.KeyCodecTests
 import lucuma.core.model.sequence.arb.*
 import lucuma.core.model.sequence.gmos.DynamicConfig.GmosNorth
 import lucuma.core.model.sequence.gmos.arb.*
@@ -23,7 +24,8 @@ final class AtomSuite extends DisciplineSuite {
 
   override val scalaCheckTestParameters = Test.Parameters.default.withMaxSize(10)
 
-  checkAll("Atom.Id", UidTests[Atom.Id].uid)
+  checkAll("Uid[Atom.Id]", UidTests[Atom.Id].uid)
+  checkAll("KeyCodec[Atom.Id]", KeyCodecTests[Atom.Id].keyCodec)
 
   checkAll("Eq[Atom[GmosNorth]]", EqTests[Atom[GmosNorth]].eqv)
   checkAll("Atom.id",             LensTests(Atom.id[GmosNorth]))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepSuite.scala
@@ -4,6 +4,7 @@
 package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
+import io.circe.testing.KeyCodecTests
 import lucuma.core.model.sequence.arb.*
 import lucuma.core.model.sequence.gmos.DynamicConfig.GmosNorth
 import lucuma.core.model.sequence.gmos.arb.*
@@ -21,7 +22,8 @@ final class StepSuite extends DisciplineSuite {
   import ArbStepEstimate.given
   import ArbUid.*
 
-  checkAll("Step.Id", UidTests[Step.Id].uid)
+  checkAll("Uid[Step.Id]", UidTests[Step.Id].uid)
+  checkAll("KeyCodec[Step.Id]", KeyCodecTests[Step.Id].keyCodec)
 
   checkAll("Eq[Step[GmosNorth]]",    EqTests[Step[GmosNorth]].eqv)
   checkAll("Step.id",                LensTests(Step.id[GmosNorth]))


### PR DESCRIPTION
Adds `KeyDecoder`/`KeyEncoder` to classes that extend `WithGuid`/`WithUid`.

It doesn't seem possible to make `Gid`/`Uid` extend `KeyDecoder`/`KeyEncoder` since their `apply` signatures clash with `Decoder`/`Encoder`. (Maybe they should be named `decode`/`encode` in circe...)