### PR TITLE
split support roles

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.104"
+ThisBuild / tlBaseVersion                         := "0.105"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ProgramUserRole.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ProgramUserRole.scala
@@ -10,6 +10,7 @@ enum ProgramUserRole(val tag: String) derives Enumerated:
   case Pi      extends ProgramUserRole("pi")
   case Coi     extends ProgramUserRole("coi")
   case CoiRO   extends ProgramUserRole("coi_ro")
-  case Support extends ProgramUserRole("support")
+  case SupportPrimary extends ProgramUserRole("support_primary")
+  case SupportSecondary extends ProgramUserRole("support_secondary")
 
 end ProgramUserRole

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.10.2


### PR DESCRIPTION
From `ProgramUserRole` this removes `Support` and replaces it with `SupportPrimary` and `SupportSecondary`. This will break client applications until the ODB is updated.