### PR TITLE
Move guide config model from observe/seqexec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.93"
+ThisBuild / tlBaseVersion                         := "0.94"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 
@@ -81,6 +81,7 @@ lazy val testkit = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel"     %%% "spire-laws"         % spireVersion,
       "eu.timepit"        %%% "refined-scalacheck" % refinedVersion,
       "io.circe"          %%% "circe-testing"      % circeVersion,
+      "com.manyangled"    %%% "coulomb-testkit"    % coulombVersion,
       "io.chrisdavenport" %%% "cats-scalacheck"    % catsScalacheckVersion
     )
   )

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ComaOption.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ComaOption.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.NewType
+
+object ComaOption extends NewType[Boolean] {
+  val ComaOn = ComaOption(true)
+  val ComaOff = ComaOption(false)
+
+  def fromBoolean(b: Boolean): ComaOption = if (b) ComaOn else ComaOff
+}
+
+type ComaOption = ComaOption.Type

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/FieldLens.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/FieldLens.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum FieldLens(val tag: String) derives Enumerated {
+  case In extends FieldLens("in")
+  case Out extends FieldLens("out")
+}
+

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GuideProbe.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GuideProbe.scala
@@ -8,8 +8,8 @@ import lucuma.core.util.Enumerated
 /**
  * Enumerated type for guide probe
  */
-enum GuideProbe(val tag: String) extends Product with Serializable derives Enumerated {
-  case PWFS1     extends GuideProbe("Pwfs2")
-  case PWFS2     extends GuideProbe("Pwfs1")
+enum GuideProbe(val tag: String) derives Enumerated {
+  case PWFS1     extends GuideProbe("Pwfs1")
+  case PWFS2     extends GuideProbe("Pwfs2")
   case GmosOIWFS extends GuideProbe("GmosOiwfs")
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GuideProbe.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GuideProbe.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+/**
+ * Enumerated type for guide probe
+ */
+enum GuideProbe(val tag: String) extends Product with Serializable derives Enumerated {
+  case PWFS1     extends GuideProbe("Pwfs2")
+  case PWFS2     extends GuideProbe("Pwfs1")
+  case GmosOIWFS extends GuideProbe("GmosOiwfs")
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/M1Source.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/M1Source.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+/** Enumerated type for M1 Source. */
+enum M1Source(val tag: String) derives Enumerated {
+  case PWFS1 extends M1Source("Pwfs1")
+  case PWFS2 extends M1Source("Pwfs2")
+  case OIWFS extends M1Source("Oiwfs")
+  case GAOS  extends M1Source("Gaos")
+  case HRWFS extends M1Source("Hrwfs")
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/MountGuideOption.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/MountGuideOption.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.NewType
+
+object MountGuideOption extends NewType[Boolean] {
+  val MountGuideOn = MountGuideOption(true)
+  val MountGuideOff = MountGuideOption(false)
+
+  def fromBoolean(b: Boolean): MountGuideOption = if (b) MountGuideOn else MountGuideOff
+}
+type MountGuideOption = MountGuideOption.Type
+

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/StepGuideState.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/StepGuideState.scala
@@ -8,9 +8,9 @@ import lucuma.core.util.Enumerated
 /**
  * An enumeration whose value determines whether guiding is enabled for a particular step.
  */
-enum GuideState(val tag: String, val name: String, val description: String) derives Enumerated {
+enum StepGuideState(val tag: String, val name: String, val description: String) derives Enumerated {
 
-  case Enabled  extends GuideState("enabled",  "Enabled",  "Guiding is enabled.")
-  case Disabled extends GuideState("disabled", "Disabled", "Guiding is disabled.")
+  case Enabled  extends StepGuideState("enabled",  "Enabled",  "Guiding is enabled.")
+  case Disabled extends StepGuideState("disabled", "Disabled", "Guiding is disabled.")
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/TipTiltSource.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/TipTiltSource.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+/** Enumerated type for Tip/Tilt Source. */
+enum TipTiltSource(val tag: String) derives Enumerated {
+  case PWFS1 extends TipTiltSource("Pwfs1")
+  case PWFS2 extends TipTiltSource("Pwfs2")
+  case OIWFS extends TipTiltSource("Oiwfs")
+  case GAOS  extends TipTiltSource("Gaos")
+}
+

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/gems.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/gems.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.NewType
+
+object Cwfs1Usage extends NewType[Boolean] {
+  val Use = Cwfs1Usage(true)
+  val DontUse = Cwfs1Usage(false)
+
+  def fromBoolean(b: Boolean): Cwfs1Usage = if (b) Use else DontUse
+}
+
+type Cwfs1Usage = Cwfs1Usage.Type
+
+object Cwfs2Usage extends NewType[Boolean] {
+  val Use = Cwfs2Usage(true)
+  val DontUse = Cwfs2Usage(false)
+
+  def fromBoolean(b: Boolean): Cwfs2Usage = if (b) Use else DontUse
+}
+
+type Cwfs2Usage = Cwfs2Usage.Type
+
+object Cwfs3Usage extends NewType[Boolean] {
+  val Use = Cwfs3Usage(true)
+  val DontUse = Cwfs3Usage(false)
+
+  def fromBoolean(b: Boolean): Cwfs3Usage = if (b) Use else DontUse
+}
+
+type Cwfs3Usage = Cwfs3Usage.Type
+
+object Odgw1Usage extends NewType[Boolean] {
+  val Use = Odgw1Usage(true)
+  val DontUse = Odgw1Usage(false)
+
+  def fromBoolean(b: Boolean): Odgw1Usage = if (b) Use else DontUse
+}
+type Odgw1Usage = Odgw1Usage.Type
+
+object Odgw2Usage extends NewType[Boolean] {
+  val Use = Odgw2Usage(true)
+  val DontUse = Odgw2Usage(false)
+
+  def fromBoolean(b: Boolean): Odgw2Usage = if (b) Use else DontUse
+}
+type Odgw2Usage = Odgw2Usage.Type
+
+object Odgw3Usage extends NewType[Boolean] {
+  val Use = Odgw3Usage(true)
+  val DontUse = Odgw3Usage(false)
+
+  def fromBoolean(b: Boolean): Odgw3Usage = if (b) Use else DontUse
+}
+type Odgw3Usage = Odgw3Usage.Type
+
+object Odgw4Usage extends NewType[Boolean] {
+  val Use = Odgw4Usage(true)
+  val DontUse = Odgw4Usage(false)
+
+  def fromBoolean(b: Boolean): Odgw4Usage = if (b) Use else DontUse
+}
+type Odgw4Usage = Odgw4Usage.Type
+
+object P1Usage extends NewType[Boolean] {
+  val Use = P1Usage(true)
+  val DontUse = P1Usage(false)
+
+  def fromBoolean(b: Boolean): P1Usage = if (b) Use else DontUse
+}
+type P1Usage = P1Usage.Type
+
+object OIUsage extends NewType[Boolean] {
+  val Use = OIUsage(true)
+  val DontUse = OIUsage(false)
+
+  def fromBoolean(b: Boolean): OIUsage = if (b) Use else DontUse
+}
+type OIUsage = OIUsage.Type

--- a/modules/core/shared/src/main/scala/lucuma/core/model/AltairConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/AltairConfig.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.syntax.all.*
+import coulomb.Quantity
+import coulomb.units.accepted.Millimeter
+
+sealed trait AltairConfig
+
+object AltairConfig {
+  case object AltairOff extends AltairConfig
+  case class Ngs(
+    blend: Boolean, 
+    starPos: (Quantity[BigDecimal, Millimeter], Quantity[BigDecimal, Millimeter])
+  ) extends AltairConfig
+  case class Lgs(
+    strap: Boolean, 
+    sfo: Boolean, 
+    starPos: (Quantity[BigDecimal, Millimeter], Quantity[BigDecimal, Millimeter])
+  ) extends AltairConfig
+  case object LgsWithP1 extends AltairConfig
+  case object LgsWithOi extends AltairConfig
+
+  given Eq[Ngs] = Eq.by(x => (x.blend, x.starPos._1.value, x.starPos._2.value))
+  given Eq[Lgs] = Eq.by(x => (x.strap, x.sfo, x.starPos._1.value, x.starPos._2.value))
+
+  given Eq[AltairConfig] = Eq.instance {
+    case (AltairOff, AltairOff) => true
+    case (a: Lgs, b: Lgs)       => a === b
+    case (a: Ngs, b: Ngs)       => a === b
+    case (LgsWithOi, LgsWithOi) => true
+    case (LgsWithP1, LgsWithP1) => true
+    case _                      => false
+  }
+}
+

--- a/modules/core/shared/src/main/scala/lucuma/core/model/GemsConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/GemsConfig.scala
@@ -1,0 +1,100 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.Show
+import cats.syntax.all.*
+import lucuma.core.enums.*
+
+sealed trait GemsConfig extends Product with Serializable {
+    val isCwfs1Used: Boolean
+    val isCwfs2Used: Boolean
+    val isCwfs3Used: Boolean
+    val isOdgw1Used: Boolean
+    val isOdgw2Used: Boolean
+    val isOdgw3Used: Boolean
+    val isOdgw4Used: Boolean
+    val isP1Used: Boolean
+    val isOIUsed: Boolean
+  }
+
+object GemsConfig {
+  case object GemsOff extends GemsConfig {
+    override val isCwfs1Used: Boolean = false
+    override val isCwfs2Used: Boolean = false
+    override val isCwfs3Used: Boolean = false
+    override val isOdgw1Used: Boolean = false
+    override val isOdgw2Used: Boolean = false
+    override val isOdgw3Used: Boolean = false
+    override val isOdgw4Used: Boolean = false
+    override val isP1Used: Boolean    = false
+    override val isOIUsed: Boolean    = false
+  }
+
+  final case class GemsOn(
+    cwfs1: Cwfs1Usage,
+    cwfs2: Cwfs2Usage,
+    cwfs3: Cwfs3Usage,
+    odgw1: Odgw1Usage,
+    odgw2: Odgw2Usage,
+    odgw3: Odgw3Usage,
+    odgw4: Odgw4Usage,
+    useP1: P1Usage,
+    useOI: OIUsage
+  ) extends GemsConfig {
+
+    override val isCwfs1Used: Boolean = cwfs1 === Cwfs1Usage.Use
+
+    override val isCwfs2Used: Boolean = cwfs2 === Cwfs2Usage.Use
+
+    override val isCwfs3Used: Boolean = cwfs3 === Cwfs3Usage.Use
+
+    override val isOdgw1Used: Boolean = odgw1 === Odgw1Usage.Use
+
+    override val isOdgw2Used: Boolean = odgw2 === Odgw2Usage.Use
+
+    override val isOdgw3Used: Boolean = odgw3 === Odgw3Usage.Use
+
+    override val isOdgw4Used: Boolean = odgw4 === Odgw4Usage.Use
+
+    override val isP1Used: Boolean = useP1 === P1Usage.Use
+
+    override val isOIUsed: Boolean = useOI === OIUsage.Use
+  }
+
+  given Show[GemsConfig] = Show.show { x =>
+    List(
+      if (x.isCwfs1Used) "CWFS1".some else none,
+      if (x.isCwfs2Used) "CWFS2".some else none,
+      if (x.isCwfs3Used) "CWFS3".some else none,
+      if (x.isOdgw1Used) "ODGW1".some else none,
+      if (x.isOdgw2Used) "ODGW2".some else none,
+      if (x.isOdgw3Used) "ODGW3".some else none,
+      if (x.isOdgw4Used) "ODGW4".some else none
+    ).flattenOption
+      .mkString("(", ", ", ")")
+  }
+
+  given Eq[GemsOn] = Eq.by(x =>
+    (
+      x.cwfs1,
+      x.cwfs2,
+      x.cwfs3,
+      x.odgw1,
+      x.odgw2,
+      x.odgw3,
+      x.odgw4,
+      x.useP1,
+      x.useOI
+    )
+  )
+
+  given Eq[GemsConfig] = Eq.instance {
+    case (a: GemsOn, b: GemsOn) => a === b
+    case (GemsOff, GemsOff)     => true
+    case _                      => false
+  }
+}
+

--- a/modules/core/shared/src/main/scala/lucuma/core/model/GuideConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/GuideConfig.scala
@@ -40,15 +40,14 @@ import monocle.std.option
 
 case class GuideConfig(
   tcsGuide:      TelescopeGuideConfig,
-  gaosGuide:     Option[Either[AltairConfig, GemsConfig]],
-  gemsSkyPaused: Boolean
+  gaosGuide:     Option[Either[AltairConfig, GemsConfig]]
 ) derives Eq
 
 object GuideConfig {
-  val tcsGuide: Lens[GuideConfig, TelescopeGuideConfig]                      = Focus[GuideConfig](_.tcsGuide)
+  val tcsGuide: Lens[GuideConfig, TelescopeGuideConfig]                      =
+    Focus[GuideConfig](_.tcsGuide)
   val gaosGuide: Lens[GuideConfig, Option[Either[AltairConfig, GemsConfig]]] =
     Focus[GuideConfig](_.gaosGuide)
-  val gemsSkyPaused: Lens[GuideConfig, Boolean]                              = Focus[GuideConfig](_.gemsSkyPaused)
   val altairGuide: Optional[GuideConfig, AltairConfig]                       =
     gaosGuide.andThen(option.some).andThen(either.stdLeft)
   val gemsGuide: Optional[GuideConfig, GemsConfig]                           =
@@ -63,7 +62,6 @@ object GuideConfig {
         false,
         None),
       None,
-      false
     )
 
   given Decoder[AltairConfig] = Decoder.instance[AltairConfig] { c =>
@@ -251,13 +249,12 @@ object GuideConfig {
 
   given Decoder[GuideConfig] =
     Decoder
-      .forProduct3[GuideConfig, TelescopeGuideConfig, Option[Either[AltairConfig, GemsConfig]], Boolean](
+      .forProduct2[GuideConfig, TelescopeGuideConfig, Option[Either[AltairConfig, GemsConfig]]](
         "tcsGuide",
-        "gaosGuide",
-        "gemsSkyPaused"
-      )(GuideConfig(_, _, _))
+        "gaosGuide"
+      )(GuideConfig(_, _))
 
   given Encoder[GuideConfig] =
-    Encoder.forProduct3("tcsGuide", "gaosGuide", "gemsSkyPaused")(u => (u.tcsGuide, u.gaosGuide, u.gemsSkyPaused))
+    Encoder.forProduct2("tcsGuide", "gaosGuide")(u => (u.tcsGuide, u.gaosGuide))
 }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/GuideConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/GuideConfig.scala
@@ -1,0 +1,263 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.derived.*
+import cats.syntax.all.*
+import coulomb.syntax.*
+import coulomb.units.accepted.Millimeter
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.syntax.*
+import lucuma.core.enums.ComaOption
+import lucuma.core.enums.Cwfs1Usage
+import lucuma.core.enums.Cwfs2Usage
+import lucuma.core.enums.Cwfs3Usage
+import lucuma.core.enums.GuideProbe
+import lucuma.core.enums.M1Source
+import lucuma.core.enums.MountGuideOption
+import lucuma.core.enums.OIUsage
+import lucuma.core.enums.Odgw1Usage
+import lucuma.core.enums.Odgw2Usage
+import lucuma.core.enums.Odgw3Usage
+import lucuma.core.enums.Odgw4Usage
+import lucuma.core.enums.P1Usage
+import lucuma.core.enums.TipTiltSource
+import lucuma.core.model.AltairConfig.*
+import lucuma.core.model.GemsConfig.*
+import lucuma.core.model.M1GuideConfig.*
+import lucuma.core.model.M2GuideConfig.*
+import lucuma.core.model.TelescopeGuideConfig.given
+import monocle.Focus
+import monocle.Lens
+import monocle.Optional
+import monocle.std.either
+import monocle.std.option
+
+case class GuideConfig(
+  tcsGuide:      TelescopeGuideConfig,
+  gaosGuide:     Option[Either[AltairConfig, GemsConfig]],
+  gemsSkyPaused: Boolean
+) derives Eq
+
+object GuideConfig {
+  val tcsGuide: Lens[GuideConfig, TelescopeGuideConfig]                      = Focus[GuideConfig](_.tcsGuide)
+  val gaosGuide: Lens[GuideConfig, Option[Either[AltairConfig, GemsConfig]]] =
+    Focus[GuideConfig](_.gaosGuide)
+  val gemsSkyPaused: Lens[GuideConfig, Boolean]                              = Focus[GuideConfig](_.gemsSkyPaused)
+  val altairGuide: Optional[GuideConfig, AltairConfig]                       =
+    gaosGuide.andThen(option.some).andThen(either.stdLeft)
+  val gemsGuide: Optional[GuideConfig, GemsConfig]                           =
+    gaosGuide.andThen(option.some).andThen(either.stdRight)
+
+  val defaultGuideConfig: GuideConfig =
+    GuideConfig(
+      TelescopeGuideConfig(
+        MountGuideOption.MountGuideOff,
+        M1GuideOff,
+        M2GuideOff,
+        false,
+        None),
+      None,
+      false
+    )
+
+  given Decoder[AltairConfig] = Decoder.instance[AltairConfig] { c =>
+    c.downField("aoOn").as[Boolean].flatMap {
+      if (_)
+        c.downField("mode").as[String].flatMap {
+          case "NGS" =>
+            for {
+              blnd <- c.downField("oiBlend").as[Boolean]
+              gsx  <- c.downField("aogsx").as[BigDecimal]
+              gsy  <- c.downField("aogsy").as[BigDecimal]
+            } yield Ngs(blnd, (gsx.withUnit[Millimeter], gsy.withUnit[Millimeter]))
+          case "LGS" =>
+            c.downField("useP1").as[Boolean].flatMap {
+              if (_) Right(LgsWithP1)
+              else
+                c.downField("useOI").as[Boolean].flatMap {
+                  if (_) Right(LgsWithOi)
+                  else
+                    for {
+                      strapLoop <- c.downField("strapOn").as[Boolean]
+                      sfoLoop   <- c.downField("sfoOn").as[Boolean]
+                      gsx       <- c.downField("aogsx").as[BigDecimal]
+                      gsy       <- c.downField("aogsy").as[BigDecimal]
+                    } yield Lgs(strapLoop, sfoLoop, (gsx.withUnit[Millimeter], gsy.withUnit[Millimeter]))
+                }
+            }
+          case _     => Left(DecodingFailure("AltairConfig", c.history))
+        }
+      else Right(AltairOff)
+    }
+  }
+
+  given Encoder[AltairConfig] = {
+    case AltairConfig.AltairOff => Json.obj("aoOn" -> Json.fromBoolean(false))
+    case LgsWithP1 =>
+      Json.obj(
+        "aoOn" -> Json.fromBoolean(true),
+        "mode" -> "LGS".asJson,
+        "useP1" -> Json.fromBoolean(true),
+        "useOI" -> Json.fromBoolean(false),
+      )
+    case LgsWithOi =>
+      Json.obj(
+        "aoOn" -> Json.fromBoolean(true),
+        "mode" -> "LGS".asJson,
+        "useP1" -> Json.fromBoolean(false),
+        "useOI" -> Json.fromBoolean(true)
+      )
+    case Ngs(blend, starPos) =>
+      Json.obj(
+        "aoOn" -> Json.fromBoolean(true),
+        "mode" -> "NGS".asJson,
+        "useP1" -> Json.fromBoolean(false),
+        "useOI" -> Json.fromBoolean(false),
+        "oiBlend" -> blend.asJson,
+        "aogsx" -> Json.fromBigDecimal(starPos._1.value),
+        "aogsy" -> Json.fromBigDecimal(starPos._2.value)
+      )
+    case Lgs(strap, sfo, starPos) =>
+      Json.obj(
+        "aoOn" -> Json.fromBoolean(true),
+        "mode" -> "LGS".asJson,
+        "useP1" -> Json.fromBoolean(false),
+        "useOI" -> Json.fromBoolean(false),
+        "strapOn" -> Json.fromBoolean(strap),
+        "sfoOn" -> Json.fromBoolean(sfo),
+        "aogsx" -> Json.fromBigDecimal(starPos._1.value),
+        "aogsy" -> Json.fromBigDecimal(starPos._2.value)
+      )
+  }
+
+  given Decoder[GemsConfig] = Decoder.instance[GemsConfig] { c =>
+    c.downField("aoOn").as[Boolean].flatMap { x =>
+      if (x)
+        for {
+          cwfs1 <- c.downField("ttgs1On").as[Boolean]
+          cwfs2 <- c.downField("ttgs2On").as[Boolean]
+          cwfs3 <- c.downField("ttgs3On").as[Boolean]
+          odgw1 <- c.downField("odgw1On").as[Boolean]
+          odgw2 <- c.downField("odgw2On").as[Boolean]
+          odgw3 <- c.downField("odgw3On").as[Boolean]
+          odgw4 <- c.downField("odgw4On").as[Boolean]
+          useP1 <- c.downField("useP1").as[Boolean].recover { case _ => false }
+          useOI <- c.downField("useOI").as[Boolean].recover { case _ => false }
+        } yield GemsOn(
+          Cwfs1Usage.fromBoolean(cwfs1),
+          Cwfs2Usage.fromBoolean(cwfs2),
+          Cwfs3Usage.fromBoolean(cwfs3),
+          Odgw1Usage.fromBoolean(odgw1),
+          Odgw2Usage.fromBoolean(odgw2),
+          Odgw3Usage.fromBoolean(odgw3),
+          Odgw4Usage.fromBoolean(odgw4),
+          P1Usage.fromBoolean(useP1),
+          OIUsage.fromBoolean(useOI)
+        )
+      else Right(GemsOff)
+    }
+  }
+
+  given Encoder[GemsConfig] = {
+    case GemsOff =>
+      Json.obj("aoOn" -> Json.fromBoolean(false))
+    case GemsOn(cwfs1, cwfs2, cwfs3, odgw1, odgw2, odgw3, odgw4, useP1, useOI) =>
+      Json.obj(
+        "aoOn"    -> Json.fromBoolean(true),
+        "ttgs1On" -> cwfs1.asJson,
+        "ttgs2On" -> cwfs2.asJson,
+        "ttgs3On" -> cwfs3.asJson,
+        "odgw1On" -> odgw1.asJson,
+        "odgw2On" -> odgw2.asJson,
+        "odgw3On" -> odgw3.asJson,
+        "odgw4On" -> odgw4.asJson,
+        "useP1"   -> useP1.asJson,
+        "useOI"   -> useOI.asJson
+      )
+  }
+
+  given Decoder[Either[AltairConfig, GemsConfig]] =
+    Decoder.decodeEither[AltairConfig, GemsConfig]("altair", "gems")
+
+  given Encoder[Either[AltairConfig, GemsConfig]] =
+    Encoder.encodeEither[AltairConfig, GemsConfig]("altair", "gems")
+
+  given Decoder[MountGuideOption] =
+    Decoder.decodeBoolean.map(if(_) MountGuideOption.MountGuideOn else MountGuideOption.MountGuideOff)
+
+  given Decoder[M1GuideConfig] = Decoder.instance[M1GuideConfig] { c =>
+    c.downField("on").as[Boolean].flatMap {
+      if (_)
+        c.downField("source").as[M1Source].map(M1GuideOn(_))
+      else Right(M1GuideOff)
+    }
+  }
+
+  given Encoder[M1GuideConfig] = {
+    case M1GuideConfig.M1GuideOff => Json.obj("on" -> Json.fromBoolean(false))
+    case M1GuideConfig.M1GuideOn(source) => Json.obj("on" -> Json.fromBoolean(true), "source" -> source.asJson)
+  }
+
+  given Decoder[ComaOption] = Decoder.decodeBoolean.map(if (_) ComaOption.ComaOn else ComaOption.ComaOff)
+
+  given Decoder[M2GuideConfig] = Decoder.instance[M2GuideConfig] { c =>
+    c.downField("on").as[Boolean].flatMap {
+      if (_)
+        for {
+          srcs <- c.downField("sources").as[Set[TipTiltSource]]
+          coma <- c.downField("comaOn").as[ComaOption]
+        } yield M2GuideOn(coma, srcs)
+      else Right(M2GuideOff)
+    }
+  }
+
+  given Encoder[M2GuideConfig] = {
+    case M2GuideConfig.M2GuideOff => Json.obj("on" -> Json.fromBoolean(false))
+    case M2GuideConfig.M2GuideOn(coma, sources) =>
+      Json.obj(
+        "on"      -> Json.fromBoolean(true),
+        "comaOn"  -> coma.asJson,
+        "sources" -> sources.asJson
+      )
+  }
+
+  given Decoder[ProbeGuide] = Decoder.forProduct2[ProbeGuide, GuideProbe, GuideProbe]("from", "to")(ProbeGuide.apply)
+
+  given Encoder[ProbeGuide] = Encoder.forProduct2("from", "to")(x => (x.from, x.to))
+
+  given Decoder[TelescopeGuideConfig] =
+    Decoder.forProduct5[TelescopeGuideConfig, MountGuideOption, M1GuideConfig, M2GuideConfig, Boolean, Option[ProbeGuide]](
+      "mountGuideOn",
+      "m1Guide",
+      "m2Guide",
+      "dayTimeMode",
+      "probeGuide",
+    )(TelescopeGuideConfig.apply)
+
+  given Encoder[TelescopeGuideConfig] =
+    Encoder.forProduct5(
+      "mountGuideOn",
+      "m1Guide",
+      "m2Guide",
+      "dayTimeMode",
+      "probeGuide"
+    )(x => (x.mountGuide, x.m1Guide, x.m2Guide, x.dayTimeMode, x.probeGuide))
+
+  given Decoder[GuideConfig] =
+    Decoder
+      .forProduct3[GuideConfig, TelescopeGuideConfig, Option[Either[AltairConfig, GemsConfig]], Boolean](
+        "tcsGuide",
+        "gaosGuide",
+        "gemsSkyPaused"
+      )(GuideConfig(_, _, _))
+
+  given Encoder[GuideConfig] =
+    Encoder.forProduct3("tcsGuide", "gaosGuide", "gemsSkyPaused")(u => (u.tcsGuide, u.gaosGuide, u.gemsSkyPaused))
+}
+

--- a/modules/core/shared/src/main/scala/lucuma/core/model/M1GuideConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/M1GuideConfig.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.*
+import cats.derived.*
+import cats.syntax.all.*
+import lucuma.core.enums.M1Source
+
+/** Data type for M1 guide config. */
+sealed trait M1GuideConfig extends Product with Serializable derives Eq, Show {
+  def uses(s: M1Source): Boolean
+}
+
+object M1GuideConfig {
+  case object M1GuideOff extends M1GuideConfig derives Eq, Show {
+    override def uses(s: M1Source): Boolean = false
+  }
+
+  case class M1GuideOn(source: M1Source) extends M1GuideConfig derives Eq, Show {
+    override def uses(s: M1Source): Boolean = source === s
+  }
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/M2GuideConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/M2GuideConfig.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.*
+import cats.derived.*
+import cats.syntax.all.*
+import lucuma.core.enums.ComaOption
+import lucuma.core.enums.TipTiltSource
+
+/** Data type for M2 guide config. */
+sealed trait M2GuideConfig extends Product with Serializable derives Eq {
+  def uses(s: TipTiltSource): Boolean
+}
+
+object M2GuideConfig {
+  case object M2GuideOff extends M2GuideConfig derives Eq, Show {
+    override def uses(s: TipTiltSource): Boolean = false
+  }
+
+  case class M2GuideOn(coma: ComaOption, sources: Set[TipTiltSource]) extends M2GuideConfig derives Eq {
+    override def uses(s: TipTiltSource): Boolean = sources.contains(s)
+  }
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ProbeGuide.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ProbeGuide.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.Show
+import cats.derived.*
+import lucuma.core.enums.GuideProbe
+
+/** Data type for guide config. */
+case class ProbeGuide(from: GuideProbe, to: GuideProbe) derives Eq, Show

--- a/modules/core/shared/src/main/scala/lucuma/core/model/TelescopeGuideConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/TelescopeGuideConfig.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.derived.*
+import lucuma.core.enums.MountGuideOption
+import monocle.Focus
+import monocle.Lens
+
+/** Data type for guide config. */
+case class TelescopeGuideConfig(
+  mountGuide:  MountGuideOption,
+  m1Guide:     M1GuideConfig,
+  m2Guide:     M2GuideConfig,
+  dayTimeMode: Boolean,
+  probeGuide:  Option[ProbeGuide]
+) derives Eq
+
+object TelescopeGuideConfig {
+  val mountGuide: Lens[TelescopeGuideConfig, MountGuideOption] =
+    Focus[TelescopeGuideConfig](_.mountGuide)
+
+  val m1Guide: Lens[TelescopeGuideConfig, M1GuideConfig] =
+    Focus[TelescopeGuideConfig](_.m1Guide)
+
+  val m2Guide: Lens[TelescopeGuideConfig, M2GuideConfig] =
+    Focus[TelescopeGuideConfig](_.m2Guide)
+
+  val dayTimeMode: Lens[TelescopeGuideConfig, Boolean] =
+    Focus[TelescopeGuideConfig](_.dayTimeMode)
+
+  val probeGuide: Lens[TelescopeGuideConfig, Option[ProbeGuide]] =
+    Focus[TelescopeGuideConfig](_.probeGuide)
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/StepConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/StepConfig.scala
@@ -121,7 +121,7 @@ object StepConfig {
       Focus[Gcal](_.shutter)
   }
 
-  final case class Science(offset: Offset, guiding: GuideState) extends StepConfig(StepType.Science)
+  final case class Science(offset: Offset, guiding: StepGuideState) extends StepConfig(StepType.Science)
 
   object Science {
     implicit val eqStepConfigScience: Eq[Science] =
@@ -135,7 +135,7 @@ object StepConfig {
       Focus[Science](_.offset)
 
     /** @group Optics */
-    val guiding: Lens[Science, GuideState] =
+    val guiding: Lens[Science, StepGuideState] =
       Focus[Science](_.guiding)
   }
 

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/package.scala
@@ -24,6 +24,6 @@ sealed trait IsValid[+E]:
 object IsValid:
   case object Valid extends IsValid[Nothing]:
     override def mapError[E0](f: Nothing => E0): IsValid[E0] = this
-    
+
   case class Invalid[E](error: E) extends IsValid[E]:
     override def mapError[E0](f: E => E0): IsValid[E0] = Invalid(f(error))

--- a/modules/core/shared/src/main/scala/lucuma/core/util/NewType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/NewType.scala
@@ -22,7 +22,7 @@ trait NewType[Wrapped]:
   opaque type Type = Wrapped
 
   inline def apply(w: Wrapped): Type = w
-  
+
   val value: Iso[Type, Wrapped] = Iso[Type, Wrapped](_.value)(apply)
 
   extension (t: Type)

--- a/modules/testkit/src/main/scala/lucuma/core/arb/package.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/arb/package.scala
@@ -49,8 +49,8 @@ implicit val cogenNonNegativeInt: Cogen[NonNegInt] = Cogen[Int].contramap(_.valu
 
 implicit val cogenNonEmptyString: Cogen[NonEmptyString] = Cogen[String].contramap(_.value)
 
-def newTypeArbitrary[T: Arbitrary](base: NewType[T]): Arbitrary[base.Type] = 
+def newTypeArbitrary[T: Arbitrary](base: NewType[T]): Arbitrary[base.Type] =
   Arbitrary(arbitrary[T].map(base.apply(_)))
 
-def newTypeCogen[T: Cogen](base: NewType[T]): Cogen[base.Type] = 
+def newTypeCogen[T: Cogen](base: NewType[T]): Cogen[base.Type] =
   Cogen[T].contramap(_.value)

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbAltairConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbAltairConfig.scala
@@ -1,0 +1,76 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import coulomb.Quantity
+import coulomb.testkit.given
+import coulomb.units.accepted.Millimeter
+import lucuma.core.model.AltairConfig
+import lucuma.core.model.AltairConfig.*
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbAltairConfig {
+
+  given Arbitrary[Lgs] = Arbitrary {
+    for {
+      st <- arbitrary[Boolean]
+      sf <- arbitrary[Boolean]
+      l1 <- arbitrary[Quantity[BigDecimal, Millimeter]]
+      l2 <- arbitrary[Quantity[BigDecimal, Millimeter]]
+    } yield Lgs(st, sf, (l1, l2))
+  }
+
+  given Cogen[Lgs] =
+    Cogen[(
+      Boolean,
+      Boolean,
+      (Quantity[BigDecimal, Millimeter], Quantity[BigDecimal, Millimeter])
+    )]
+      .contramap(x => (x.strap, x.sfo, x.starPos))
+
+  given Arbitrary[Ngs] = Arbitrary {
+    for {
+      b  <- arbitrary[Boolean]
+      l1 <- arbitrary[Quantity[BigDecimal, Millimeter]]
+      l2 <- arbitrary[Quantity[BigDecimal, Millimeter]]
+    } yield Ngs(b, (l1, l2))
+  }
+
+  given Cogen[Ngs] =
+    Cogen[(
+      Boolean,
+      (Quantity[BigDecimal, Millimeter], Quantity[BigDecimal, Millimeter])
+    )].contramap(x => (x.blend, x.starPos))
+
+  given Arbitrary[AltairConfig] = Arbitrary {
+    Gen.oneOf(arbitrary[Lgs],
+              arbitrary[Ngs],
+              Gen.const(AltairOff),
+              Gen.const(LgsWithP1),
+              Gen.const(LgsWithOi)
+    )
+  }
+
+  given Cogen[AltairConfig] = Cogen[Option[
+    Option[Option[Either[(Boolean,
+                          Boolean,
+                          Quantity[BigDecimal, Millimeter],
+                          Quantity[BigDecimal, Millimeter]
+                         ),
+                         (Boolean, Quantity[BigDecimal, Millimeter], Quantity[BigDecimal, Millimeter])
+    ]]]
+  ]].contramap {
+    case AltairOff    => None
+    case LgsWithP1    => Some(None)
+    case LgsWithOi    => Some(Some(None))
+    case Lgs(a, b, c) => Some(Some(Some(Left(a, b, c._1, c._2))))
+    case Ngs(a, c)    => Some(Some(Some(Right(a, c._1, c._2))))
+  }
+
+}
+
+object ArbAltairConfig extends ArbAltairConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbGemsConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbGemsConfig.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import cats.syntax.all.*
+import lucuma.core.arb.*
+import lucuma.core.enums.*
+import lucuma.core.model.GemsConfig
+import lucuma.core.model.GemsConfig.GemsOff
+import lucuma.core.model.GemsConfig.GemsOn
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Cogen.*
+import org.scalacheck.Gen
+
+trait ArbGemsConfig {
+
+  given Arbitrary[Cwfs1Usage] = newTypeArbitrary(Cwfs1Usage)
+
+  given Arbitrary[Cwfs2Usage] = newTypeArbitrary(Cwfs2Usage)
+
+  given Arbitrary[Cwfs3Usage] = newTypeArbitrary(Cwfs3Usage)
+
+  given Arbitrary[Odgw1Usage] = newTypeArbitrary(Odgw1Usage)
+
+  given Arbitrary[Odgw2Usage] = newTypeArbitrary(Odgw2Usage)
+
+  given Arbitrary[Odgw3Usage] = newTypeArbitrary(Odgw3Usage)
+
+  given Arbitrary[Odgw4Usage] = newTypeArbitrary(Odgw4Usage)
+
+  given Arbitrary[OIUsage] = newTypeArbitrary(OIUsage)
+
+  given Arbitrary[P1Usage] = newTypeArbitrary(P1Usage)
+
+  given Arbitrary[GemsOn] = Arbitrary {
+    for {
+      c1  <- arbitrary[Cwfs1Usage]
+      c2  <- arbitrary[Cwfs2Usage]
+      c3  <- arbitrary[Cwfs3Usage]
+      od1 <- arbitrary[Odgw1Usage]
+      od2 <- arbitrary[Odgw2Usage]
+      od3 <- arbitrary[Odgw3Usage]
+      od4 <- arbitrary[Odgw4Usage]
+      oi  <- arbitrary[OIUsage]
+      p1  <- arbitrary[P1Usage]
+    } yield GemsOn(c1, c2, c3, od1, od2, od3, od4, p1, oi)
+  }
+
+  given Cogen[GemsOn] =
+    Cogen[(Boolean, Boolean, Boolean, Boolean, Boolean, Boolean, Boolean, Boolean, Boolean)]
+      .contramap(x =>
+        (
+          x.cwfs1 === Cwfs1Usage.Use,
+          x.cwfs2 === Cwfs2Usage.Use,
+          x.cwfs3 === Cwfs3Usage.Use,
+          x.odgw1 === Odgw1Usage.Use,
+          x.odgw2 === Odgw2Usage.Use,
+          x.odgw3 === Odgw3Usage.Use,
+          x.odgw4 === Odgw4Usage.Use,
+          x.useP1 === P1Usage.Use,
+          x.useOI === OIUsage.Use
+        )
+      )
+
+  given Arbitrary[GemsConfig] = Arbitrary {
+    Gen.oneOf(arbitrary[GemsOn], Gen.const(GemsOff))
+  }
+
+  given Cogen[GemsConfig] = Cogen[Option[GemsOn]].contramap {
+    case GemsOff   => None
+    case x: GemsOn => Some(x)
+  }
+
+}
+
+object ArbGemsConfig extends ArbGemsConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbGuideConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbGuideConfig.scala
@@ -19,16 +19,14 @@ trait ArbGuideConfig {
     for {
       tg <- arbitrary[TelescopeGuideConfig]
       gc <- arbitrary[Option[Either[AltairConfig, GemsConfig]]]
-      p  <- arbitrary[Boolean]
-    } yield GuideConfig(tg, gc, p)
+    } yield GuideConfig(tg, gc)
   }
 
-  given Cogen[GuideConfig] = 
+  given Cogen[GuideConfig] =
     Cogen[(
-      TelescopeGuideConfig, 
-      Option[Either[AltairConfig, GemsConfig]], 
-      Boolean
-    )].contramap(x => (x.tcsGuide, x.gaosGuide, x.gemsSkyPaused))
+      TelescopeGuideConfig,
+      Option[Either[AltairConfig, GemsConfig]],
+    )].contramap(x => (x.tcsGuide, x.gaosGuide))
 }
 
 object ArbGuideConfig extends ArbGuideConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbGuideConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbGuideConfig.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import lucuma.core.model.AltairConfig
+import lucuma.core.model.GemsConfig
+import lucuma.core.model.GuideConfig
+import lucuma.core.model.TelescopeGuideConfig
+import lucuma.core.model.arb.ArbAltairConfig.given
+import lucuma.core.model.arb.ArbGemsConfig.given
+import lucuma.core.model.arb.ArbTelescopeGuideConfig.given
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+
+trait ArbGuideConfig {
+  given Arbitrary[GuideConfig] = Arbitrary {
+    for {
+      tg <- arbitrary[TelescopeGuideConfig]
+      gc <- arbitrary[Option[Either[AltairConfig, GemsConfig]]]
+      p  <- arbitrary[Boolean]
+    } yield GuideConfig(tg, gc, p)
+  }
+
+  given Cogen[GuideConfig] = 
+    Cogen[(
+      TelescopeGuideConfig, 
+      Option[Either[AltairConfig, GemsConfig]], 
+      Boolean
+    )].contramap(x => (x.tcsGuide, x.gaosGuide, x.gemsSkyPaused))
+}
+
+object ArbGuideConfig extends ArbGuideConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbM1GuideConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbM1GuideConfig.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import lucuma.core.enums.M1Source
+import lucuma.core.model.M1GuideConfig
+import lucuma.core.util.arb.ArbEnumerated.given
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbM1GuideConfig {
+
+  given arbM1GuideOn: Arbitrary[M1GuideConfig.M1GuideOn] =
+    Arbitrary {
+      for {
+        s <- arbitrary[M1Source]
+      } yield M1GuideConfig.M1GuideOn(s)
+    }
+
+  given m1GuideOnCogen: Cogen[M1GuideConfig.M1GuideOn] =
+    Cogen[M1Source].contramap(_.source)
+
+  given arbM1GuideConfig: Arbitrary[M1GuideConfig] =
+    Arbitrary {
+      for {
+        off <- Gen.const(M1GuideConfig.M1GuideOff)
+        on  <- arbitrary[M1GuideConfig.M1GuideOn]
+        l   <- Gen.oneOf(off, on)
+      } yield l
+    }
+
+  given m1GuideConfigCogen: Cogen[M1GuideConfig] =
+    Cogen[Option[M1GuideConfig.M1GuideOn]].contramap {
+      case x: M1GuideConfig.M1GuideOn => Some(x)
+      case _                          => None
+    }
+}
+
+object ArbM1GuideConfig extends ArbM1GuideConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbM2GuideConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbM2GuideConfig.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import lucuma.core.arb.*
+import lucuma.core.enums.ComaOption
+import lucuma.core.enums.TipTiltSource
+import lucuma.core.model.M2GuideConfig
+import lucuma.core.util.arb.ArbEnumerated.given
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbM2GuideConfig {
+
+  given Arbitrary[ComaOption] = newTypeArbitrary(ComaOption)
+
+  given arbM2GuideOn: Arbitrary[M2GuideConfig.M2GuideOn] =
+    Arbitrary {
+      for {
+        c <- arbitrary[ComaOption]
+        s <- arbitrary[List[TipTiltSource]]
+      } yield M2GuideConfig.M2GuideOn(c, s.sortBy(x => s"$x").toSet)
+    }
+
+  given m2GuideOnCogen: Cogen[M2GuideConfig.M2GuideOn] =
+    Cogen[(Boolean, List[TipTiltSource])].contramap(x =>
+      (x.coma.value, x.sources.toList)
+    )
+
+  given arbM2GuideConfig: Arbitrary[M2GuideConfig] =
+    Arbitrary {
+      for {
+        off <- Gen.const(M2GuideConfig.M2GuideOff)
+        on  <- arbitrary[M2GuideConfig.M2GuideOn]
+        l   <- Gen.oneOf(off, on)
+      } yield l
+    }
+
+  given m2GuideConfigCogen: Cogen[M2GuideConfig] =
+    Cogen[Option[M2GuideConfig.M2GuideOn]].contramap {
+      case x: M2GuideConfig.M2GuideOn => Some(x)
+      case _                          => None
+    }
+}
+
+object ArbM2GuideConfig extends ArbM2GuideConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbProbeGuide.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbProbeGuide.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import lucuma.core.enums.*
+import lucuma.core.model.ProbeGuide
+import lucuma.core.util.arb.ArbEnumerated.given
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+
+trait ArbProbeGuide {
+
+  given Arbitrary[ProbeGuide] =
+    Arbitrary {
+      for {
+        f <- arbitrary[GuideProbe]
+        t <- arbitrary[GuideProbe]
+      } yield ProbeGuide(f, t)
+    }
+
+  given Cogen[ProbeGuide] =
+    Cogen[(GuideProbe, GuideProbe)]
+      .contramap(x => (x.from, x.to))
+}
+
+object ArbProbeGuide extends ArbProbeGuide

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTelescopeGuideConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbTelescopeGuideConfig.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import lucuma.core.arb.*
+import lucuma.core.enums.*
+import lucuma.core.model.M1GuideConfig
+import lucuma.core.model.M2GuideConfig
+import lucuma.core.model.ProbeGuide
+import lucuma.core.model.TelescopeGuideConfig
+import lucuma.core.util.arb.ArbEnumerated.*
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+
+import ArbM1GuideConfig.given
+import ArbM2GuideConfig.given
+import ArbProbeGuide.given
+
+trait ArbTelescopeGuideConfig {
+  given Arbitrary[MountGuideOption] = newTypeArbitrary(MountGuideOption)
+
+  given Arbitrary[TelescopeGuideConfig] =
+    Arbitrary {
+      for {
+        mo <- arbitrary[MountGuideOption]
+        m1 <- arbitrary[M1GuideConfig]
+        m2 <- arbitrary[M2GuideConfig]
+        m  <- arbitrary[Boolean]
+        pg <- arbitrary[Option[ProbeGuide]]
+      } yield TelescopeGuideConfig(mo, m1, m2, m, pg)
+    }
+
+  given Cogen[TelescopeGuideConfig] =
+    Cogen[(Boolean, M1GuideConfig, M2GuideConfig, Boolean, Option[ProbeGuide])]
+      .contramap(x => (x.mountGuide.value, x.m1Guide, x.m2Guide, x.dayTimeMode, x.probeGuide))
+}
+
+object ArbTelescopeGuideConfig extends ArbTelescopeGuideConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbStepConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbStepConfig.scala
@@ -61,14 +61,14 @@ trait ArbStepConfig {
     Arbitrary {
       for {
         o <- arbitrary[Offset]
-        g <- arbitrary[GuideState]
+        g <- arbitrary[StepGuideState]
       } yield StepConfig.Science(o, g)
     }
 
   implicit val cogStepConfigScience: Cogen[StepConfig.Science] =
     Cogen[(
       Offset,
-      GuideState
+      StepGuideState
     )].contramap { a => (
       a.offset,
       a.guiding

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/GuideConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/GuideConfigSuite.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.kernel.laws.discipline.EqTests
+import io.circe.testing.CodecTests
+import io.circe.testing.instances.arbitraryJson
+import lucuma.core.enums.GuideProbe
+import lucuma.core.model.GuideConfig.given
+import lucuma.core.model.arb.ArbAltairConfig.given
+import lucuma.core.model.arb.ArbGemsConfig.given
+import lucuma.core.model.arb.ArbGuideConfig.given
+import lucuma.core.model.arb.ArbM1GuideConfig.given
+import lucuma.core.model.arb.ArbM2GuideConfig.given
+import lucuma.core.model.arb.ArbProbeGuide.given
+import lucuma.core.model.arb.ArbTelescopeGuideConfig.given
+import lucuma.core.model.arb.*
+import lucuma.core.util.arb.ArbEnumerated.given
+import munit.*
+
+class GuideConfigSuite extends DisciplineSuite {
+
+  // Laws
+  checkAll("Eq[GuideConifg]", EqTests[GuideConfig].eqv)
+  checkAll("Eq[M1GuideConifg]", EqTests[M1GuideConfig].eqv)
+  checkAll("Eq[M2GuideConifg]", EqTests[M2GuideConfig].eqv)
+  checkAll("Eq[GemsConfig]", EqTests[GemsConfig].eqv)
+  checkAll("Eq[AltairConfig]", EqTests[AltairConfig].eqv)
+  checkAll("Eq[TelescopeGuideConfig]", EqTests[TelescopeGuideConfig].eqv)
+  checkAll("Eq[ProbeGuide]", EqTests[ProbeGuide].eqv)
+  checkAll("M1GuideConfig JSON Codec", CodecTests[M1GuideConfig].codec)
+  checkAll("M2GuideConfig JSON Codec", CodecTests[M2GuideConfig].codec)
+  checkAll("GemsConfig JSON Codec", CodecTests[GemsConfig].codec)
+  checkAll("AltairConfig JSON Codec", CodecTests[AltairConfig].codec)
+  checkAll("GuideProbe JSON Codec", CodecTests[GuideProbe].unserializableCodec)
+  checkAll("ProbeGuide JSON Codec", CodecTests[ProbeGuide].unserializableCodec)
+  checkAll("TelescopeConfig JSON Codec", CodecTests[TelescopeGuideConfig].unserializableCodec)
+
+}


### PR DESCRIPTION
We want navigate and observe to communicate with each other., sharing the state of telescope guiding

At the moment they have different models to do so but we can unify them and move them here to `lucuma-core`