### PR TITLE
`TimestampInterval` and `TimestampUnion`

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
@@ -166,18 +166,30 @@ object TimeSpan {
       toDuration.toString
 
     /**
+     * Adds two TimeSpan values, if the resulting value is in range.
+     */
+    def add(other: TimeSpan): Option[TimeSpan] =
+      fromMicroseconds(timeSpan.toMicroseconds + other.toMicroseconds)
+
+    /**
      * Adds two TimeSpan values, capping the resulting value at `Max`.
      */
     @targetName("boundedAdd")
     def +|(other: TimeSpan): TimeSpan =
-      fromMicroseconds(timeSpan.toMicroseconds + other.toMicroseconds).getOrElse(Max)
+      add(other).getOrElse(Max)
+
+    /**
+     * Subtracts two TimeSpan values, if the resulting value is in range.
+     */
+    def subtract(other: TimeSpan): Option[TimeSpan] =
+      fromMicroseconds(timeSpan.toMicroseconds - other.toMicroseconds)
 
     /**
      * Subtracts a TimeSpan value, with a floor of `Min` on the resulting value.
      */
     @targetName("boundedSubtract")
     def -|(other: TimeSpan): TimeSpan =
-      fromMicroseconds(timeSpan.toMicroseconds - other.toMicroseconds).getOrElse(Min)
+      subtract(other).getOrElse(Min)
 
     /**
      * Multiplies a TimeSpan by an integer, limiting the resulting value to the

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimestampInterval.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimestampInterval.scala
@@ -1,0 +1,221 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import cats.Comparison
+import cats.Eq
+import cats.Order
+import cats.Order.catsKernelOrderingForOrder
+import cats.syntax.order.*
+import org.typelevel.cats.time.*
+
+import java.time.Instant
+
+// Open/closed bounds complication.  Always want [start, end).
+// Type parameter instead of int value, allows floating point, rational etc.
+// 'Point' unnecessary.
+
+/**
+ * A TimestampInterval represents a period of time with a fixed starting point
+ * 'start' (inclusive) and an fixed ending point 'end' (exclusive).  In other
+ * words, [start, end).  Whereas a TimeSpan focuses solely on an amount of
+ * time, the TimestampInterval tracks specific start and end times.
+ *
+ * @param start time at which the interval begins (inclusive)
+ * @param end time at which the interval ends (exclusive)
+ */
+sealed class TimestampInterval private (val start: Timestamp, val end: Timestamp) {
+
+  import TimestampInterval.between
+  import TimestampInterval.Overlap
+
+  assert(start <= end, s"start time ($start) must be <= end time ($end)")
+
+  /**
+   * The amount of time represented by the interval, if possible to fit in a
+   * TimeSpan.
+   */
+  def timeSpan: Option[TimeSpan] =
+    TimeSpan.between(start, end)
+
+  /**
+   * The amount of time represented by the interval, but capped at
+   * TimeSpan.Max.  Most TimestampIntervals in practice will fall
+   * well short of TimeSpan.Max and this provides a convenient way
+   * of working with time spans that avoids Option.
+   */
+  def boundedTimeSpan: TimeSpan =
+    timeSpan.getOrElse(TimeSpan.Max)
+
+  def contains(time: Timestamp): Boolean =
+    start <= time && time < end
+
+  def containsInstant(time: Instant): Boolean =
+    start.toInstant <= time && time < end.toInstant
+
+  /**
+   * The interval that includes both this and 'other' interval along with all
+   * timestamps in between.
+   */
+  def span(other: TimestampInterval): TimestampInterval =
+    between(start min other.start, end max other.end)
+
+  def plus(other: TimestampInterval): List[TimestampInterval] =
+    overlap(other) match {
+      case Overlap.None if !abuts(other) => List(this, other).sorted
+      case _                             => List(span(other))
+    }
+
+  def minus(other: TimestampInterval): List[TimestampInterval] =
+    overlap(other) match {
+      case Overlap.LowerPartial   => List(between(start, other.start))
+      case Overlap.UpperPartial   => List(between(other.end, end))
+      case Overlap.ProperSuperset => List(between(start, other.start), between(other.end, end))
+      case Overlap.None           => List(this)
+      case Overlap.ProperSubset |
+           Overlap.Equal          => Nil
+    }
+
+  /**
+   * Determines whether and how this interval overlaps with the 'other'
+   * interval.
+   */
+  def overlap(other: TimestampInterval): Overlap =
+    start.comparison(other.start) match {
+      case Comparison.LessThan    =>
+        if (end <= other.start) Overlap.None
+        else if (end < other.end) Overlap.LowerPartial
+        else Overlap.ProperSuperset
+
+      case Comparison.EqualTo     =>
+        if (end === other.end) Overlap.Equal
+        else if (end < other.end) Overlap.ProperSubset
+        else Overlap.ProperSuperset
+
+      case Comparison.GreaterThan =>
+        if (start >= other.end) Overlap.None
+        else if (end > other.end) Overlap.UpperPartial
+        else Overlap.ProperSubset
+    }
+
+  /**
+   * Two time intervals abut if they fall side by side on the timeline with
+   * no intervening timestamps.
+   */
+  def abuts(other: TimestampInterval): Boolean =
+    other.start === end || other.end === start
+
+  /**
+   * Determines whether two intervals overlap in any way.
+   */
+  def intersects(other: TimestampInterval): Boolean =
+    overlap(other).intersects
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case t: TimestampInterval => start === t.start && end === t.end
+      case _                    => false
+    }
+
+  override def hashCode: Int =
+    start.hashCode() * 31 + end.hashCode();
+
+  override def toString: String =
+    s"[${start.format}, ${end.format})"
+
+}
+
+object TimestampInterval {
+
+  def between(t0: Timestamp, t1: Timestamp): TimestampInterval =
+    if (t0 <= t1) new TimestampInterval(t0, t1) else new TimestampInterval(t1, t0)
+
+  given Order[TimestampInterval] =
+    Order.whenEqual(Order.by(_.start), Order.by(_.end))
+
+  enum Overlap {
+
+    /** No common timestamps between the two intervals. */
+    case None
+
+    /** This interval overlaps only the lower end of the other interval. */
+    case LowerPartial
+
+    /** This interval overlaps only the upper end of the other interval. */
+    case UpperPartial
+
+    /** Both intervals contain the same timestamps. */
+    case Equal
+
+    /**
+     * All the elements of this interval are contained in the other interval,
+     * and they are not Equal.  That is, there are elements in the other
+     * interval not contained in this interval.
+     */
+    case ProperSubset
+
+    /**
+     * All the elements of the other interval are contained in this interval,
+     * but they are not Equal.  That is, there are elements of this interval
+     * which are not contained in the other interval.
+     */
+    case ProperSuperset
+  }
+
+  object Overlap {
+
+    given Eq[Overlap] = Eq.fromUniversalEquals
+
+    extension (self: Overlap) {
+
+      /**
+       * Returns True if the intervals are overlapping in any way.
+       */
+      def intersects: Boolean =
+        return self =!= None
+
+      /**
+       * Returns True if the intervals are only partially overlapping, False
+       * if not overlapping or if one totally overlaps the other.
+       */
+      def isPartial: Boolean =
+        self match {
+          case LowerPartial | UpperPartial => true
+          case _                           => false
+        }
+
+      /**
+       * Returns True if one interval totally overlaps the other, False if
+       * partially overlapping or not overlapping at all.
+       */
+      def isTotal: Boolean =
+       self match {
+          case Equal | ProperSubset | ProperSuperset => true
+          case _                                     => false
+        }
+
+      /**
+       * Returns True if the first interval is a subset (partial or equal)
+       * of the other.
+       */
+      def isSubset: Boolean =
+        self match {
+          case Equal | ProperSubset => true
+          case _                    => false
+        }
+
+      /**
+       * Returns True if the first interval is a superset (partial or equal)
+       * of the other.
+       */
+      def isSuperset: Boolean =
+        self match {
+          case Equal | ProperSuperset => true
+          case _                      => false
+        }
+    }
+  }
+
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimestampUnion.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimestampUnion.scala
@@ -85,11 +85,20 @@ sealed class TimestampUnion private (val intervals: SortedSet[TimestampInterval]
   def contains(timestamp: Timestamp): Boolean =
     intervals.exists(_.contains(timestamp))
 
+  /**
+   * Sums the time spanned by all the intervals in this union, assuming the
+   * result fits in a `TimeSpan`.
+   */
   def sum: Option[TimeSpan] =
     intervals.toList.traverse(_.timeSpan).flatMap { ts =>
       ts.foldLeft(TimeSpan.Zero.some) { case (s, t) => s.flatMap(_.add(t)) }
     }
 
+  /**
+   * Sums the time spanned by all the intervals in this union, capping the
+   * result at `TimeSpan.Max`.  This is sufficient for most uses and more
+   * convenient than `sum`.
+   */
   def boundedSum: TimeSpan =
     intervals.foldMap(_.boundedTimeSpan)
 
@@ -112,6 +121,9 @@ sealed class TimestampUnion private (val intervals: SortedSet[TimestampInterval]
 
 object TimestampUnion {
 
+  /**
+   * The empty TimestampUnion.
+   */
   val Empty: TimestampUnion =
     new TimestampUnion(SortedSet.empty)
 

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimestampUnion.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimestampUnion.scala
@@ -1,0 +1,127 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import cats.Eq
+import cats.Order.catsKernelOrderingForOrder
+import cats.syntax.eq.*
+import cats.syntax.foldable.*
+import cats.syntax.option.*
+import cats.syntax.traverse.*
+
+import scala.collection.immutable.SortedSet
+
+sealed class TimestampUnion private (val intervals: SortedSet[TimestampInterval]) {
+
+  import TimestampUnion.Empty
+
+  /**
+   * Adds the specified interval, which will be merged into the collection
+   * of intervals.
+   */
+  def add(n: TimestampInterval): TimestampUnion = {
+    val (u, nʹ) = intervals.foldLeft((Empty, n)) { case ((res, nʹ), ti) =>
+      if (nʹ.abuts(ti) || nʹ.intersects(ti)) (res, nʹ.span(ti)) else (res + ti, nʹ)
+    }
+    new TimestampUnion(u.intervals + nʹ)
+  }
+
+  /**
+   * Alias for add.
+   */
+  def +(n: TimestampInterval): TimestampUnion =
+    add(n)
+
+  def ++(ns: IterableOnce[TimestampInterval]): TimestampUnion =
+    ns.iterator.foldLeft(this)(_.add(_))
+
+  /**
+   * Removes the specified interval, which will be clipped out of the
+   * collection of intervals.
+   */
+  def remove(del: TimestampInterval): TimestampUnion =
+    intervals.foldLeft(Empty) { (res, ti) => res ++ ti.minus(del) }
+
+  /**
+   * Alias for remove.
+   */
+  def -(del: TimestampInterval): TimestampUnion =
+    remove(del)
+
+  def --(ns: IterableOnce[TimestampInterval]): TimestampUnion =
+    ns.iterator.foldLeft(this)(_.remove(_))
+
+  /**
+   * Intersection of two TimestampUnions, creating a new union with intervals
+   * whose times are covered in both.
+   */
+  def intersect(other: TimestampUnion): TimestampUnion = {
+    def collectPoints(init: Vector[Timestamp], intervals: SortedSet[TimestampInterval]): Vector[Timestamp] =
+      intervals.foldLeft(init) { (v, ti) => v.appended(ti.start).appended(ti.end) }
+
+    val points = collectPoints(collectPoints(Vector.empty, intervals), other.intervals).sorted
+
+    if (points.isEmpty)
+      Empty
+    else
+      points.zip(points.tail).foldLeft(Empty) { case (res, (a, b)) =>
+        if (contains(a) && other.contains(a)) res.add(TimestampInterval.between(a, b)) else res
+      }
+  }
+
+  /**
+   * Alias for intersect.
+   */
+  def ∩(other: TimestampUnion): TimestampUnion =
+    intersect(other)
+
+  def ++(other: TimestampUnion): TimestampUnion =
+    ++(other.intervals)
+
+  def --(other: TimestampUnion): TimestampUnion =
+    --(other.intervals)
+
+  def contains(timestamp: Timestamp): Boolean =
+    intervals.exists(_.contains(timestamp))
+
+  def sum: Option[TimeSpan] =
+    intervals.toList.traverse(_.timeSpan).flatMap { ts =>
+      ts.foldLeft(TimeSpan.Zero.some) { case (s, t) => s.flatMap(_.add(t)) }
+    }
+
+  def boundedSum: TimeSpan =
+    intervals.foldMap(_.boundedTimeSpan)
+
+  def isEmpty: Boolean =
+    intervals.isEmpty
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case u: TimestampUnion => intervals === u.intervals
+      case _                 => false
+    }
+
+  override def hashCode: Int =
+    intervals.hashCode() * 31
+
+  override def toString: String =
+    s"{${intervals.mkString(", ")}}"
+
+}
+
+object TimestampUnion {
+
+  val Empty: TimestampUnion =
+    new TimestampUnion(SortedSet.empty)
+
+  def apply(intervals: TimestampInterval*): TimestampUnion =
+    fromIntervals(intervals)
+
+  def fromIntervals(intervals: IterableOnce[TimestampInterval]): TimestampUnion =
+    Empty ++ intervals
+
+  given Eq[TimestampUnion] =
+    Eq.by(_.intervals)
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimestampUnion.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimestampUnion.scala
@@ -5,6 +5,7 @@ package lucuma.core.util
 
 import cats.Eq
 import cats.Order.catsKernelOrderingForOrder
+import cats.kernel.BoundedSemilattice
 import cats.syntax.eq.*
 import cats.syntax.foldable.*
 import cats.syntax.option.*
@@ -135,5 +136,8 @@ object TimestampUnion {
 
   given Eq[TimestampUnion] =
     Eq.by(_.intervals)
+
+  given BoundedSemilattice[TimestampUnion] =
+    BoundedSemilattice.instance(Empty, _ ++ _)
 
 }

--- a/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestamp.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestamp.scala
@@ -5,7 +5,6 @@ package lucuma.core.util
 package arb
 
 import lucuma.core.arb.ArbTime
-import lucuma.core.util.Timestamp
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
 

--- a/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestampInterval.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestampInterval.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+package arb
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck._
+
+trait ArbTimestampInterval {
+
+  import ArbTimestamp.*
+
+  given Arbitrary[TimestampInterval] =
+    Arbitrary {
+      for {
+        t0 <- arbitrary[Timestamp]
+        t1 <- arbitrary[Timestamp]
+      } yield TimestampInterval.between(t0, t1)
+    }
+
+  given Cogen[TimestampInterval] =
+    Cogen[(Timestamp, Timestamp)].contramap { a => (a.start, a.end) }
+
+}
+
+object ArbTimestampInterval extends ArbTimestampInterval

--- a/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestampUnion.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbTimestampUnion.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+package arb
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck._
+
+trait ArbTimestampUnion {
+
+  import ArbTimestampInterval.given
+
+  given Arbitrary[TimestampUnion] =
+    Arbitrary {
+      for {
+        sz <- Gen.chooseNum(0, 10)
+        ts <- Gen.listOfN(sz, arbitrary[TimestampInterval])
+      } yield TimestampUnion.fromIntervals(ts)
+    }
+
+  given Cogen[TimestampUnion] =
+    Cogen[List[TimestampInterval]].contramap { a =>
+      a.intervals.toList
+    }
+}
+
+object ArbTimestampUnion extends ArbTimestampUnion

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
@@ -1,0 +1,134 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import munit.DisciplineSuite
+import org.scalacheck.Prop.forAll
+
+class TimestampIntervalSuite extends DisciplineSuite {
+
+  import arb.ArbTimestampInterval.given
+
+  import TimestampInterval.Overlap
+
+  private def timestamp(epochMilli: Long): Timestamp =
+    Timestamp.ofEpochMilli(epochMilli).get
+
+  private def interval(epochMilli0: Long, epochMilli1: Long): TimestampInterval =
+    TimestampInterval.between(timestamp(epochMilli0), timestamp(epochMilli1))
+
+  private def testOverlap(ex: Overlap, ts: (TimestampInterval, TimestampInterval)*): Unit =
+    ts.foreach { case (a, b) => assertEquals(a.overlap(b), ex) }
+
+  test("overlap => None") {
+    testOverlap(Overlap.None,
+      (interval( 0, 10), interval(20, 30)),
+      (interval(20, 30), interval( 0, 10)),
+      (interval( 0, 10), interval(10, 20)),
+      (interval(10, 20), interval( 0, 10))
+    )
+  }
+
+  test("overlap => LowerPartial") {
+    testOverlap(Overlap.LowerPartial,
+      (interval(0, 10), interval(1, 11)),
+      (interval(0, 10), interval(9, 11))
+    )
+  }
+
+  test("overlap => UpperPartial") {
+    testOverlap(Overlap.UpperPartial,
+      (interval(1, 11), interval(0, 10)),
+      (interval(9, 11), interval(0, 10))
+    )
+  }
+
+  test("overlap => Equal") {
+    testOverlap(Overlap.Equal,
+      (interval(0, 10), interval(0, 10)),
+      (interval(0,  0), interval(0,  0))
+    )
+  }
+
+  test("overlap => ProperSubset") {
+    testOverlap(Overlap.ProperSubset,
+      (interval(1, 9), interval(0, 10)),
+      (interval(5, 5), interval(0, 10))
+    )
+  }
+
+  test("overlap => ProperSuperset") {
+    testOverlap(Overlap.ProperSuperset,
+      (interval(0, 10), interval(1, 9)),
+      (interval(0, 10), interval(5, 5))
+    )
+  }
+
+  test("overlap reverse") {
+    forAll { (t0: TimestampInterval, t1: TimestampInterval) =>
+      t0.overlap(t1) match {
+        case Overlap.ProperSubset   => assertEquals(Overlap.ProperSuperset, t1.overlap(t0))
+        case Overlap.ProperSuperset => assertEquals(Overlap.ProperSubset,   t1.overlap(t0))
+        case Overlap.None           => assertEquals(Overlap.None,           t1.overlap(t0))
+        case Overlap.Equal          => assertEquals(Overlap.Equal,          t1.overlap(t0))
+        case Overlap.LowerPartial   => assertEquals(Overlap.UpperPartial,   t1.overlap(t0))
+        case Overlap.UpperPartial   => assertEquals(Overlap.LowerPartial,   t1.overlap(t0))
+      }
+    }
+
+  }
+
+  test("span") {
+    assertEquals(interval(0, 10).span(interval(5, 5)), interval(0, 10))
+    assertEquals(interval(0, 10).span(interval(1, 9)), interval(0, 10))
+
+    assertEquals(interval(0, 10).span(interval(1, 11)), interval(0, 11))
+    assertEquals(interval(1, 11).span(interval(0, 10)), interval(0, 11))
+  }
+
+  test("span is commutative") {
+    forAll { (t0: TimestampInterval, t1: TimestampInterval) =>
+      assertEquals(t0.span(t1), t1.span(t0))
+    }
+  }
+
+  test("span is associative") {
+    forAll { (t0: TimestampInterval, t1: TimestampInterval, t2: TimestampInterval) =>
+      assertEquals(t0.span(t1).span(t2), t0.span(t1.span(t2)))
+    }
+  }
+
+  test("plus") {
+    assertEquals(interval(0, 10).plus(interval(10, 20)), List(interval(0, 20)))
+    assertEquals(interval(0, 10).plus(interval( 9, 20)), List(interval(0, 20)))
+    assertEquals(interval(0, 10).plus(interval(20, 30)), List(interval(0, 10), interval(20, 30)))
+  }
+
+  test("plus is commutative") {
+    forAll { (t0: TimestampInterval, t1: TimestampInterval) =>
+      assertEquals(t0.plus(t1), t1.plus(t0))
+    }
+  }
+
+  test("minus") {
+    // Lower Partial
+    assertEquals(interval(1, 10).minus(interval(0,  2)), List(interval(2, 10)))
+
+    // Upper Partial
+    assertEquals(interval(1, 10).minus(interval(9, 11)), List(interval(1, 9)))
+
+    // Proper Superset
+    assertEquals(interval(0, 10).minus(interval(3,  6)), List(interval(0, 3), interval(6, 10)))
+
+    // None
+    assertEquals(interval(0, 10).minus(interval(10, 20)), List(interval(0, 10)))
+
+    // Proper Subset
+    assertEquals(interval(3, 6).minus(interval(0, 10)), Nil)
+
+    // Equal
+    assertEquals(interval(0, 10).minus(interval(0, 10)), Nil)
+  }
+
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
@@ -3,12 +3,15 @@
 
 package lucuma.core.util
 
+import cats.kernel.laws.discipline.*
 import munit.DisciplineSuite
 import org.scalacheck.Prop.forAll
 
 class TimestampIntervalSuite extends DisciplineSuite {
 
   import arb.ArbTimestampInterval.given
+
+  checkAll("Order", OrderTests[TimestampInterval].order)
 
   import TimestampInterval.Overlap
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
@@ -1,0 +1,90 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import cats.Order.catsKernelOrderingForOrder
+import cats.syntax.foldable.*
+import munit.DisciplineSuite
+import org.scalacheck.Prop.forAll
+
+class TimestampUnionSuite extends DisciplineSuite {
+
+  override val scalaCheckInitialSeed = "_02WNmmy0BdvWpczJPELqOuF8vAb3JpSKcmglRbAVWE="
+
+  import arb.ArbTimestamp.*
+  import arb.ArbTimestampInterval.given
+  import arb.ArbTimestampUnion.given
+
+  private def timestamp(epochMilli: Long): Timestamp =
+    Timestamp.ofEpochMilli(epochMilli).get
+
+  private def interval(epochMilli0: Long, epochMilli1: Long): TimestampInterval =
+    TimestampInterval.between(timestamp(epochMilli0), timestamp(epochMilli1))
+
+  private def expect(u: TimestampUnion, expected: List[TimestampInterval]): Unit =
+    assertEquals(u.intervals.toList, expected, s"$u")
+
+  test("add one") {
+    expect(TimestampUnion(interval(1, 3)), List(interval(1, 3)))
+  }
+
+  test("add disjoint") {
+    expect(TimestampUnion(interval(1, 2), interval(4, 5)), List(interval(1, 2), interval(4, 5)))
+    expect(TimestampUnion(interval(4, 5), interval(1, 2)), List(interval(1, 2), interval(4, 5)))
+  }
+
+  test("add abutting") {
+    expect(TimestampUnion(interval(1, 2), interval(2, 3)), List(interval(1, 3)))
+  }
+
+  test("add two partial overlapping") {
+    expect(TimestampUnion(interval(1, 3), interval(2, 4)), List(interval(1, 4)))
+    expect(TimestampUnion(interval(2, 4), interval(1, 3)), List(interval(1, 4)))
+  }
+
+  test("add two completely overlapping") {
+    expect(TimestampUnion(interval(1, 4), interval(2, 3)), List(interval(1, 4)))
+    expect(TimestampUnion(interval(2, 3), interval(1, 4)), List(interval(1, 4)))
+  }
+
+  test("remove all") {
+    expect(TimestampUnion(interval(1,3)).remove(interval(1,3)), Nil)
+  }
+
+  test("remove nothing") {
+    expect(TimestampUnion(interval(1,3)).remove(interval(5, 6)), List(interval(1, 3)))
+  }
+
+  test("remove in middle") {
+    expect(TimestampUnion(interval(1, 4)).remove(interval(2, 3)), List(interval(1, 2), interval(3, 4)))
+  }
+
+  test("add order is irrelevant") {
+    forAll { (u: TimestampUnion, ts: List[TimestampInterval]) =>
+      val tsʹ = ts.take(10)
+      assertEquals(u ++ tsʹ, u ++ tsʹ.sorted)
+    }
+  }
+
+  test("remove order is irrelevant") {
+    forAll { (u: TimestampUnion, ts: List[TimestampInterval]) =>
+      assertEquals(u -- ts.take(10), u -- ts.take(10).sorted)
+    }
+  }
+
+  test("intersect") {
+    forAll { (u0: TimestampUnion, u1: TimestampUnion, ts: List[Timestamp]) =>
+      val u2 = u0 ∩ u1
+      ts.foreach { t =>
+        assertEquals(u2.contains(t), u0.contains(t) && u1.contains(t), s"intersect: $u0 ∩ $u1 = $u2, t=$t, u0(${u0.contains(t)}), u1(${u1.contains(t)}), u2(${u2.contains(t)})")
+      }
+    }
+  }
+
+  test("boundedSum") {
+    forAll { (u: TimestampUnion) =>
+      assertEquals(u.boundedSum, u.intervals.foldMap(_.boundedTimeSpan))
+    }
+  }
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
@@ -16,6 +16,7 @@ class TimestampUnionSuite extends DisciplineSuite {
   import arb.ArbTimestampUnion.given
 
   checkAll("Eq", EqTests[TimestampUnion].eqv)
+  checkAll("BoundedSemilattice", BoundedSemilatticeTests[TimestampUnion].boundedSemilattice)
 
   private def timestamp(epochMilli: Long): Timestamp =
     Timestamp.ofEpochMilli(epochMilli).get

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
@@ -3,8 +3,8 @@
 
 package lucuma.core.util
 
-import cats.kernel.laws.discipline.*
 import cats.Order.catsKernelOrderingForOrder
+import cats.kernel.laws.discipline.*
 import cats.syntax.foldable.*
 import munit.DisciplineSuite
 import org.scalacheck.Prop.forAll

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
@@ -3,6 +3,7 @@
 
 package lucuma.core.util
 
+import cats.kernel.laws.discipline.*
 import cats.Order.catsKernelOrderingForOrder
 import cats.syntax.foldable.*
 import munit.DisciplineSuite
@@ -10,11 +11,11 @@ import org.scalacheck.Prop.forAll
 
 class TimestampUnionSuite extends DisciplineSuite {
 
-  override val scalaCheckInitialSeed = "_02WNmmy0BdvWpczJPELqOuF8vAb3JpSKcmglRbAVWE="
-
   import arb.ArbTimestamp.*
   import arb.ArbTimestampInterval.given
   import arb.ArbTimestampUnion.given
+
+  checkAll("Eq", EqTests[TimestampUnion].eqv)
 
   private def timestamp(epochMilli: Long): Timestamp =
     Timestamp.ofEpochMilli(epochMilli).get


### PR DESCRIPTION
Time accounting calculations in the `ocs` project make extensive use of its `Interval` and `Union` classes.  Here in `lucuma` we have the `BoundedInterval` and Spire's `IntervalSeq`, which appear to address similar concerns.  I will need something like this for time accounting in GPP. 

For time accounting even the `BoundedInterval` simplification of Spire's `Interval` is more general than we need thanks to `Point` instances and open vs closed bounds on each end of the interval.  We'll always want `[start, end)`.  The `IntervalSeq` in turn works with raw `Interval`s, including unbounded and empty intervals etc.

This PR would add `TimestampInterval` and `TimestampUnion` to provide a simple solution for time accounting.  I'll offer it here but I can move it to `lucuma-odb` if we think it would be confusing or not useful in other contexts.