### PR TITLE
Change `TimestampInterval.minus` wrt "empty" intervals.

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimestampInterval.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimestampInterval.scala
@@ -85,12 +85,15 @@ sealed class TimestampInterval private (val start: Timestamp, val end: Timestamp
    */
   def minus(other: TimestampInterval): List[TimestampInterval] =
     overlap(other) match {
-      case Overlap.LowerPartial   => List(between(start, other.start))
-      case Overlap.UpperPartial   => List(between(other.end, end))
-      case Overlap.ProperSuperset => List(between(start, other.start), between(other.end, end))
-      case Overlap.None           => List(this)
+      case Overlap.LowerPartial                                  => List(between(start, other.start))
+      case Overlap.UpperPartial                                  => List(between(other.end, end))
+      case Overlap.ProperSuperset if (other.start === other.end) => List(this)
+      case Overlap.ProperSuperset if (start === other.start)     => List(between(other.end, end))
+      case Overlap.ProperSuperset if (end === other.end)         => List(between(start, other.start))
+      case Overlap.ProperSuperset                                => List(between(start, other.start), between(other.end, end))
+      case Overlap.None                                          => List(this)
       case Overlap.ProperSubset |
-           Overlap.Equal          => Nil
+           Overlap.Equal                                         => Nil
     }
 
   /**

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
@@ -125,16 +125,29 @@ class TimestampIntervalSuite extends DisciplineSuite {
     assertEquals(interval(1, 10).minus(interval(9, 11)), List(interval(1, 9)))
 
     // Proper Superset
-    assertEquals(interval(0, 10).minus(interval(3,  6)), List(interval(0, 3), interval(6, 10)))
+    assertEquals(interval(0, 10).minus(interval(3, 6)), List(interval(0, 3), interval(6, 10)))
+    assertEquals(interval(0, 10).minus(interval(0, 6)), List(interval(6, 10)))
+    assertEquals(interval(0, 10).minus(interval(3, 10)), List(interval(0, 3)))
+    // with empty intervals 
+    assertEquals(interval(0, 10).minus(interval(0, 0)), List(interval(0, 10)))
+    assertEquals(interval(0, 10).minus(interval(3, 3)), List(interval(0, 10)))
 
     // None
     assertEquals(interval(0, 10).minus(interval(10, 20)), List(interval(0, 10)))
+    // with empty intervals
+    assertEquals(interval(10, 10).minus(interval(0, 10)), List(interval(10, 10)))
+    assertEquals(interval(0, 10).minus(interval(10, 10)), List(interval(0, 10)))
+
 
     // Proper Subset
     assertEquals(interval(3, 6).minus(interval(0, 10)), Nil)
+    // with empty intervals
+    assertEquals(interval(0, 0).minus(interval(0, 10)), Nil)
+    assertEquals(interval(3, 3).minus(interval(0, 10)), Nil)
 
     // Equal
     assertEquals(interval(0, 10).minus(interval(0, 10)), Nil)
+    assertEquals(interval(1, 1).minus(interval(1, 1)), Nil)
   }
 
   test("intersection") {


### PR DESCRIPTION
There was some edge cases in `minus` related to intervals where `start === end`. 

In 2 cases, the resulting List of intervals would produce adjacent intervals that would "sum" to what I expect. Such as (using the test notation):
> List(interval(0, 3), interval(3, 10))

In 2 other cases, the result contained a "empty" interval disjoint from what I would expect. Such as:
> List(interval(0, 3), interval(10, 10))

I will put comments in the test denoting the exact behavior that changed.

@swalker2m - You'll have to let me know if this matches your expectations for your use in the `TimestampUnion` or not.