### PR TITLE
Downgrade cats-parse to 0.3.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.89"
+ThisBuild / tlBaseVersion                         := "0.90"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 
@@ -22,7 +22,7 @@ lazy val lucumaRefinedVersion  = "0.1.2"
 lazy val catsTimeVersion       = "0.5.1"
 lazy val circeVersion          = "0.14.6"
 lazy val catsScalacheckVersion = "0.3.2"
-lazy val catsParseVersion      = "1.0.0"
+lazy val catsParseVersion      = "0.3.10"
 lazy val kittensVersion        = "3.1.0"
 lazy val scalajsStubVersion    = "1.1.0"
 


### PR DESCRIPTION
Shane and I discussed this and decided it would be better to downgrade cats-parse until http4s is on the new version than to propagate the sbt `libraryDependencySchemes` hack throughout our projects.

Any disagreements?