### PR TITLE
Remove Eq for AttachmentType since it also is Enumerated

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/AttachmentType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/AttachmentType.scala
@@ -3,8 +3,6 @@
 
 package lucuma.core.enums
 
-import cats.Eq
-import cats.derived.*
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.util.Enumerated
@@ -17,8 +15,7 @@ enum AttachmentType(
   val longName:        String,
   val uniqueInProgram: Boolean,
   val fileExtensions:  Set[NonEmptyString] // empty set implies accepts anything
-) derives Enumerated,
-      Eq:
+) derives Enumerated:
 
   case Science
       extends AttachmentType(


### PR DESCRIPTION
Another scala 3.6 migration issue.