### PR TITLE
Execution Event Updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.93"
+ThisBuild / tlBaseVersion                         := "0.94"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SlewStage.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SlewStage.scala
@@ -7,7 +7,7 @@ import lucuma.core.util.Enumerated
 
 enum SlewStage(val tag: String, val name: String, val description: String) derives Enumerated {
 
-  case Start extends SlewStage("start", "Slew Start", "Slew started.")
-  case End   extends SlewStage("stop",  "Stop Stop",  "Slew stopped.")
+  case Start extends SlewStage("start_slew", "Start Slew", "Slew started.")
+  case End   extends SlewStage("end_slew",   "End Slew",   "Slew ended.")
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SlewStage.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SlewStage.scala
@@ -7,7 +7,7 @@ import lucuma.core.util.Enumerated
 
 enum SlewStage(val tag: String, val name: String, val description: String) derives Enumerated {
 
-  case Start extends SlewStage("start_slew", "Start Slew", "Slew started.")
-  case End   extends SlewStage("end_slew",   "End Slew",   "Slew ended.")
+  case StartSlew extends SlewStage("start_slew", "Start Slew", "Slew started.")
+  case EndSlew   extends SlewStage("end_slew",   "End Slew",   "Slew ended.")
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SlewStage.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SlewStage.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum SlewStage(val tag: String, val name: String, val description: String) derives Enumerated {
+
+  case Start extends SlewStage("start", "Slew Start", "Slew started.")
+  case End   extends SlewStage("stop",  "Stop Stop",  "Slew stopped.")
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/StepStage.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/StepStage.scala
@@ -7,11 +7,15 @@ import lucuma.core.util.Enumerated
 
 enum StepStage(val tag: String, val name: String, val description: String) derives Enumerated {
 
+  case Abort          extends StepStage("abort",           "Abort Step",      "A step was aborted abruptly.")
+  case Continue       extends StepStage("continue",        "Continue Step",   "A paused step was continued.")
   case EndConfigure   extends StepStage("end_configure",   "End Configure",   "End of instrument configuration stage.")
   case EndObserve     extends StepStage("end_observe",     "End Observe",     "End of data collection for all datasets produced by this step.")
   case EndStep        extends StepStage("end_step",        "End Step",        "Step complete.")
+  case Pause          extends StepStage("pause",           "Pause Step",      "A step was paused mid-execution.")
   case StartConfigure extends StepStage("start_configure", "Start Configure", "Start of instrument configuration stage.")
   case StartObserve   extends StepStage("start_observe",   "Start Observe",   "Start of data collection for this step.")
   case StartStep      extends StepStage("start_step",      "Start Step",      "Step started.")
+  case Stop           extends StepStage("stop",            "Stop Step",       "A step was stopped gracefully before completion.")
 
 }

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExecutionEvent.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExecutionEvent.scala
@@ -6,6 +6,7 @@ package arb
 
 import lucuma.core.enums.DatasetStage
 import lucuma.core.enums.SequenceCommand
+import lucuma.core.enums.SlewStage
 import lucuma.core.enums.StepStage
 import lucuma.core.model.sequence.Dataset
 import lucuma.core.model.sequence.Step
@@ -82,6 +83,32 @@ trait ArbExecutionEvent {
       a.command
     )}
 
+  given Arbitrary[ExecutionEvent.SlewEvent] =
+    Arbitrary {
+      for {
+        eid <- arbitrary[ExecutionEvent.Id]
+        rec <- arbitrary[Timestamp]
+        oid <- arbitrary[Observation.Id]
+        vid <- arbitrary[Visit.Id]
+        stg <- arbitrary[SlewStage]
+      } yield ExecutionEvent.SlewEvent(eid, rec, oid, vid, stg)
+    }
+
+  given Cogen[ExecutionEvent.SlewEvent] =
+    Cogen[(
+      ExecutionEvent.Id,
+      Timestamp,
+      Observation.Id,
+      Visit.Id,
+      SlewStage
+    )].contramap { a => (
+      a.id,
+      a.received,
+      a.observationId,
+      a.visitId,
+      a.stage
+    )}
+
   given Arbitrary[ExecutionEvent.StepEvent] =
     Arbitrary {
       for {
@@ -116,6 +143,7 @@ trait ArbExecutionEvent {
       Gen.oneOf[ExecutionEvent](
         arbitrary[ExecutionEvent.DatasetEvent],
         arbitrary[ExecutionEvent.SequenceEvent],
+        arbitrary[ExecutionEvent.SlewEvent],
         arbitrary[ExecutionEvent.StepEvent]
       )
     }
@@ -124,10 +152,12 @@ trait ArbExecutionEvent {
     Cogen[(
       Option[ExecutionEvent.DatasetEvent],
       Option[ExecutionEvent.SequenceEvent],
+      Option[ExecutionEvent.SlewEvent],
       Option[ExecutionEvent.StepEvent]
     )].contramap { a => (
       ExecutionEvent.datasetEvent.getOption(a),
       ExecutionEvent.sequenceEvent.getOption(a),
+      ExecutionEvent.slewEvent.getOption(a),
       ExecutionEvent.stepEvent.getOption(a)
     )}
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/ExecutionEventSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/ExecutionEventSuite.scala
@@ -14,6 +14,7 @@ class ExecutionEventSuite extends DisciplineSuite {
   checkAll("Eq[ExecutionEvent]", EqTests[ExecutionEvent].eqv)
   checkAll("ExecutionEvent.datasetEvent", PrismTests(ExecutionEvent.datasetEvent))
   checkAll("ExecutionEvent.sequenceEvent", PrismTests(ExecutionEvent.sequenceEvent))
+  checkAll("ExecutionEvent.slewEvent", PrismTests(ExecutionEvent.slewEvent))
   checkAll("ExecutionEvent.stepEvent", PrismTests(ExecutionEvent.sequenceEvent))
 
 }


### PR DESCRIPTION
After discussion about execution events, I believe the consensus is:

* `Abort`, `Continue`, `Pause`, `Start` have an interpretation at the sequence level and will remain there
* They also need to be present at the step level and are added in this PR
* We're missing slew events

but please correct me if I'm wrong.
