### PR TITLE
Offset for Every Step

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.106"
+ThisBuild / tlBaseVersion                         := "0.107"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/Step.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/Step.scala
@@ -7,6 +7,8 @@ import cats.Eq
 import cats.syntax.all.*
 import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.ObserveClass
+import lucuma.core.enums.StepGuideState
+import lucuma.core.math.Offset
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.WithUid
 import lucuma.refined.*
@@ -22,17 +24,15 @@ case class Step[+D](
   id:                Step.Id,
   instrumentConfig:  D,
   stepConfig:        StepConfig,
+  telescopeConfig:   TelescopeConfig,
   estimate:          StepEstimate,
   observeClass:      ObserveClass = ObserveClass.Science,
   breakpoint:        Breakpoint = Breakpoint.Disabled,
-) {
-
+):
   lazy val timeEstimate: CategorizedTime =
     CategorizedTime(observeClass.chargeClass -> estimate.total)
 
-}
-
-object Step extends WithUid('s'.refined) {
+object Step extends WithUid('s'.refined):
 
   /** @group Optics */
   def id[D]: Lens[Step[D], Step.Id] =
@@ -45,6 +45,18 @@ object Step extends WithUid('s'.refined) {
   /** @group Optics */
   def stepConfig[D]: Lens[Step[D], StepConfig] =
     Focus[Step[D]](_.stepConfig)
+
+  /** @group Optics */
+  def telescopeConfig[D]: Lens[Step[D], TelescopeConfig] =
+    Focus[Step[D]](_.telescopeConfig)
+
+  /** @group Optics */
+  def offset[D]: Lens[Step[D], Offset] =
+    telescopeConfig.andThen(TelescopeConfig.offset)
+
+  /** @group Optics */
+  def guiding[D]: Lens[Step[D], StepGuideState] =
+    telescopeConfig.andThen(TelescopeConfig.guiding)
 
   /** @group Optics */
   def estimate[D]: Lens[Step[D], StepEstimate] =
@@ -63,9 +75,8 @@ object Step extends WithUid('s'.refined) {
       x.id,
       x.instrumentConfig,
       x.stepConfig,
+      x.telescopeConfig,
       x.estimate,
       x.observeClass,
       x.breakpoint
     )}
-
-}

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/StepConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/StepConfig.scala
@@ -9,6 +9,7 @@ import cats.data.NonEmptySet
 import cats.derived.*
 import cats.syntax.all.*
 import lucuma.core.enums.*
+import lucuma.core.math.Offset
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
@@ -157,5 +158,21 @@ object StepConfig:
   val science: Prism[StepConfig, Science] =
     GenPrism[StepConfig, Science]
 
+  /** @group Optics */
   val smartGcal: Prism[StepConfig, SmartGcal] =
     GenPrism[StepConfig, SmartGcal]
+
+  /** @group Optics */
+  val telescope: Optional[StepConfig, TelescopeConfig] =
+    gcal
+      .andThen(Gcal.telescope)
+      .orElse(science.andThen(Science.telescope))
+      .orElse(smartGcal.andThen(SmartGcal.telescope))
+
+  /** @group Optics */
+  val offset: Optional[StepConfig, Offset] =
+    telescope.andThen(TelescopeConfig.offset)
+
+  /** @group Optics */
+  val guiding: Optional[StepConfig, StepGuideState] =
+    telescope.andThen(TelescopeConfig.guiding)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/TelescopeConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/TelescopeConfig.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+
+import cats.Order
+import cats.derived.*
+import lucuma.core.enums.StepGuideState
+import lucuma.core.math.Offset
+import monocle.Focus
+import monocle.Lens
+
+case class TelescopeConfig(
+  offset:  Offset,
+  guiding: StepGuideState
+) derives Order
+
+object TelescopeConfig:
+
+  /** @group Optics */
+  val offset: Lens[TelescopeConfig, Offset] =
+    Focus[TelescopeConfig](_.offset)
+
+  /** @group Optics */
+  val guiding: Lens[TelescopeConfig, StepGuideState] =
+    Focus[TelescopeConfig](_.guiding)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/TelescopeConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/TelescopeConfig.scala
@@ -17,6 +17,9 @@ case class TelescopeConfig(
 
 object TelescopeConfig:
 
+  val Default: TelescopeConfig =
+    TelescopeConfig(Offset.Zero, StepGuideState.Enabled)
+
   /** @group Optics */
   val offset: Lens[TelescopeConfig, Offset] =
     Focus[TelescopeConfig](_.offset)

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbStep.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbStep.scala
@@ -16,6 +16,7 @@ trait ArbStep {
   import ArbEnumerated.given
   import ArbStepEstimate.given
   import ArbStepConfig.given
+  import ArbTelescopeConfig.given
   import ArbUid.given
 
   given [D: Arbitrary]: Arbitrary[Step[D]] =
@@ -24,10 +25,11 @@ trait ArbStep {
         i <- arbitrary[Step.Id]
         d <- arbitrary[D]
         c <- arbitrary[StepConfig]
+        t <- arbitrary[TelescopeConfig]
         e <- arbitrary[StepEstimate]
         o <- arbitrary[ObserveClass]
         b <- arbitrary[Breakpoint]
-      } yield Step(i, d, c, e, o, b)
+      } yield Step(i, d, c, t, e, o, b)
     }
 
   given [D: Cogen]: Cogen[Step[D]] =
@@ -35,12 +37,14 @@ trait ArbStep {
       Step.Id,
       D,
       StepConfig,
+      TelescopeConfig,
       StepEstimate,
       Breakpoint
     )].contramap { a =>
       (a.id,
        a.instrumentConfig,
        a.stepConfig,
+       a.telescopeConfig,
        a.estimate,
        a.breakpoint
       )

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbTelescopeConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbTelescopeConfig.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence
+package arb
+
+import lucuma.core.enums.StepGuideState
+import lucuma.core.math.Offset
+import lucuma.core.math.arb.ArbOffset
+import lucuma.core.util.arb.ArbEnumerated
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+
+trait ArbTelescopeConfig:
+  import ArbEnumerated.given
+  import ArbOffset.given
+
+  given Arbitrary[TelescopeConfig] =
+    Arbitrary:
+      for
+        o <- arbitrary[Offset]
+        g <- arbitrary[StepGuideState]
+      yield TelescopeConfig(o, g)
+
+  given Cogen[TelescopeConfig] =
+    Cogen[(
+      Offset,
+      StepGuideState
+    )].contramap: a =>
+      (a.offset, a.guiding)
+
+object ArbTelescopeConfig extends ArbTelescopeConfig

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepConfigSuite.scala
@@ -4,17 +4,14 @@
 package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
-import lucuma.core.math.arb.ArbOffset
 import lucuma.core.model.sequence.arb.*
 import lucuma.core.util.arb.*
 import monocle.law.discipline.*
 import munit.*
 
-final class StepConfigSuite extends DisciplineSuite {
+final class StepConfigSuite extends DisciplineSuite:
   import ArbEnumerated.given
-  import ArbOffset.given
   import ArbStepConfig.given
-  import ArbTelescopeConfig.given
 
   checkAll("Eq[StepConfig.Gcal]", EqTests[StepConfig.Gcal].eqv)
   checkAll("StepConfig.Gcal.lamp", LensTests(StepConfig.Gcal.lamp))
@@ -23,19 +20,10 @@ final class StepConfigSuite extends DisciplineSuite {
   checkAll("StepConfig.Gcal.filter", LensTests(StepConfig.Gcal.filter))
   checkAll("StepConfig.Gcal.diffuser", LensTests(StepConfig.Gcal.diffuser))
   checkAll("StepConfig.Gcal.shutter", LensTests(StepConfig.Gcal.shutter))
-  checkAll("StepConfig.Gcal.telescope", LensTests(StepConfig.Gcal.telescope))
-
-  checkAll("Eq[StepConfig.Science]", EqTests[StepConfig.Science].eqv)
-  checkAll("StepConfig.Science.telescope", LensTests(StepConfig.Science.telescope))
 
   checkAll("Eq[StepConfig.SmartGcal]", EqTests[StepConfig.SmartGcal].eqv)
   checkAll("StepConfig.SmartGcal.smartGcalType", LensTests(StepConfig.SmartGcal.smartGcalType))
-  checkAll("StepConfig.SmartGcal.telescope", LensTests(StepConfig.SmartGcal.telescope))
 
   checkAll("Eq[StepConfig]", EqTests[StepConfig].eqv)
-  checkAll("StepConfig.offset", OptionalTests(StepConfig.offset))
-  checkAll("StepConfig.guiding", OptionalTests(StepConfig.guiding))
   checkAll("StepConfig.gcal", PrismTests(StepConfig.gcal))
-  checkAll("StepConfig.science", PrismTests(StepConfig.science))
   checkAll("StepConfig.smartGcal", PrismTests(StepConfig.smartGcal))
-}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepConfigSuite.scala
@@ -4,16 +4,15 @@
 package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
-import lucuma.core.math.arb.*
 import lucuma.core.model.sequence.arb.*
 import lucuma.core.util.arb.*
 import monocle.law.discipline.*
 import munit.*
 
 final class StepConfigSuite extends DisciplineSuite {
-  import ArbStepConfig.given
   import ArbEnumerated.given
-  import ArbOffset.given
+  import ArbStepConfig.given
+  import ArbTelescopeConfig.given
 
   checkAll("Eq[StepConfig.Gcal]", EqTests[StepConfig.Gcal].eqv)
   checkAll("StepConfig.Gcal.lamp", LensTests(StepConfig.Gcal.lamp))
@@ -22,11 +21,17 @@ final class StepConfigSuite extends DisciplineSuite {
   checkAll("StepConfig.Gcal.filter", LensTests(StepConfig.Gcal.filter))
   checkAll("StepConfig.Gcal.diffuser", LensTests(StepConfig.Gcal.diffuser))
   checkAll("StepConfig.Gcal.shutter", LensTests(StepConfig.Gcal.shutter))
+  checkAll("StepConfig.Gcal.telescope", LensTests(StepConfig.Gcal.telescope))
 
   checkAll("Eq[StepConfig.Science]", EqTests[StepConfig.Science].eqv)
-  checkAll("StepConfig.Science.offset", LensTests(StepConfig.Science.offset))
+  checkAll("StepConfig.Science.telescope", LensTests(StepConfig.Science.telescope))
+
+  checkAll("Eq[StepConfig.SmartGcal]", EqTests[StepConfig.SmartGcal].eqv)
+  checkAll("StepConfig.SmartGcal.smartGcalType", LensTests(StepConfig.SmartGcal.smartGcalType))
+  checkAll("StepConfig.SmartGcal.telescope", LensTests(StepConfig.SmartGcal.telescope))
 
   checkAll("Eq[StepConfig]", EqTests[StepConfig].eqv)
   checkAll("StepConfig.gcal", PrismTests(StepConfig.gcal))
   checkAll("StepConfig.science", PrismTests(StepConfig.science))
+  checkAll("StepConfig.smartGcal", PrismTests(StepConfig.smartGcal))
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepConfigSuite.scala
@@ -4,6 +4,7 @@
 package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
+import lucuma.core.math.arb.ArbOffset
 import lucuma.core.model.sequence.arb.*
 import lucuma.core.util.arb.*
 import monocle.law.discipline.*
@@ -11,6 +12,7 @@ import munit.*
 
 final class StepConfigSuite extends DisciplineSuite {
   import ArbEnumerated.given
+  import ArbOffset.given
   import ArbStepConfig.given
   import ArbTelescopeConfig.given
 
@@ -31,6 +33,8 @@ final class StepConfigSuite extends DisciplineSuite {
   checkAll("StepConfig.SmartGcal.telescope", LensTests(StepConfig.SmartGcal.telescope))
 
   checkAll("Eq[StepConfig]", EqTests[StepConfig].eqv)
+  checkAll("StepConfig.offset", OptionalTests(StepConfig.offset))
+  checkAll("StepConfig.guiding", OptionalTests(StepConfig.guiding))
   checkAll("StepConfig.gcal", PrismTests(StepConfig.gcal))
   checkAll("StepConfig.science", PrismTests(StepConfig.science))
   checkAll("StepConfig.smartGcal", PrismTests(StepConfig.smartGcal))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/StepSuite.scala
@@ -5,6 +5,7 @@ package lucuma.core.model.sequence
 
 import cats.kernel.laws.discipline.*
 import io.circe.testing.KeyCodecTests
+import lucuma.core.math.arb.ArbOffset
 import lucuma.core.model.sequence.arb.*
 import lucuma.core.model.sequence.gmos.DynamicConfig.GmosNorth
 import lucuma.core.model.sequence.gmos.arb.*
@@ -13,13 +14,14 @@ import lucuma.core.util.laws.UidTests
 import monocle.law.discipline.*
 import munit.*
 
-final class StepSuite extends DisciplineSuite {
-
+final class StepSuite extends DisciplineSuite:
   import ArbDynamicConfig.given
   import ArbEnumerated.given
+  import ArbOffset.given
   import ArbStep.given
   import ArbStepConfig.given
   import ArbStepEstimate.given
+  import ArbTelescopeConfig.given
   import ArbUid.given
 
   checkAll("Uid[Step.Id]", UidTests[Step.Id].uid)
@@ -29,6 +31,8 @@ final class StepSuite extends DisciplineSuite {
   checkAll("Step.id",                LensTests(Step.id[GmosNorth]))
   checkAll("Step.instrumentConfig",  LensTests(Step.instrumentConfig[GmosNorth]))
   checkAll("Step.stepConfig",        LensTests(Step.stepConfig[GmosNorth]))
+  checkAll("Step.telescopeConfig",   LensTests(Step.telescopeConfig[GmosNorth]))
+  checkAll("Step.offset",            LensTests(Step.offset[GmosNorth]))
+  checkAll("Step.guiding",           LensTests(Step.guiding[GmosNorth]))
   checkAll("Step.breakpoint",        LensTests(Step.breakpoint[GmosNorth]))
   checkAll("Step.estimate",          LensTests(Step.estimate[GmosNorth]))
-}


### PR DESCRIPTION
Pulls the `StepConfig.Science` telescope configuration (offset and guiding) up to `Step` itself.  This information was already part of `Science` steps but will now be included in all steps.  The telescope configuration is separated into its own `TelescopeConfig`.

There is more discussion of this at the end of ShortCut 3374, starting here: https://app.shortcut.com/lucuma/story/3374/update-gmos-sequence-generator#activity-3731