### PR TITLE
move workflow classes into core

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationWorkflowState.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationWorkflowState.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum ObservationWorkflowState(val tag: String) derives Enumerated:
+  case Inactive   extends ObservationWorkflowState("inactive")
+  case Undefined  extends ObservationWorkflowState("undefined")
+  case Unapproved extends ObservationWorkflowState("unapproved")
+  case Defined    extends ObservationWorkflowState("defined")
+  case Ready      extends ObservationWorkflowState("ready")
+  case Ongoing    extends ObservationWorkflowState("ongoing")
+  case Completed  extends ObservationWorkflowState("completed")
+
+
+

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ObservationWorkflow.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ObservationWorkflow.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.derived.*
+import io.circe.Codec
+import lucuma.core.enums.ObservationWorkflowState
+
+final case class ObservationWorkflow(
+  state: ObservationWorkflowState,
+  validTransitions: List[ObservationWorkflowState],
+  validationErrors: List[ObservationValidation]
+) derives Codec, Eq
+


### PR DESCRIPTION
This moves `ObservationWorkflowState` and `ObservationWorkflow` (currently part of https://github.com/gemini-hlsw/lucuma-odb/pull/1455) into core.