### PR TITLE
Change names of configuration request observation validations

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationValidationCode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationValidationCode.scala
@@ -16,25 +16,25 @@ enum ObservationValidationCode(
   case ConfigurationRequestUnavailable 
     extends ObservationValidationCode(
       "config_request_unavailable", 
-      "Configuration Request Unavailable", 
+      "Unknown Approval Status", 
       ObservationValidationCode.ConfigurationRequestMsg.Unavailable
     )
   case ConfigurationRequestNotRequested
     extends ObservationValidationCode(
       "config_request_not_requested", 
-      "Configuration Request Not Requested", 
-      ObservationValidationCode.ConfigurationRequestMsg.Unavailable
+      "Needs Approval", 
+      ObservationValidationCode.ConfigurationRequestMsg.NotRequested
     )
   case ConfigurationRequestDenied
     extends ObservationValidationCode(
       "config_request_denied", 
-      "Configuration Request Denied", 
+      "Denied", 
       ObservationValidationCode.ConfigurationRequestMsg.Denied
     )
   case ConfigurationRequestPending
     extends ObservationValidationCode(
       "config_request_pending", 
-      "Configuration Request Pending", 
+      "Approval Pending", 
       ObservationValidationCode.ConfigurationRequestMsg.Pending
     )
 


### PR DESCRIPTION
When I created these codes, I forgot how they were used in the UI and I chose names poorly... 
Also fixes a copy/paste error with a description.