### PR TITLE
Atom Events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.96"
+ThisBuild / tlBaseVersion                         := "0.97"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/AtomStage.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/AtomStage.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum AtomStage(val tag: String, val name: String, val description: String) derives Enumerated {
+
+  case EndAtom   extends AtomStage("end_atom",   "End Atom",   "Atom complete.")
+  case StartAtom extends AtomStage("start_atom", "Start Atom", "Atom started.")
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ExecutionEvent.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ExecutionEvent.scala
@@ -37,11 +37,11 @@ sealed trait ExecutionEvent derives Eq {
     datasetEvent:  DatasetEvent  => A
   ): A =
     this match {
-      case e@SlewEvent(_, _, _, _, _)          => slewEvent(e)
-      case e@SequenceEvent(_, _, _, _, _)      => sequenceEvent(e)
-      case e@AtomEvent(_, _, _, _, _, _)       => atomEvent(e)
-      case e@StepEvent(_, _, _, _, _, _)       => stepEvent(e)
-      case e@DatasetEvent(_, _, _, _, _, _, _) => datasetEvent(e)
+      case e@SlewEvent(_, _, _, _, _)             => slewEvent(e)
+      case e@SequenceEvent(_, _, _, _, _)         => sequenceEvent(e)
+      case e@AtomEvent(_, _, _, _, _, _)          => atomEvent(e)
+      case e@StepEvent(_, _, _, _, _, _, _)       => stepEvent(e)
+      case e@DatasetEvent(_, _, _, _, _, _, _, _) => datasetEvent(e)
     }
 
 }
@@ -78,6 +78,7 @@ object ExecutionEvent extends WithGid('e'.refined) {
     received:      Timestamp,
     observationId: Observation.Id,
     visitId:       Visit.Id,
+    atomId:        Atom.Id,
     stepId:        Step.Id,
     stage:         StepStage
   ) extends ExecutionEvent derives Eq
@@ -87,6 +88,7 @@ object ExecutionEvent extends WithGid('e'.refined) {
     received:      Timestamp,
     observationId: Observation.Id,
     visitId:       Visit.Id,
+    atomId:        Atom.Id,
     stepId:        Step.Id,
     datasetId:     Dataset.Id,
     stage:         DatasetStage

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Timestamp.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Timestamp.scala
@@ -137,6 +137,17 @@ object Timestamp {
 
     def plusSecondsOption(secondsToAdd: Long): Option[Timestamp] =
       fromInstant(timestamp.plusSeconds(secondsToAdd))
+
+    /**
+     * The timestamp interval between this timestamp and the given
+     * `endExclusive` timestamp.  If `endExclusive` comes before this
+     * timestamp, an empty interval at this timestamp is returned.
+     *
+     * @param endExclusive the end time of the TimestampInterval
+     */
+    def intervalUntil(endExclusive: Timestamp): TimestampInterval =
+      if (endExclusive <= timestamp) TimestampInterval.between(timestamp, timestamp)
+      else TimestampInterval.between(timestamp, endExclusive)
   }
 
   val FromString: Format[String, Timestamp] =

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExecutionEvent.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExecutionEvent.scala
@@ -34,10 +34,11 @@ trait ArbExecutionEvent {
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
+        aid <- arbitrary[Atom.Id]
         sid <- arbitrary[Step.Id]
         did <- arbitrary[Dataset.Id]
         stg <- arbitrary[DatasetStage]
-      } yield ExecutionEvent.DatasetEvent(eid, rec, oid, vid, sid, did, stg)
+      } yield ExecutionEvent.DatasetEvent(eid, rec, oid, vid, aid, sid, did, stg)
     }
 
   given Cogen[ExecutionEvent.DatasetEvent] =
@@ -46,6 +47,7 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
+      Atom.Id,
       Step.Id,
       Dataset.Id,
       DatasetStage
@@ -54,6 +56,7 @@ trait ArbExecutionEvent {
       a.received,
       a.observationId,
       a.visitId,
+      a.atomId,
       a.stepId,
       a.datasetId,
       a.stage
@@ -147,9 +150,10 @@ trait ArbExecutionEvent {
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
+        aid <- arbitrary[Atom.Id]
         sid <- arbitrary[Step.Id]
         stg <- arbitrary[StepStage]
-      } yield ExecutionEvent.StepEvent(eid, rec, oid, vid, sid, stg)
+      } yield ExecutionEvent.StepEvent(eid, rec, oid, vid, aid, sid, stg)
     }
 
   given Cogen[ExecutionEvent.StepEvent] =
@@ -158,6 +162,7 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
+      Atom.Id,
       Step.Id,
       StepStage
     )].contramap { a => (
@@ -165,6 +170,7 @@ trait ArbExecutionEvent {
       a.received,
       a.observationId,
       a.visitId,
+      a.atomId,
       a.stepId,
       a.stage
     )}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/ExecutionEventSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/ExecutionEventSuite.scala
@@ -12,6 +12,7 @@ class ExecutionEventSuite extends DisciplineSuite {
   import ArbExecutionEvent.given
 
   checkAll("Eq[ExecutionEvent]", EqTests[ExecutionEvent].eqv)
+  checkAll("ExecutionEvent.atomEvent", PrismTests(ExecutionEvent.atomEvent))
   checkAll("ExecutionEvent.datasetEvent", PrismTests(ExecutionEvent.datasetEvent))
   checkAll("ExecutionEvent.sequenceEvent", PrismTests(ExecutionEvent.sequenceEvent))
   checkAll("ExecutionEvent.slewEvent", PrismTests(ExecutionEvent.slewEvent))

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampSuite.scala
@@ -6,6 +6,7 @@ package lucuma.core.util
 import cats.kernel.laws.discipline.*
 import cats.syntax.either.*
 import cats.syntax.option.*
+import cats.syntax.order.*
 import lucuma.core.arb.ArbTime.given
 import lucuma.core.optics.laws.discipline.*
 import lucuma.core.util.arb.ArbTimestamp
@@ -89,4 +90,10 @@ class TimestampSuite extends DisciplineSuite {
     }
   }
 
+  property("intervalUntil") {
+    forAll { (t0: Timestamp, t1: Timestamp) =>
+      val ti = t0.intervalUntil(t1)
+      assert(t0 < t1 == ti.nonEmpty)
+    }
+  }
 }


### PR DESCRIPTION
This PR prepares the way for adding atom events to the API.  Atom events will allow Explore to display the sequence in a more intuitive way.  It only occurred to me to add start / end since it doesn't seem like abort, etc. work at the atom level?