### PR TITLE
Claim 'c' for Call for Proposals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.95"
+ThisBuild / tlBaseVersion                         := "0.96"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ids.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ids.scala
@@ -6,9 +6,9 @@ package lucuma.core.model
 import lucuma.core.util.WithGid
 import lucuma.refined.*
 
-object Configuration  extends WithGid('c'.refined)
-object Group          extends WithGid('g'.refined)
-object ObsAttachment  extends WithGid('a'.refined)
-object Observation    extends WithGid('o'.refined)
-object Program        extends WithGid('p'.refined)
-object Visit          extends WithGid('v'.refined)
+object CallForProposals extends WithGid('c'.refined)
+object Group            extends WithGid('g'.refined)
+object ObsAttachment    extends WithGid('a'.refined)
+object Observation      extends WithGid('o'.refined)
+object Program          extends WithGid('p'.refined)
+object Visit            extends WithGid('v'.refined)

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/IdsSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/IdsSuite.scala
@@ -12,14 +12,14 @@ import munit.DisciplineSuite
 final class IdsSuite extends DisciplineSuite {
   import ArbGid.given
 
-  checkAll("Gid[Configuration.Id]", GidTests[Configuration.Id].gid)
+  checkAll("Gid[CallForProposals.Id]", GidTests[CallForProposals.Id].gid)
   checkAll("Gid[Dataset.Id]", GidTests[Dataset.Id].gid)
   checkAll("Gid[ExecutionEvent.Id]", GidTests[ExecutionEvent.Id].gid)
   checkAll("Gid[Observation.Id]", GidTests[Observation.Id].gid)
   checkAll("Gid[Program.Id]", GidTests[Program.Id].gid)
   checkAll("Gid[Visit.Id]", GidTests[Visit.Id].gid)
 
-  checkAll("KeyCodec[Configuration.Id]", KeyCodecTests[Configuration.Id].keyCodec)
+  checkAll("KeyCodec[CallForProposals.Id]", KeyCodecTests[CallForProposals.Id].keyCodec)
   checkAll("KeyCodec[Dataset.Id]", KeyCodecTests[Dataset.Id].keyCodec)
   checkAll("KeyCodec[ExecutionEvent.Id]", KeyCodecTests[ExecutionEvent.Id].keyCodec)
   checkAll("KeyCodec[Observation.Id]", KeyCodecTests[Observation.Id].keyCodec)


### PR DESCRIPTION
We define GID type `c` for `Configuration` but configurations are no-longer top-level objects and this GID type was never used.  I'd like to repurpose it for Call for Proposals objects.