### PR TITLE
`UserProfile`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.109"
+ThisBuild / tlBaseVersion                         := "0.110"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/OrcidProfile.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/OrcidProfile.scala
@@ -3,28 +3,24 @@
 
 package lucuma.core.model
 
-import cats.*
-import cats.implicits.*
+import cats.Eq
 
 /**
- * An ORCID profile is an OrcidId and an ORCID user profile or else a fallback
- * profile.
+ * An ORCID profile is an OrcidId and a user profile.
  */
 final case class OrcidProfile(
-  orcidId:  OrcidId,
-  primary:  UserProfile,
-  fallback: UserProfile
+  orcidId: OrcidId,
+  profile: UserProfile
 ):
 
   /** The best display name we can provide, based on available information. */
-  def displayName: String = (
-    primary.displayName <+> fallback.displayName
-  ).getOrElse(orcidId.value.toString)
+  def displayName: String =
+    profile.displayName.getOrElse(orcidId.value.toString)
 
   /** The orcid primary email, or else the fallback email (if any). */
   def email: Option[String] =
-    primary.email <+> fallback.email
+    profile.email
 
 object OrcidProfile:
   given Eq[OrcidProfile] =
-    Eq.by(x => (x.orcidId, x.primary, x.fallback))
+    Eq.by(x => (x.orcidId, x.profile))

--- a/modules/core/shared/src/main/scala/lucuma/core/model/UserProfile.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/UserProfile.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.*
+import cats.implicits.*
+
+/** A user's name and email. */
+final case class UserProfile(
+  givenName:  Option[String],
+  familyName: Option[String],
+  creditName: Option[String],
+  email:      Option[String],
+):
+
+  /** The best display name we can provide, based on available information. */
+  def displayName: Option[String] =
+    creditName                                       <+>
+    (givenName, familyName).mapN((g, f) => s"$g $f") <+>
+    familyName                                       <+>
+    givenName
+
+object UserProfile:
+
+  val Empty: UserProfile =
+    UserProfile(None, None, None, None)
+
+  given Eq[UserProfile] =
+    Eq.by(x => (x.givenName, x.familyName, x.creditName, x.email))

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbOrcidProfile.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbOrcidProfile.scala
@@ -5,28 +5,24 @@ package lucuma.core.model.arb
 
 import lucuma.core.model.OrcidId
 import lucuma.core.model.OrcidProfile
+import lucuma.core.model.UserProfile
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.*
 
-trait ArbOrcidProfile {
+trait ArbOrcidProfile:
   import ArbOrcidId.given
+  import ArbUserProfile.given
 
   given Arbitrary[OrcidProfile] =
-    Arbitrary {
-      for {
-        id           <- arbitrary[OrcidId]
-        givenName    <- arbitrary[Option[String]]
-        familyName   <- arbitrary[Option[String]]
-        creditName   <- arbitrary[Option[String]]
-        primaryEmail <- arbitrary[Option[String]]
-      } yield OrcidProfile(id, givenName, familyName, creditName, primaryEmail)
-    }
+    Arbitrary:
+      for
+        id       <- arbitrary[OrcidId]
+        primary  <- arbitrary[UserProfile]
+        fallback <- arbitrary[UserProfile]
+      yield OrcidProfile(id, primary, fallback)
 
   given Cogen[OrcidProfile] =
-    Cogen[(OrcidId, Option[String], Option[String], Option[String], Option[String])].contramap(x =>
-      (x.orcidId, x.givenName, x.familyName, x.creditName, x.primaryEmail)
-    )
-
-}
+    Cogen[(OrcidId, UserProfile, UserProfile)].contramap: x =>
+      (x.orcidId, x.primary, x.fallback)
 
 object ArbOrcidProfile extends ArbOrcidProfile

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbOrcidProfile.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbOrcidProfile.scala
@@ -16,13 +16,12 @@ trait ArbOrcidProfile:
   given Arbitrary[OrcidProfile] =
     Arbitrary:
       for
-        id       <- arbitrary[OrcidId]
-        primary  <- arbitrary[UserProfile]
-        fallback <- arbitrary[UserProfile]
-      yield OrcidProfile(id, primary, fallback)
+        id      <- arbitrary[OrcidId]
+        profile <- arbitrary[UserProfile]
+      yield OrcidProfile(id, profile)
 
   given Cogen[OrcidProfile] =
-    Cogen[(OrcidId, UserProfile, UserProfile)].contramap: x =>
-      (x.orcidId, x.primary, x.fallback)
+    Cogen[(OrcidId, UserProfile)].contramap: a =>
+      (a.orcidId, a.profile)
 
 object ArbOrcidProfile extends ArbOrcidProfile

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbUserProfile.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbUserProfile.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.arb
+
+import lucuma.core.model.UserProfile
+import org.scalacheck.*
+import org.scalacheck.Arbitrary.*
+
+trait ArbUserProfile:
+
+  given Arbitrary[UserProfile] =
+    Arbitrary:
+      for
+        givenName    <- arbitrary[Option[String]]
+        familyName   <- arbitrary[Option[String]]
+        creditName   <- arbitrary[Option[String]]
+        primaryEmail <- arbitrary[Option[String]]
+      yield UserProfile(givenName, familyName, creditName, primaryEmail)
+
+  given Cogen[UserProfile] =
+    Cogen[(Option[String], Option[String], Option[String], Option[String])].contramap: x =>
+      (x.givenName, x.familyName, x.creditName, x.email)
+
+object ArbUserProfile extends ArbUserProfile

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/UserProfileSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/UserProfileSuite.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.kernel.laws.discipline.EqTests
+import lucuma.core.model.arb.*
+import munit.*
+
+final class UserProfileSuite extends DisciplineSuite:
+  import ArbUserProfile.given
+
+  // Laws
+  checkAll("UserProfile", EqTests[UserProfile].eqv)


### PR DESCRIPTION
This is a straightforward, if irksome, change to `OrcidProfile`.  It splits the user profile part (names+email) into `UserProfile` and makes `OrcidProfile` a tuple of `(OrcidId, UserProfile)`.  The reason for this is a pending update to the ODB schema that will add a "fallback" `UserProfile` to the `ProgramUser` type which can be used to hold name and email information when not publicly shared via ORCiD.