### PR TITLE
Added BoundedTime, Timestamp + TimeSpan

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/BandedTime.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/BandedTime.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.Order
+import cats.derived.*
+import lucuma.core.enums.ScienceBand
+
+/**
+ * Pairs an optional science band with a categorized time.  Because programs
+ * may have observations in distinct bands, at the top-level we must group by
+ * band.
+ */
+case class BandedTime(
+  band: Option[ScienceBand],
+  time: CategorizedTime
+) derives Order
+
+object BandedTime:
+  val Empty: BandedTime = BandedTime(None, CategorizedTime.Zero)

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Timestamp.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Timestamp.scala
@@ -21,6 +21,7 @@ import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoField
 import java.time.temporal.ChronoUnit.MICROS
 import java.util.Locale
+import scala.annotation.targetName
 
 /**
  * Timestamp is an Instant truncated and limited to fit in a database
@@ -137,6 +138,22 @@ object Timestamp {
 
     def plusSecondsOption(secondsToAdd: Long): Option[Timestamp] =
       fromInstant(timestamp.plusSeconds(secondsToAdd))
+
+    /**
+     * Adds the given amount of time to the Timestamp, producing a new
+     * Timestamp that far in the future.  The value is capped at Timestamp.Max.
+     */
+    @targetName("boundedAdd")
+    def +|(time: TimeSpan): Timestamp =
+      plusMicrosOption(time.toMicroseconds).getOrElse(Timestamp.Max)
+
+    /**
+     * Subtracts the given amount of time from the Timestamp, producing a new
+     * Timestamp that far in the past.  The value is limited at Timestamp.Min.
+     */
+    @targetName("boundedSubtract")
+    def -|(time: TimeSpan): Timestamp =
+      plusMicrosOption(- time.toMicroseconds).getOrElse(Timestamp.Min)
 
     /**
      * The timestamp interval between this timestamp and the given

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbBandedTime.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbBandedTime.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+package arb
+
+import lucuma.core.enums.ScienceBand
+import lucuma.core.util.arb.ArbEnumerated
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+
+trait ArbBandedTime:
+  import ArbCategorizedTime.given
+  import ArbEnumerated.given
+
+  given Arbitrary[BandedTime] =
+    Arbitrary {
+      arbitrary[(Option[ScienceBand], CategorizedTime)].map(BandedTime.apply)
+    }
+
+  given Cogen[BandedTime] =
+    Cogen[(Option[ScienceBand], CategorizedTime)].contramap(b => (b.band, b.time))
+
+object ArbBandedTime extends ArbBandedTime

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/BandedTimeSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/BandedTimeSuite.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.kernel.laws.discipline.*
+import lucuma.core.model.sequence.arb.ArbBandedTime
+import munit.DisciplineSuite
+
+final class BandedTimeSuite extends DisciplineSuite:
+
+  import ArbBandedTime.given
+
+  checkAll("Order[BandedTime]", OrderTests[BandedTime].order)

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampSuite.scala
@@ -9,6 +9,7 @@ import cats.syntax.option.*
 import cats.syntax.order.*
 import lucuma.core.arb.ArbTime.given
 import lucuma.core.optics.laws.discipline.*
+import lucuma.core.util.arb.ArbTimeSpan.given
 import lucuma.core.util.arb.ArbTimestamp
 import lucuma.core.util.arb.ArbTimestamp.given
 import monocle.law.discipline.PrismTests
@@ -95,5 +96,15 @@ class TimestampSuite extends DisciplineSuite {
       val ti = t0.intervalUntil(t1)
       assert(t0 < t1 == ti.nonEmpty)
     }
+  }
+
+  property("boundedAdd") {
+    forAll: (t: Timestamp, ts: TimeSpan) =>
+      assertEquals(t +| ts, t.plusMicrosOption(ts.toMicroseconds).getOrElse(Timestamp.Max))
+  }
+
+  property("boundedSubtract") {
+    forAll: (t: Timestamp, ts: TimeSpan) =>
+      assertEquals(t -| ts, t.plusMicrosOption(- ts.toMicroseconds).getOrElse(Timestamp.Min))
   }
 }


### PR DESCRIPTION
A couple of unrelated updates to core:

* Adds `BoundedTime` which is needed for per-band time accounting at the program level.
* Adds convenience for increasing or decreasing a `Timestamp` by an amount of time in a `TimeSpan`.  This will simplify somewhat the new sequence generation code in the ODB.