### PR TITLE
Add TimeAccountingCategory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.100"
+ThisBuild / tlBaseVersion                         := "0.101"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/Partner.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/Partner.scala
@@ -9,18 +9,19 @@ enum Partner(
   val tag: String,
   val shortName: String,
   val longName: String,
-  val sites: Set[Site]
+  val sites: Set[Site],
+  val timeAccountingCategory: TimeAccountingCategory
 ) derives Enumerated {
 
   def abbreviation: String =
     tag.toUpperCase
 
-  case AR extends Partner("ar", "Argentina", "Argentina",            Site.all.toSet)
-  case BR extends Partner("br", "Brazil",    "Brazil",               Site.all.toSet)
-  case CA extends Partner("ca", "Canada",    "Canada",               Site.all.toSet)
-  case CL extends Partner("cl", "Chile",     "Chile",                Set(Site.GS))
-  case KR extends Partner("kr", "Korea",     "Republic of Korea",    Site.all.toSet)
-  case UH extends Partner("uh", "U of H",    "University of Hawaii", Set(Site.GN))
-  case US extends Partner("us", "USA",       "United States",        Site.all.toSet)
+  case AR extends Partner("ar", "Argentina", "Argentina",            Site.all.toSet, TimeAccountingCategory.AR)
+  case BR extends Partner("br", "Brazil",    "Brazil",               Site.all.toSet, TimeAccountingCategory.BR)
+  case CA extends Partner("ca", "Canada",    "Canada",               Site.all.toSet, TimeAccountingCategory.CA)
+  case CL extends Partner("cl", "Chile",     "Chile",                Set(Site.GS),   TimeAccountingCategory.CL)
+  case KR extends Partner("kr", "Korea",     "Republic of Korea",    Site.all.toSet, TimeAccountingCategory.KR)
+  case UH extends Partner("uh", "U of H",    "University of Hawaii", Set(Site.GN),   TimeAccountingCategory.UH)
+  case US extends Partner("us", "USA",       "United States",        Site.all.toSet, TimeAccountingCategory.US)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/TimeAccountingCategory.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/TimeAccountingCategory.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+/**
+ * Time accounting categories.  Time is allocated and time is charged to one or
+ * more of these categories.  Each Gemini partner has its own time accounting
+ * category which is used for queue, classical and fast turnaround proposals.
+ * Other proposal types have their own distinct categories.
+  */
+enum TimeAccountingCategory(
+  val tag: String,
+  val description: String
+) derives Enumerated:
+
+  def abbreviation: String = tag.toUpperCase
+
+  case AR   extends TimeAccountingCategory("ar",   "Argentina")
+  case BR   extends TimeAccountingCategory("br",   "Brazil")
+  case CA   extends TimeAccountingCategory("ca",   "Canada")
+  case CFHT extends TimeAccountingCategory("cfht", "CFHT Exchange")
+  case CL   extends TimeAccountingCategory("cl",   "Chile")
+  case DD   extends TimeAccountingCategory("dd",   "Director's Time")
+  case DS   extends TimeAccountingCategory("ds",   "Demo Science")
+  case GT   extends TimeAccountingCategory("gt",   "Guaranteed Time")
+  case JP   extends TimeAccountingCategory("jp",   "Subaru")
+  case KECK extends TimeAccountingCategory("keck", "Keck Exchange")
+  case KR   extends TimeAccountingCategory("kr",   "Republic of Korea")
+  case LP   extends TimeAccountingCategory("lp",   "Large Program")
+  case LTP  extends TimeAccountingCategory("ltp",  "Limited-term Participant")
+  case SV   extends TimeAccountingCategory("sv",   "System Verification")
+  case UH   extends TimeAccountingCategory("uh",   "University of Hawaii")
+  case US   extends TimeAccountingCategory("us",   "United States")
+
+end TimeAccountingCategory


### PR DESCRIPTION
Adds time accounting categories from the [ODB](https://github.com/gemini-hlsw/lucuma-odb/pull/1325), which will be updated to use this version.  See [ShortCut 3119](https://app.shortcut.com/lucuma/story/3119/time-accounting-categories).