### PR TITLE
Make Step covariant on DynamicConfig

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/Step.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/Step.scala
@@ -18,7 +18,7 @@ import monocle.Lens
  *
  * @tparam D dynamic config type (e.g., DynamicConfig.GmosNorth)
  */
-case class Step[D](
+case class Step[+D](
   id:                Step.Id,
   instrumentConfig:  D,
   stepConfig:        StepConfig,


### PR DESCRIPTION
This makes, for example, a `Step[gmos.DynamicConfig.GmosNorth]` a subtype of `Step[gmos.DynamicConfig]`. Comes handy in the UI.