### PR TITLE
`CategorizedTime.equals` vs. `Order[CategorizedTime]`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.90"
+ThisBuild / tlBaseVersion                         := "0.91"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/CategorizedTime.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/CategorizedTime.scala
@@ -12,24 +12,120 @@ import lucuma.core.enums.ChargeClass
 import lucuma.core.enums.ObserveClass
 import lucuma.core.util.TimeSpan
 
-import scala.annotation.targetName
 import scala.collection.immutable.SortedMap
 
 /**
  * Time charge broken down by charge class.
  */
-opaque type CategorizedTime = SortedMap[ChargeClass, TimeSpan]
+case class CategorizedTime private (
+  programTime: TimeSpan,
+  partnerTime: TimeSpan,
+  nonCharged:  TimeSpan
+) {
+
+  /**
+   * Gets the time charged for the given charge class.
+   */
+  def apply(chargeClass: ChargeClass): TimeSpan =
+    chargeClass match {
+      case ChargeClass.Program    => programTime
+      case ChargeClass.Partner    => partnerTime
+      case ChargeClass.NonCharged => nonCharged
+    }
+
+  /**
+   * Lists the charge classes and their time value.
+   */
+  def charges: List[(ChargeClass, TimeSpan)] =
+    ChargeClass.values.toList.fproduct(apply)
+
+  /**
+   * Returns `true` if there are no charges for any charge class.
+   */
+  def isZero: Boolean =
+    charges.forall((_, t) => t.isZero)
+
+  /**
+   * Returns `true` if there is a charge for at least one charge class.
+   */
+  def nonZero: Boolean =
+    !isZero
+
+  /**
+   * Sets the value associated with the given `ChargeClass` to `time`.
+   */
+  def updated(chargeClass: ChargeClass, time: TimeSpan): CategorizedTime =
+    chargeClass match {
+      case ChargeClass.Program    => copy(programTime = time)
+      case ChargeClass.Partner    => copy(partnerTime = time)
+      case ChargeClass.NonCharged => copy(nonCharged  = time)
+    }
+
+  /**
+   * Modifies the amount associated with the given charge class using the
+   * provided operation.
+   */
+  def modify(chargeClass: ChargeClass, op: TimeSpan => TimeSpan): CategorizedTime =
+    updated(chargeClass, op(apply(chargeClass)))
+
+  /**
+   * Adjusts this `CategorizedTime` instance according to the supplied
+   * correction, adding or subtracting time associated its charge class but
+   * bounded by the min and max `TimeSpan` values.
+   */
+  def correct(c: TimeChargeCorrection): CategorizedTime =
+    c.op match {
+      case TimeChargeCorrection.Op.Add      => modify(c.chargeClass, _ +| c.amount)
+      case TimeChargeCorrection.Op.Subtract => modify(c.chargeClass, _ -| c.amount)
+    }
+
+  /**
+   * Sums the current charge associated with `chargeClass` with the given
+   * `time`, returning a new CategorizedTime value.
+   */
+  def sumCharge(chargeClass: ChargeClass, time: TimeSpan): CategorizedTime =
+    modify(chargeClass, _ +| time)
+
+  /**
+   * Sums all the charges regardless of charge class.
+   */
+  def sum: TimeSpan =
+    ChargeClass.values.toList.foldMap(apply)
+
+  /**
+   * Adds the corresponding charges for two CategorizedTime values.
+   */
+  def +|(other: CategorizedTime): CategorizedTime =
+    other.charges.foldLeft(this) { case (res, (chargeClass, time)) =>
+      res.sumCharge(chargeClass, time)
+    }
+
+}
 
 object CategorizedTime {
 
+  /**
+   * A CategorizedTime instance which associates Zero time with all charge
+   * classes.
+   */
   val Zero: CategorizedTime =
-    SortedMap.empty
+    CategorizedTime(TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero)
 
+  /**
+   * Constructs a CategorizedTime instance from the provided charges.  If a
+   * ChargeClass is duplicated in the argument list, the last instance applies.
+   */
   def apply(charges: (ChargeClass, TimeSpan)*): CategorizedTime =
     from(charges)
 
-  def from(it: IterableOnce[(ChargeClass, TimeSpan)]): CategorizedTime =
-    SortedMap.from(it.iterator.filter { (_, t) => t.nonZero })
+  /**
+   * Constructs a CategorizedTime instance from the provided charges.  If a
+   * ChargeClass is duplicated in the argument list, the last instance applies.
+   */
+  def from(it: IterableOnce[(ChargeClass, TimeSpan)]): CategorizedTime = {
+    val m = SortedMap.from(it.iterator.filter { (_, t) => t.nonZero }).withDefaultValue(TimeSpan.Zero)
+    CategorizedTime(m(ChargeClass.Program), m(ChargeClass.Partner), m(ChargeClass.NonCharged))
+  }
 
   /**
    * Creates a `CategorizedTime` instance where the entirety of the step estimate
@@ -37,97 +133,6 @@ object CategorizedTime {
    */
   def fromStep(observeClass: ObserveClass, stepEstimate: StepEstimate): CategorizedTime =
     apply(observeClass.chargeClass -> stepEstimate.total)
-
-  extension (self: CategorizedTime) {
-
-    /**
-     * Gets the time charged for the given charge class (or TimeSpan.Zero if no
-     * charge is recorded).  Alias for `getOrZero`.
-     */
-    def apply(chargeClass: ChargeClass): TimeSpan =
-      getOrZero(chargeClass)
-
-    // N.B., if you refer to `apply` within this extensions object, it will
-    // find the Map apply :-/ For that reason I added `getOrZero`.
-
-    /**
-     * Adjusts this `CategorizedTime` instance according to the supplied
-     * correction, adding or subtracting time associated its charge class but
-     * bounded by the min and max `TimeSpan` values.
-     */
-    def correct(c: TimeChargeCorrection): CategorizedTime =
-      c.op match {
-        case TimeChargeCorrection.Op.Add      => modify(c.chargeClass, _ +| c.amount)
-        case TimeChargeCorrection.Op.Subtract => modify(c.chargeClass, _ -| c.amount)
-      }
-
-    /**
-     * Gets the time charged for the given charge class (or TimeSpan.Zero if no
-     * charge is recorded).
-     */
-    def getOrZero(chargeClass: ChargeClass): TimeSpan =
-      self.getOrElse(chargeClass, TimeSpan.Zero)
-
-    /**
-     * Returns `true` if there are no charges for any charge class.
-     */
-    def isZero: Boolean =
-      self.isEmpty
-
-    /**
-     * Returns `true` if there is a charge for at least one charge class.
-     */
-    def nonZero: Boolean =
-      !isZero
-
-    // An updated implementation used internally to remove Zero TimeSpan
-    // charges.  Named _updated to distinguish with self.updated.
-    private def _updated(chargeClass: ChargeClass, time: TimeSpan): CategorizedTime =
-      if (time.isZero) self.removed(chargeClass)
-      else self.updated(chargeClass, time)
-
-    /**
-     * Returns an updated CategorizedTime value, changing the charge associated
-     * with `chargeClass` to `time`.
-     */
-    def updated(chargeClass: ChargeClass, time: TimeSpan): CategorizedTime =
-      _updated(chargeClass, time)
-
-    /**
-     * Modifies the amount associated with the given charge class using the
-     * provided operation.
-     */
-    def modify(chargeClass: ChargeClass, op: TimeSpan => TimeSpan): CategorizedTime =
-      _updated(chargeClass, op(getOrZero(chargeClass)))
-
-    /**
-     * Sums the current charge associated with `chargeClass` with the given
-     * `time`, returning a new CategorizedTime value.
-     */
-    def sumCharge(chargeClass: ChargeClass, time: TimeSpan): CategorizedTime =
-      modify(chargeClass, _ +| time)
-
-    /**
-     * Sums all the charges regardless of charge class.
-     */
-    def sum: TimeSpan =
-      ChargeClass.values.toList.foldMap(getOrZero)
-
-    /**
-     * Lists the charge classes and their time value.
-     */
-    def charges: List[(ChargeClass, TimeSpan)] =
-      ChargeClass.values.toList.fproduct(getOrZero)
-
-    /**
-     * Adds the corresponding charges for two CategorizedTime values.
-     */
-    @targetName("boundedAdd")
-    def +|(other: CategorizedTime): CategorizedTime =
-      other.charges.foldLeft(self) { case (res, (chargeClass, time)) =>
-        res.sumCharge(chargeClass, time)
-      }
-  }
 
   given CommutativeMonoid[CategorizedTime] =
     CommutativeMonoid.instance(Zero, _ +| _)
@@ -137,10 +142,10 @@ object CategorizedTime {
    */
   given Order[CategorizedTime] =
     Order.whenEqual[CategorizedTime](
-      Order.by(pt => ChargeClass.values.toList.foldMap(pt.getOrZero)),  // Order.by(_.sum) picks up Map's sum :-/
+      Order.by(_.sum),
       Order.whenEqual(
-        Order.by(_.getOrZero(ChargeClass.Program)),
-        Order.by(_.getOrZero(ChargeClass.Partner))
+        Order.by(_.apply(ChargeClass.Program)),
+        Order.by(_.apply(ChargeClass.Partner))
       )
     )
 

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
@@ -138,6 +138,12 @@ object TimeSpan {
 
   extension (timeSpan: TimeSpan) {
 
+    def isZero: Boolean =
+      toMicroseconds === 0
+
+    def nonZero: Boolean =
+      !isZero
+
     def toMicroseconds: Long =
       timeSpan.value
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/CategorizedTimeSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/CategorizedTimeSuite.scala
@@ -38,15 +38,29 @@ final class CategorizedTimeSuite extends DisciplineSuite {
   }
 
   test("modify") {
-    forAll { (tc: CategorizedTime, c: ChargeClass, s: TimeSpan) =>
-      assertEquals(tc.modify(c, _ +| s)(c), tc(c) +| s)
-      assertEquals(tc.modify(c, _ -| s)(c), tc(c) -| s)
+    forAll { (a: CategorizedTime, c: ChargeClass, s: TimeSpan) =>
+      assertEquals(a.modify(c, _ +| s)(c), a(c) +| s)
+      assertEquals(a.modify(c, _ -| s)(c), a(c) -| s)
     }
   }
 
   test("apply") {
     forAll { (a: CategorizedTime) =>
-      assertEquals(a(ChargeClass.Program), a.getOrZero(ChargeClass.Program))
+      assertEquals(a(ChargeClass.Program), a.programTime)
+      assertEquals(a(ChargeClass.Partner), a.partnerTime)
+      assertEquals(a(ChargeClass.NonCharged), a.nonCharged)
+    }
+  }
+
+  test("sumCharge") {
+    forAll { (a: CategorizedTime, t: TimeSpan, c: ChargeClass) =>
+      assertEquals(a.sumCharge(c, t)(c), a(c) +| t)
+    }
+  }
+
+  test("sum") {
+    forAll { (a: CategorizedTime) =>
+      assertEquals(a.sum, a(ChargeClass.Program) +| a(ChargeClass.Partner) +| a(ChargeClass.NonCharged))
     }
   }
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/CategorizedTimeSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/CategorizedTimeSuite.scala
@@ -4,10 +4,15 @@
 package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
+import cats.syntax.eq.*
 import cats.syntax.monoid.*
+import cats.syntax.option.*
 import lucuma.core.enums.ChargeClass
+import lucuma.core.model.ServiceUser
+import lucuma.core.model.User
 import lucuma.core.model.sequence.arb.ArbCategorizedTime
 import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.arb.ArbTimeSpan
 import munit.*
@@ -42,6 +47,50 @@ final class CategorizedTimeSuite extends DisciplineSuite {
   test("apply") {
     forAll { (a: CategorizedTime) =>
       assertEquals(a(ChargeClass.Program), a.getOrZero(ChargeClass.Program))
+    }
+  }
+
+  test("CategorizedTime.Zero equals explicitly specified TimeSpan.Zero charges") {
+    assertEquals(
+      CategorizedTime(
+        ChargeClass.Program -> TimeSpan.Zero,
+        ChargeClass.Partner -> TimeSpan.Zero,
+        ChargeClass.NonCharged -> TimeSpan.Zero
+      ),
+      CategorizedTime.Zero
+    )
+
+    assertEquals(
+      CategorizedTime.from(List(ChargeClass.Program -> TimeSpan.Zero)),
+      CategorizedTime.Zero
+    )
+  }
+
+  test("CategorizedTime.Zero equals computed zero") {
+    assertEquals(
+      CategorizedTime.Zero.sumCharge(ChargeClass.Program, TimeSpan.Zero),
+      CategorizedTime.Zero
+    )
+
+    val ms         = TimeSpan.unsafeFromMicroseconds(1000L)
+    val correction = TimeChargeCorrection(
+      Timestamp.Min,
+      ServiceUser(User.Id.fromLong(1L).get, "Test"),
+      ChargeClass.Program,
+      TimeChargeCorrection.Op.Subtract,
+      ms,
+      none
+    )
+
+    assertEquals(
+      CategorizedTime(ChargeClass.Program -> ms).correct(correction),
+      CategorizedTime.Zero
+    )
+  }
+
+  test("equals and Order agree") {
+    forAll { (a: CategorizedTime, b: CategorizedTime) =>
+      (a == b) === (a === b)
     }
   }
 


### PR DESCRIPTION
`CategorizedTime` is an `opaque type` that is a `SortedMap` at heart. When a `ChargeClass` has `Zero` time associated with it, the map might or might not have an entry for that charge class.  This makes comparison with `.equals`, which just compares the two underlying `SortedMap`s,  inconsistent with the `Order` implementation and frustrates testing.  For example `SortedMap.empty != SortedMap(ChargeClass.Program -> TimeSpan.Zero)` but `Order` considers the two `CategorizedTime`s to be equal.

I've "fixed" this by ensuring that a charge class with a  `TimeCharge.Zero` is never present in the map.  This may be considered a bit fragile.  An alternative would be to just convert `CategorizedTime` into a straightforward `case class`.