### PR TITLE
Fix UserInvitation.token

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/UserInvitation.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/UserInvitation.scala
@@ -49,7 +49,7 @@ object UserInvitation {
   type Id = Id.Type
 
   extension(invitation: UserInvitation)
-    def token: String = s"${invitation.id}.${invitation.body}"
+    def token: String = fromString.reverseGet(invitation)
 
   private val R: Regex =
     raw"^([0-9a-f]{3,})\.([0-9a-f]{96})$$".r


### PR DESCRIPTION
I somehow managed to overlook the fact that `fromString` is a Prism and implemented `tag`, albeit incorrectly. 😦 

I `would` just remove `token` and use `fromString.reverseGet` directly in the ODB, but that would break bincompat and I'd have to spend the day upgrading the world...