### PR TITLE
Move the configuration request types from the ODB for use in explore.

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ConfigurationRequestStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ConfigurationRequestStatus.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+
+enum ConfigurationRequestStatus(val tag: String) derives Enumerated:
+  case Requested extends ConfigurationRequestStatus("Requested")
+  case Approved  extends ConfigurationRequestStatus("Approved")
+  case Denied    extends ConfigurationRequestStatus("Denied")
+  case Withdrawn extends ConfigurationRequestStatus("Withdrawn")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObservingModeType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObservingModeType.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum ObservingModeType(val dbTag: String, val instrument: Instrument):
+  case GmosNorthLongSlit extends ObservingModeType("gmos_north_long_slit", Instrument.GmosNorth)
+  case GmosSouthLongSlit extends ObservingModeType("gmos_south_long_slit", Instrument.GmosSouth)
+
+object ObservingModeType:
+
+  given Enumerated[ObservingModeType] =
+    Enumerated.from(
+      GmosNorthLongSlit,
+      GmosSouthLongSlit
+    ).withTag(_.dbTag)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.kernel.Order
+import cats.syntax.all.*
+import lucuma.core.enums.CloudExtinction
+import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosSouthGrating
+import lucuma.core.enums.ImageQuality
+import lucuma.core.enums.ObservingModeType
+import lucuma.core.enums.SkyBackground
+import lucuma.core.enums.WaterVapor
+import lucuma.core.math.Angle
+import lucuma.core.math.Coordinates
+import lucuma.core.model.Configuration.ObservingMode.GmosNorthLongSlit
+import lucuma.core.model.Configuration.ObservingMode.GmosSouthLongSlit
+
+case class Configuration(conditions: Configuration.Conditions, refererenceCoordinates: Coordinates, observingMode: Configuration.ObservingMode):
+  def subsumes(other: Configuration): Boolean =
+    conditions >= other.conditions &&
+    observingMode.fov.toDoubleDegrees / 2.0 >= refererenceCoordinates.angularDistance(other.refererenceCoordinates).toDoubleDegrees &&
+    observingMode === other.observingMode
+
+object Configuration:
+
+  case class Conditions(
+    cloudExtinction: CloudExtinction,
+    imageQuality: ImageQuality,
+    skyBackground: SkyBackground,
+    waterVapor: WaterVapor,
+  )
+
+  object Conditions:
+
+    given Order[Conditions] = 
+      Order.reverse: // larger means better here
+        Order.by: conds =>
+          (conds.cloudExtinction, conds.imageQuality, conds.skyBackground, conds.waterVapor)
+
+  // For now we define field of view as a disc of some angular radius on the sky.
+  sealed abstract class ObservingMode(val tpe: ObservingModeType, val fov: Angle):
+    def gmosNorthLongSlit: Option[GmosNorthLongSlit] = Some(this).collect { case m: GmosNorthLongSlit => m }
+    def gmosSouthLongSlit: Option[GmosSouthLongSlit] = Some(this).collect { case m: GmosSouthLongSlit => m }
+
+  object ObservingMode:
+
+    // TODO: right now we're allowing sufficient slop to allow adjusting the target along [half] the length of the slit, but
+    // this also allows moving to a target that's off the slit entirely since we're just measuring a single offset distance.
+    // What we really need here is a polygon, but that's complicated by position angle (which may be allowed to flip or may
+    // be chosen dynamically based on parallactic angle). 
+    case class GmosNorthLongSlit(grating: GmosNorthGrating) extends ObservingMode(lucuma.core.enums.ObservingModeType.GmosNorthLongSlit, Angle.fromDoubleArcseconds(5.5 * 60)) // slit length of 5.5’
+    case class GmosSouthLongSlit(grating: GmosSouthGrating) extends ObservingMode(lucuma.core.enums.ObservingModeType.GmosSouthLongSlit, Angle.fromDoubleArcseconds(5.5 * 60)) // slit length of 5.5’
+
+    given Eq[ObservingMode] =
+      Eq.instance:
+        case (GmosNorthLongSlit(g1), GmosNorthLongSlit(g2)) => g1 === g2
+        case (GmosSouthLongSlit(g1), GmosSouthLongSlit(g2)) => g1 === g2
+        case _ => false

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ConfigurationRequest.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ConfigurationRequest.scala
@@ -3,20 +3,14 @@
 
 package lucuma.core.model
 
-import lucuma.core.util.Enumerated
+import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.util.WithGid
 import lucuma.refined.*
 
 case class ConfigurationRequest(
   id: ConfigurationRequest.Id,
-  status: ConfigurationRequest.Status,
+  status: ConfigurationRequestStatus,
   configuration: Configuration
 )
 
-object ConfigurationRequest extends WithGid('x'.refined) {
-  enum Status(val tag: String) derives Enumerated:
-    case Requested extends Status("Requested")
-    case Approved  extends Status("Approved")
-    case Denied    extends Status("Denied")
-    case Withdrawn extends Status("Withdrawn")
-}
+object ConfigurationRequest extends WithGid('x'.refined)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ConfigurationRequest.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ConfigurationRequest.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import lucuma.core.util.Enumerated
+import lucuma.core.util.WithGid
+import lucuma.refined.*
+
+case class ConfigurationRequest(
+  id: ConfigurationRequest.Id,
+  status: ConfigurationRequest.Status,
+  configuration: Configuration
+)
+
+object ConfigurationRequest extends WithGid('x'.refined) {
+  enum Status(val tag: String) derives Enumerated:
+    case Requested extends Status("Requested")
+    case Approved  extends Status("Approved")
+    case Denied    extends Status("Denied")
+    case Withdrawn extends Status("Withdrawn")
+}


### PR DESCRIPTION
ObservingModeType is used in Configuration, so it needed to be moved as well.

I will update lucuma-odb for these changes once this is released.