### PR TITLE
Change ConfigurationRequestStatus.tag to lowercase to match DB

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ConfigurationRequestStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ConfigurationRequestStatus.scala
@@ -7,7 +7,7 @@ import lucuma.core.util.Enumerated
 
 
 enum ConfigurationRequestStatus(val tag: String) derives Enumerated:
-  case Requested extends ConfigurationRequestStatus("Requested")
-  case Approved  extends ConfigurationRequestStatus("Approved")
-  case Denied    extends ConfigurationRequestStatus("Denied")
-  case Withdrawn extends ConfigurationRequestStatus("Withdrawn")
+  case Requested extends ConfigurationRequestStatus("requested")
+  case Approved  extends ConfigurationRequestStatus("approved")
+  case Denied    extends ConfigurationRequestStatus("denied")
+  case Withdrawn extends ConfigurationRequestStatus("withdrawn")


### PR DESCRIPTION
Because we have lots of enums of various case schemes, or some reason I thought the Codecs handled the switch to all lowercase for the DB. It turns out I was wrong. The `tag` has to match the DB enum exactly.

Against all odds, this does not seem to break bincompat. 😌 