### PR TITLE
Night Syntax

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/syntax/NightOps.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/syntax/NightOps.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+package syntax
+
+import lucuma.core.util.Timestamp
+import lucuma.core.util.TimestampInterval
+
+trait ToNightOps {
+
+  extension(self: Night) {
+
+    def toTimestampInterval: Option[TimestampInterval] = {
+      val bi = self.interval
+      for {
+        s <- Timestamp.fromInstantTruncated(bi.lower)
+        e <- Timestamp.fromInstantTruncated(bi.upper)
+      } yield TimestampInterval.between(s, e)
+    }
+
+  }
+
+}
+
+object night extends ToNightOps

--- a/modules/core/shared/src/main/scala/lucuma/core/model/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/syntax/package.scala
@@ -4,5 +4,7 @@
 package lucuma.core.model
 
 package object syntax {
-  object all extends ToNonNegDurationOps with ToTrackingOps
+  object all extends ToNightOps
+                with ToNonNegDurationOps
+                with ToTrackingOps
 }


### PR DESCRIPTION
Adds `toTimestampInterval` syntax to `Night`.  `Night`s are `BoundedInterval[Instant]` paired with a `Site`.  I'm kind of wishing it were instead a `TimestampInterval` with a `Site`, but it would likely cause hardship to refactor it now?