### PR TITLE
DatasetReference

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/DatasetReference.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/DatasetReference.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+package sequence
+
+
+import cats.Order
+import cats.parse.Parser
+import cats.parse.Parser.*
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.syntax.*
+import lucuma.core.optics.Format
+
+/**
+ * Dataset reference combines the observation reference with the step index
+ * and exposure index.
+ */
+case class DatasetReference(
+  observationReference: ObservationReference,
+  stepIndex:            PosInt,
+  exposureIndex:        PosInt
+) {
+
+  /** Formatted dataset reference String. */
+  def label: String =
+    f"${observationReference.label}-$stepIndex%04d-$exposureIndex%04d"
+
+}
+
+object DatasetReference {
+
+  object parse {
+    import ObservationReference.parse.observation
+    import parser.ReferenceParsers.*
+
+    val dataset: Parser[DatasetReference] =
+      ((observation <* dash) ~ (index <* dash) ~ index).map { case ((obs, step), exposure) =>
+        DatasetReference(obs, step, exposure)
+      }
+  }
+
+  given Order[DatasetReference] =
+    Order.by { a => (a.observationReference, a.stepIndex.value, a.exposureIndex.value) }
+
+  given Ordering[DatasetReference] =
+    Order[DatasetReference].toOrdering
+
+  val fromString: Format[String, DatasetReference] =
+    Format(s => parse.dataset.parseAll(s).toOption, _.label)
+
+  given Decoder[DatasetReference] =
+    Decoder.decodeString.emap { s =>
+      fromString
+        .getOption(s)
+        .toRight(s"Could not parse '$s' as a DatasetReference.")
+    }
+
+  given Encoder[DatasetReference] =
+    Encoder.instance(_.label.asJson)
+
+}
+

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbDatasetReference.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbDatasetReference.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+package arb
+
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.model.ObservationReference
+import lucuma.core.model.arb.ArbObservationReference
+import lucuma.core.model.arb.ArbReference
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+
+trait ArbDatasetReference extends ArbReference {
+
+  import ArbObservationReference.given
+
+  given Arbitrary[DatasetReference] =
+    Arbitrary {
+      for {
+        p <- arbitrary[ObservationReference]
+        s <- arbitraryIndex
+        e <- arbitraryIndex
+      } yield DatasetReference(p, PosInt.unsafeFrom(s), PosInt.unsafeFrom(e))
+    }
+
+  given Cogen[DatasetReference] =
+    Cogen[(ObservationReference, Int, Int)].contramap { a => (
+      a.observationReference,
+      a.stepIndex.value,
+      a.exposureIndex.value
+    )}
+
+  val datasetReferenceStrings: Gen[String] =
+    referenceStrings[DatasetReference](_.label)
+
+}
+
+object ArbDatasetReference extends ArbDatasetReference
+

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DatasetReferenceSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/DatasetReferenceSuite.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.kernel.laws.discipline.*
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import lucuma.core.model.sequence.arb.ArbDatasetReference
+import lucuma.core.optics.laws.discipline.*
+
+final class DatasetReferenceSuite extends munit.DisciplineSuite with ArbitraryInstances {
+
+  import ArbDatasetReference.given
+  import ArbDatasetReference.datasetReferenceStrings
+
+  checkAll("DatasetReference", OrderTests[DatasetReference].order)
+  checkAll("DatasetReference", FormatTests(DatasetReference.fromString).formatWith(datasetReferenceStrings))
+  checkAll("DatasetReference", CodecTests[DatasetReference].codec)
+
+}


### PR DESCRIPTION
Adds the `DatasetReference` here in `lucuma-core` in order to, ultimately, take the place of the one in `lucuma-odb`.