### PR TITLE
ShortCut 2772

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ImageQuality.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ImageQuality.scala
@@ -21,7 +21,7 @@ sealed abstract class ImageQuality(val tag: String, val toDeciArcSeconds: Quanti
   def label: String        = f"""< ${toArcSeconds.value.toDouble}%.1f\""""
 
   def toAngle: Angle =
-    Angle.fromMicroarcseconds(toDeciArcSeconds.tToUnit[MicroArcSecond].value.value.toLong)
+    Angle.fromMicroarcseconds(toDeciArcSeconds.value.value * 100_000L)
 }
 
 object ImageQuality {

--- a/modules/tests/shared/src/test/scala/lucuma/core/enums/ImageQualitySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enums/ImageQualitySuite.scala
@@ -4,20 +4,31 @@
 package lucuma.core.enums
 
 import eu.timepit.refined.types.numeric.PosInt
-import lucuma.core.math.units.{*, given}
+import lucuma.core.math.Angle
 import lucuma.core.util.arb.ArbEnumerated
 import munit.DisciplineSuite
 import org.scalacheck.Prop.*
+
+import java.math.RoundingMode
 
 final class ImageQualitySuite extends DisciplineSuite {
 
   import ArbEnumerated.given
 
+  test("toArcSeconds") {
+    forAll { (a: ImageQuality) =>
+      assertEquals(
+        a.toArcSeconds.value.toBigDecimal(6, RoundingMode.HALF_UP),
+        Angle.signedDecimalArcseconds.get(a.toAngle)
+      )
+    }
+  }
+
   test("toAngle") {
     forAll { (a: ImageQuality) =>
       assertEquals(
         a.toAngle.toMicroarcseconds,
-        a.toDeciArcSeconds.tToUnit[MicroArcSecond].value.value.toLong
+        a.toDeciArcSeconds.value.value * 100_000L
       )
     }
   }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
@@ -87,7 +87,7 @@ final class BinningSuite extends FunSuite {
   test("shortcut-2772") {
     testLongslit(
       GmosNorthFpu.LongSlit_1_00,
-      SourceProfile.Uniform(bandNormalized),
+      SourceProfile.Point(bandNormalized),
       ImageQuality.OnePointZero,
       GmosNorthGrating.R831_G5302,
       GmosXBinning.Two,

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
@@ -82,4 +82,16 @@ final class BinningSuite extends FunSuite {
     )
   }
 
+  // Testing explore-dev using GMOS-N with the R831 grating with a 1" slit and IQ=1.0" should yield binning = 2 x 4,
+  // however, the sequence displays 1 x 1.
+  test("shortcut-2772") {
+    testLongslit(
+      GmosNorthFpu.LongSlit_1_00,
+      SourceProfile.Uniform(bandNormalized),
+      ImageQuality.OnePointZero,
+      GmosNorthGrating.R831_G5302,
+      GmosXBinning.Two,
+      GmosYBinning.Four
+    )
+  }
 }


### PR DESCRIPTION
Fixes the `ImageQuality.toAngle` calculation, which corrects ShortCut 2772.