### PR TITLE
Define F2 LongSlit/Imaging geometry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.113"
+ThisBuild / tlBaseVersion                         := "0.114"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/build.sbt
+++ b/build.sbt
@@ -114,6 +114,7 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
     resolvers += "Gemini Repository".at(
       "https://github.com/gemini-hlsw/maven-repo/raw/master/releases"
     ),
+    run / fork := true,
     libraryDependencies ++= Seq(
       ("edu.gemini.ocs" %% "edu-gemini-util-skycalc"     % "2020001.1.7" % Test)
         .cross(CrossVersion.for3Use2_13)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/F2Fpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/F2Fpu.scala
@@ -15,7 +15,7 @@ sealed abstract class F2Fpu(
   val tag: String,
   val shortName: String,
   val longName: String,
-  val slitWidth: Int,
+  val slitWidth: Int, // pixels
   val decker: String,
   val obsolete: Boolean
 ) extends Product with Serializable

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/F2LyotWheel.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/F2LyotWheel.scala
@@ -9,14 +9,20 @@ import lucuma.core.util.Enumerated
 
 /**
  * Enumerated type for Flamingos2 Lyot wheel.
+ *
+ * f/16:  plate scale = 1.61 arcsec/mm;  pixel scale=0.18 arcsec/pixel
+ * f/32:  plate scale = 0.805 arcsec/mm; pixel scale =0.09 arcsec/pixel
+ * If the Lyot wheel is set to HartmannA or HartmannB, the
+ * FOV should just be a point at the base position (this is not a
+ * scientifically useful option, but is used for focusing)
  * @group Enumerations (Generated)
  */
 sealed abstract class F2LyotWheel(
   val tag: String,
   val shortName: String,
   val longName: String,
-  val plateScale: Double,
-  val pixelScale: Double,
+  val plateScale: Double, // arcsec/mm
+  val pixelScale: Double, // arcsec/pixel
   val obsolete: Boolean
 ) extends Product with Serializable
 
@@ -44,7 +50,7 @@ object F2LyotWheel {
     fromTag(s).getOrElse(throw new NoSuchElementException(s"F2LyotWheel: Invalid tag: '$s'"))
 
   /** @group Typeclass Instances */
-  implicit val F2LyotWheelEnumerated: Enumerated[F2LyotWheel] =
+  given Enumerated[F2LyotWheel] =
     new Enumerated[F2LyotWheel] {
       def all = F2LyotWheel.all
       def tag(a: F2LyotWheel) = a.tag

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ImageQuality.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ImageQuality.scala
@@ -6,6 +6,7 @@ package lucuma.core.enums
 import coulomb.*
 import coulomb.policy.spire.standard.given
 import coulomb.syntax.*
+import coulomb.units.accepted.*
 import eu.timepit.refined.*
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.numeric.PosInt

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/PortDisposition.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/PortDisposition.scala
@@ -34,7 +34,7 @@ object PortDisposition {
     fromTag(s).getOrElse(throw new NoSuchElementException(s"PortDisposition: Invalid tag: '$s'"))
 
   /** @group Typeclass Instances */
-  implicit val PortDispositionEnumerated: Enumerated[PortDisposition] =
+  given Enumerated[PortDisposition] =
     new Enumerated[PortDisposition] {
       def all = PortDisposition.all
       def tag(a: PortDisposition) = a.tag

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
@@ -49,6 +49,13 @@ object ShapeExpression {
   final case class Ellipse(a: Offset, b: Offset) extends ShapeExpression
 
   /**
+   * Arc contained in the rectangle defined by the two positions an the angles of start and end
+   *
+   * @group Constructors
+   */
+  final case class ClosedArc(a: Offset, b: Offset, c: Angle, d: Angle) extends ShapeExpression
+
+  /**
    * Polygon defined by a list of offset positions.
    *
    * @group Constructors

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2OiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2OiwfsProbeArm.scala
@@ -39,10 +39,9 @@ trait F2OiwfsProbeArm:
     ShapeExpression.polygonAt((x0.p, y0.q), (x1.p, y1.q), (x2.p, y2.q), (x3.p, y3.q), (x4.p, y4.q), (x5.p, y5.q))
   }
 
-  private def pickoff(plateScale: F2PlateScale): ShapeExpression = {
+  private def pickoff(plateScale: F2PlateScale): ShapeExpression =
     val scaledMirrorSize = PickoffMirrorSize.withPlateScale(plateScale).toAngle
     ShapeExpression.centeredRectangle(scaledMirrorSize, scaledMirrorSize)
-  }
 
   /**
     * Description of the F2 OIWFS probe arm with the pickoff mirror centered

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2OiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2OiwfsProbeArm.scala
@@ -4,58 +4,25 @@
 package lucuma.core.geom.f2
 
 import cats.syntax.all.*
-import lucuma.core.enums.GmosNorthFpu
-import lucuma.core.enums.GmosSouthFpu
-import lucuma.core.enums.PortDisposition
-import lucuma.core.geom.ShapeExpression
-import lucuma.core.geom.syntax.all.*
-import lucuma.core.math.Angle
-import lucuma.core.math.Offset
-import lucuma.core.math.syntax.int.*
-import lucuma.core.math.units.*
 import coulomb.*
 import coulomb.policy.spire.standard.given
 import coulomb.syntax.*
 import coulomb.units.accepted.*
 import coulomb.units.si.prefixes.*
+import lucuma.core.enums.F2LyotWheel
+import lucuma.core.enums.PortDisposition
+import lucuma.core.geom.ShapeExpression
+import lucuma.core.geom.syntax.all.*
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import lucuma.core.math.units.*
+import spire.math.*
 import spire.std.bigDecimal.*
 
-import java.lang.Math.PI
-import java.lang.Math.asin
-import java.lang.Math.atan2
-import java.lang.Math.hypot
-import java.lang.Math.sin
-import lucuma.core.enums.F2LyotWheel
-
 /**
-  * Description of the GMOS OIWFS probe arm geometry.
+  * Description of the F2 OIWFS probe arm geometry.
   */
-trait F2OiwfsProbeArm {
-    // val probeArm: Shape = {
-    //   val plateScale = f2.getLyotWheel.getPlateScale
-    //   val scaledLength = ProbePickoffArmLength * plateScale
-    //   val hm = PickoffMirrorSize * plateScale / 2.0
-    //   val htw = ProbeArmTaperedWidth / 2.0
-    //
-    //   val (x0, y0) = (hm, -htw)
-    //   val (x1, y1) = (x0 + ProbeArmTaperedLength, -hm)
-    //   val (x2, y2) = (x0 + scaledLength, y1)
-    //   val (x3, y3) = (x2, hm)
-    //   val (x4, y4) = (x1, y3)
-    //   val (x5, y5) = (x0, htw)
-    //
-    //   val points = List((x0, y0), (x1, y1), (x2, y2), (x3, y3), (x4, y4), (x5, y5))
-    //   ImPolygon(points)
-    // }
-    //
-    // val pickoffMirror: Shape = {
-    //   val plateScale = f2.getLyotWheel.getPlateScale
-    //   val scaledMirrorSize = PickoffMirrorSize * plateScale
-    //   val xy = -scaledMirrorSize / 2.0
-    //   new Rectangle2D.Double(xy, xy, scaledMirrorSize, scaledMirrorSize)
-    // }
-    //
-    // new Area(probeArm) <| (_.add(new Area(pickoffMirror)))
+trait F2OiwfsProbeArm:
 
   private def arm(plateScale: F2PlateScale): ShapeExpression = {
     val scaledLength = ProbePickoffArmLength.withPlateScale(plateScale).toAngle
@@ -74,7 +41,6 @@ trait F2OiwfsProbeArm {
 
   private def pickoff(plateScale: F2PlateScale): ShapeExpression = {
     val scaledMirrorSize = PickoffMirrorSize.withPlateScale(plateScale).toAngle
-    val xy = -scaledMirrorSize.bisect
     ShapeExpression.centeredRectangle(scaledMirrorSize, scaledMirrorSize)
   }
 
@@ -92,7 +58,7 @@ trait F2OiwfsProbeArm {
     * @param posAngle position angle where positive is counterclockwise
     * @param guideStar guide star offset from the center, relative to an un-rotated frame
     * @param offsetPos offset position from the base, if any
-    * @param fpu focal plane unit, if any
+    * @param lyot Lyot Wheel position, to get the plate scale
     * @param port port disposition
     *
     * @return probe arm shape correctly rotated and offset to reach the guide star
@@ -105,113 +71,43 @@ trait F2OiwfsProbeArm {
     port:      PortDisposition
   ): ShapeExpression =
     val plateScale = BigDecimal(lyot.plateScale).withUnit[ArcSecondPerMillimeter]
-    println(s"Arm angle ${armAngle(posAngle, guideStar, offsetPos, port, plateScale).toDoubleDegrees}")
     shape(plateScale) ⟲ armAngle(posAngle, guideStar, offsetPos, port, plateScale) ↗ guideStar
 
+  /**
+    * Calculate the angle of the probe arm to reach a guide star at a given offset.
+    */
   private def armAngle(posAngle:    Angle,
                        gsOffset:    Offset,
                        offset:      Offset,
                        port:        PortDisposition,
                        plateScale:  F2PlateScale): Angle = {
+    // All calculations are done in arcseconds and just bigdecimal and doubles
     val Q = {
       val P = {
         val scaledFlippedPAO = {
-          val scaledPAO = ProbeArmOffset.withPlateScale(plateScale).value.toDouble
-          println(s"PAO ${scaledPAO} $port ")
+          val scaledPAO = ProbeArmOffset.withPlateScale(plateScale).value
           if (port === PortDisposition.Bottom) -scaledPAO else scaledPAO
         }
         val angle = -posAngle
-        // println(s"P ${angle.toDoubleDegrees} ${Angle.fromDoubleArcseconds(scaledFlippedPAO * angle.cos).toSignedDoubleDegrees}, ${Angle.fromDoubleArcseconds(scaledFlippedPAO * angle.sin).toSignedDoubleDegrees}")
-        // println(s" --> ${(scaledFlippedPAO * angle.cos)}, ${(scaledFlippedPAO * angle.sin)}")
-        ((scaledFlippedPAO * angle.cos).withUnit[ArcSecond],
-         (scaledFlippedPAO * angle.sin).withUnit[ArcSecond])
+        (scaledFlippedPAO * angle.cos, scaledFlippedPAO * angle.sin)
       }
 
       val guideStar = (gsOffset - offset.rotate(posAngle)).inverse().toDoubleArcseconds
-      println(s"P ${P._1} ${P._2}")
-      // println(s"gs offset ${gsOffset.p.toAngle.toDoubleDegrees} ${gsOffset.q.toAngle.toDoubleDegrees}")
-      println(s"Guide star $guideStar ${Angle.signedDecimalArcseconds.get(gsOffset.p.toAngle)} ${Angle.signedDecimalArcseconds.get(gsOffset.q.toAngle)}")
-      // println(s"Guide star $guideStar ${Angle.signedDecimalArcseconds.get(-guideStar.p.toAngle)} ${Angle.signedDecimalArcseconds.get(-guideStar.q.toAngle)}")
-      val D: (Quantity[BigDecimal, ArcSecond], Quantity[BigDecimal, ArcSecond]) = (guideStar._1 - P._1, guideStar._2 - P._2)
-      val dOffset = Offset(Angle.fromDoubleArcseconds((guideStar._1 - P._1).value.toDouble).p, Angle.fromDoubleArcseconds((guideStar._2 - P._2).value.toDouble).q)
-      // println(s"D ${(guideStar.p.toAngle.toMicroarcseconds / 1e6) - (P.p.toAngle.toMicroarcseconds / 1e6)} ${(guideStar.q.toAngle.toMicroarcseconds / 1e6) - (P.q.toAngle.toMicroarcseconds / 1e6)}")
-      // println(s"D ${D.p.toAngle.toMicroarcseconds / 1e6} ${D.q.toAngle.toMicroarcseconds / 1e6}")
-      println(s"offset ${offset} ")
-      println(s"GS ${guideStar._1.value} ${guideStar._2.value}")
-      println(s"D ${D._1.value} ${D._2.value}")
+      val D = ((guideStar._1 - P._1), (guideStar._2 - P._2))
 
-      val scaledPBAL = ProbeBaseArmLength.withPlateScale(plateScale).value.toDouble
-      val scaledPPAL = ProbePickoffArmLength.withPlateScale(plateScale).value.toDouble
-      val distance: Quantity[BigDecimal, ArcSecond]   = math.min(math.sqrt((D._1.value.pow(2) + D._2.value.pow(2)).toDouble), scaledPBAL + scaledPPAL).withUnit[ArcSecond]
-      // val distance = dOffset.distance(Offset(Angle.signedDecimalArcseconds.reverseGet(scaledPBAL).p, Angle.signedDecimalArcseconds.reverseGet(scaledPPAL).q)).toMicroarcseconds
-      println(s" scaledpal  ${scaledPBAL}")
-      println(s" scaledppl  ${scaledPPAL}")
-      println(s" Distance ${distance }")
-      val a = (scaledPBAL * scaledPBAL - scaledPPAL * scaledPPAL + distance.value.pow(2)) / (2 * distance.value)
-      println(s" a ${a}")
-      val h = (if (port === PortDisposition.Bottom) -1 else 1) * math.sqrt((scaledPBAL * scaledPBAL - a * a).toDouble)
-      println(s" h ${h}")
-      val p1 = (a * D._1.value + h * D._2.value) / distance.value
-      val q1 = (a * D._2.value - h * D._1.value) / distance.value
-      println(p1)
-      println(q1)
-      // val q1 = Angle.fromMicroarcseconds(((a * D.q.toAngle.toMicroarcseconds - h * D.p.toAngle.toMicroarcseconds) / distance).toLong)
-      val p = -guideStar._1.value + P._1.value + p1
-      val q = -guideStar._2.value + P._2.value + q1
+      val scaledPBAL = ProbeBaseArmLength.withPlateScale(plateScale).value
+      val scaledPPAL = ProbePickoffArmLength.withPlateScale(plateScale).value
+      val distance   = BigDecimal(math.sqrt((D._1.pow(2) + D._2.pow(2)).toDouble)).min(scaledPBAL + scaledPPAL)
+      val a = (scaledPBAL.pow(2) - scaledPPAL.pow(2) + distance.pow(2)) / (2 * distance)
+      val h = (if (port === PortDisposition.Bottom) -1 else 1) *
+                math.sqrt((scaledPBAL.pow(2)- a.pow(2)).toDouble)
+      val p1 = (a * D._1 + h * D._2) / distance
+      val q1 = (a * D._2 - h * D._1) / distance
+      val p = -guideStar._1 + P._1 + p1
+      val q = -guideStar._2 + P._2 + q1
       (p, q)
-      // Offset(Angle.signedDecimalArcseconds.reverseGet(p).p, Angle.signedDecimalArcseconds.reverseGet(q).q)
     }
-    println(s"atan $Q ${math.atan2(Q._2.toDouble, Q._1.toDouble)}")
-    val k = Angle.fromDoubleRadians(-math.atan2(Q._2.toDouble, Q._1.toDouble))
-    println(k.toDoubleDegrees)
-    k.flip
+    Angle.fromDoubleRadians(-math.atan2(Q._2.toDouble, Q._1.toDouble)).flip
   }
-  // private def armAngle(
-  //   posAngle:  Angle,
-  //   guideStar: Offset,
-  //   offsetPos: Offset,
-  //   fpu:       Option[Either[GmosNorthFpu, GmosSouthFpu]],
-  //   port:      PortDisposition
-  // ): Angle = {
-  //
-  //   val t  = Offset(427520.mas.p, 101840.mas.q)
-  //   val tʹ =
-  //     if (port === PortDisposition.Side) Offset.qAngle.modify(_.mirrorBy(Angle.Angle0))(t) else t
-  //
-  //   val bx  = Angle.signedDecimalArcseconds.get(StageArmLength).toDouble
-  //   val bxᒾ = bx * bx
-  //
-  //   val mx  = Angle.signedDecimalArcseconds.get(PickoffArmLength).toDouble
-  //   val mxᒾ = mx * mx
-  //
-  //   val (x, y) =
-  //     Offset.signedDecimalArcseconds
-  //       .get(
-  //         tʹ.rotate(posAngle) + guideStar - (offsetPos - ifuOffset(fpu)).rotate(posAngle)
-  //       )
-  //       .bimap(x => -x.toDouble, _.toDouble)
-  //
-  //   val r  = hypot(x, y)
-  //   val rᒾ = r * r
-  //   val α  = atan2(x, -y)
-  //
-  //   val φ =
-  //     math.acos(
-  //       (rᒾ - (bxᒾ + mxᒾ)) / (2.0 * bx * mx) match {
-  //         case a if a < -1.0 => -1.0
-  //         case a if a > 1.0  => 1.0
-  //         case a             => a
-  //       }
-  //     ) * (if (port === PortDisposition.Side) -1.0 else 1.0)
-  //
-  //   val θ = {
-  //     val θʹ = asin((mx / r) * sin(φ))
-  //     if (mxᒾ > (rᒾ + bxᒾ)) PI - θʹ else θʹ
-  //   }
-  //
-  //   Angle.fromDoubleRadians(-φ + θ + α + PI / 2.0)
-  // }
-
-}
 
 object probeArm extends F2OiwfsProbeArm

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2OiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2OiwfsProbeArm.scala
@@ -1,0 +1,217 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom.f2
+
+import cats.syntax.all.*
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosSouthFpu
+import lucuma.core.enums.PortDisposition
+import lucuma.core.geom.ShapeExpression
+import lucuma.core.geom.syntax.all.*
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.int.*
+import lucuma.core.math.units.*
+import coulomb.*
+import coulomb.policy.spire.standard.given
+import coulomb.syntax.*
+import coulomb.units.accepted.*
+import coulomb.units.si.prefixes.*
+import spire.std.bigDecimal.*
+
+import java.lang.Math.PI
+import java.lang.Math.asin
+import java.lang.Math.atan2
+import java.lang.Math.hypot
+import java.lang.Math.sin
+import lucuma.core.enums.F2LyotWheel
+
+/**
+  * Description of the GMOS OIWFS probe arm geometry.
+  */
+trait F2OiwfsProbeArm {
+    // val probeArm: Shape = {
+    //   val plateScale = f2.getLyotWheel.getPlateScale
+    //   val scaledLength = ProbePickoffArmLength * plateScale
+    //   val hm = PickoffMirrorSize * plateScale / 2.0
+    //   val htw = ProbeArmTaperedWidth / 2.0
+    //
+    //   val (x0, y0) = (hm, -htw)
+    //   val (x1, y1) = (x0 + ProbeArmTaperedLength, -hm)
+    //   val (x2, y2) = (x0 + scaledLength, y1)
+    //   val (x3, y3) = (x2, hm)
+    //   val (x4, y4) = (x1, y3)
+    //   val (x5, y5) = (x0, htw)
+    //
+    //   val points = List((x0, y0), (x1, y1), (x2, y2), (x3, y3), (x4, y4), (x5, y5))
+    //   ImPolygon(points)
+    // }
+    //
+    // val pickoffMirror: Shape = {
+    //   val plateScale = f2.getLyotWheel.getPlateScale
+    //   val scaledMirrorSize = PickoffMirrorSize * plateScale
+    //   val xy = -scaledMirrorSize / 2.0
+    //   new Rectangle2D.Double(xy, xy, scaledMirrorSize, scaledMirrorSize)
+    // }
+    //
+    // new Area(probeArm) <| (_.add(new Area(pickoffMirror)))
+
+  private def arm(plateScale: F2PlateScale): ShapeExpression = {
+    val scaledLength = ProbePickoffArmLength.withPlateScale(plateScale).toAngle
+    val hm = (PickoffMirrorSize.withPlateScale(plateScale) / 2.0).toAngle
+    val htw = ProbeArmTaperedWidth.bisect
+
+    val (x0, y0) = (hm, -htw)
+    val (x1, y1) = (x0 + ProbeArmTaperedLength, -hm)
+    val (x2, y2) = (x0 + scaledLength, y1)
+    val (x3, y3) = (x2, hm)
+    val (x4, y4) = (x1, y3)
+    val (x5, y5) = (x0, htw)
+
+    ShapeExpression.polygonAt((x0.p, y0.q), (x1.p, y1.q), (x2.p, y2.q), (x3.p, y3.q), (x4.p, y4.q), (x5.p, y5.q))
+  }
+
+  private def pickoff(plateScale: F2PlateScale): ShapeExpression = {
+    val scaledMirrorSize = PickoffMirrorSize.withPlateScale(plateScale).toAngle
+    val xy = -scaledMirrorSize.bisect
+    ShapeExpression.centeredRectangle(scaledMirrorSize, scaledMirrorSize)
+  }
+
+  /**
+    * Description of the F2 OIWFS probe arm with the pickoff mirror centered
+    * at the base position.
+    */
+  def shape(plateScale: F2PlateScale): ShapeExpression =
+    arm(plateScale) ∪ pickoff(plateScale)
+
+  /**
+    * The F2 OIWFS probe arm positioned to reach a particular guide star at
+    * a particular offset.
+    *
+    * @param posAngle position angle where positive is counterclockwise
+    * @param guideStar guide star offset from the center, relative to an un-rotated frame
+    * @param offsetPos offset position from the base, if any
+    * @param fpu focal plane unit, if any
+    * @param port port disposition
+    *
+    * @return probe arm shape correctly rotated and offset to reach the guide star
+    */
+  def shapeAt(
+    posAngle:  Angle,
+    guideStar: Offset,
+    offsetPos: Offset,
+    lyot:      F2LyotWheel,
+    port:      PortDisposition
+  ): ShapeExpression =
+    val plateScale = BigDecimal(lyot.plateScale).withUnit[ArcSecondPerMillimeter]
+    println(s"Arm angle ${armAngle(posAngle, guideStar, offsetPos, port, plateScale).toDoubleDegrees}")
+    shape(plateScale) ⟲ armAngle(posAngle, guideStar, offsetPos, port, plateScale) ↗ guideStar
+
+  private def armAngle(posAngle:    Angle,
+                       gsOffset:    Offset,
+                       offset:      Offset,
+                       port:        PortDisposition,
+                       plateScale:  F2PlateScale): Angle = {
+    val Q = {
+      val P = {
+        val scaledFlippedPAO = {
+          val scaledPAO = ProbeArmOffset.withPlateScale(plateScale).value.toDouble
+          println(s"PAO ${scaledPAO} $port ")
+          if (port === PortDisposition.Bottom) -scaledPAO else scaledPAO
+        }
+        val angle = -posAngle
+        // println(s"P ${angle.toDoubleDegrees} ${Angle.fromDoubleArcseconds(scaledFlippedPAO * angle.cos).toSignedDoubleDegrees}, ${Angle.fromDoubleArcseconds(scaledFlippedPAO * angle.sin).toSignedDoubleDegrees}")
+        // println(s" --> ${(scaledFlippedPAO * angle.cos)}, ${(scaledFlippedPAO * angle.sin)}")
+        ((scaledFlippedPAO * angle.cos).withUnit[ArcSecond],
+         (scaledFlippedPAO * angle.sin).withUnit[ArcSecond])
+      }
+
+      val guideStar = (gsOffset - offset.rotate(posAngle)).inverse().toDoubleArcseconds
+      println(s"P ${P._1} ${P._2}")
+      // println(s"gs offset ${gsOffset.p.toAngle.toDoubleDegrees} ${gsOffset.q.toAngle.toDoubleDegrees}")
+      println(s"Guide star $guideStar ${Angle.signedDecimalArcseconds.get(gsOffset.p.toAngle)} ${Angle.signedDecimalArcseconds.get(gsOffset.q.toAngle)}")
+      // println(s"Guide star $guideStar ${Angle.signedDecimalArcseconds.get(-guideStar.p.toAngle)} ${Angle.signedDecimalArcseconds.get(-guideStar.q.toAngle)}")
+      val D: (Quantity[BigDecimal, ArcSecond], Quantity[BigDecimal, ArcSecond]) = (guideStar._1 - P._1, guideStar._2 - P._2)
+      val dOffset = Offset(Angle.fromDoubleArcseconds((guideStar._1 - P._1).value.toDouble).p, Angle.fromDoubleArcseconds((guideStar._2 - P._2).value.toDouble).q)
+      // println(s"D ${(guideStar.p.toAngle.toMicroarcseconds / 1e6) - (P.p.toAngle.toMicroarcseconds / 1e6)} ${(guideStar.q.toAngle.toMicroarcseconds / 1e6) - (P.q.toAngle.toMicroarcseconds / 1e6)}")
+      // println(s"D ${D.p.toAngle.toMicroarcseconds / 1e6} ${D.q.toAngle.toMicroarcseconds / 1e6}")
+      println(s"offset ${offset} ")
+      println(s"GS ${guideStar._1.value} ${guideStar._2.value}")
+      println(s"D ${D._1.value} ${D._2.value}")
+
+      val scaledPBAL = ProbeBaseArmLength.withPlateScale(plateScale).value.toDouble
+      val scaledPPAL = ProbePickoffArmLength.withPlateScale(plateScale).value.toDouble
+      val distance: Quantity[BigDecimal, ArcSecond]   = math.min(math.sqrt((D._1.value.pow(2) + D._2.value.pow(2)).toDouble), scaledPBAL + scaledPPAL).withUnit[ArcSecond]
+      // val distance = dOffset.distance(Offset(Angle.signedDecimalArcseconds.reverseGet(scaledPBAL).p, Angle.signedDecimalArcseconds.reverseGet(scaledPPAL).q)).toMicroarcseconds
+      println(s" scaledpal  ${scaledPBAL}")
+      println(s" scaledppl  ${scaledPPAL}")
+      println(s" Distance ${distance }")
+      val a = (scaledPBAL * scaledPBAL - scaledPPAL * scaledPPAL + distance.value.pow(2)) / (2 * distance.value)
+      println(s" a ${a}")
+      val h = (if (port === PortDisposition.Bottom) -1 else 1) * math.sqrt((scaledPBAL * scaledPBAL - a * a).toDouble)
+      println(s" h ${h}")
+      val p1 = (a * D._1.value + h * D._2.value) / distance.value
+      val q1 = (a * D._2.value - h * D._1.value) / distance.value
+      println(p1)
+      println(q1)
+      // val q1 = Angle.fromMicroarcseconds(((a * D.q.toAngle.toMicroarcseconds - h * D.p.toAngle.toMicroarcseconds) / distance).toLong)
+      val p = -guideStar._1.value + P._1.value + p1
+      val q = -guideStar._2.value + P._2.value + q1
+      (p, q)
+      // Offset(Angle.signedDecimalArcseconds.reverseGet(p).p, Angle.signedDecimalArcseconds.reverseGet(q).q)
+    }
+    println(s"atan $Q ${math.atan2(Q._2.toDouble, Q._1.toDouble)}")
+    val k = Angle.fromDoubleRadians(-math.atan2(Q._2.toDouble, Q._1.toDouble))
+    println(k.toDoubleDegrees)
+    k.flip
+  }
+  // private def armAngle(
+  //   posAngle:  Angle,
+  //   guideStar: Offset,
+  //   offsetPos: Offset,
+  //   fpu:       Option[Either[GmosNorthFpu, GmosSouthFpu]],
+  //   port:      PortDisposition
+  // ): Angle = {
+  //
+  //   val t  = Offset(427520.mas.p, 101840.mas.q)
+  //   val tʹ =
+  //     if (port === PortDisposition.Side) Offset.qAngle.modify(_.mirrorBy(Angle.Angle0))(t) else t
+  //
+  //   val bx  = Angle.signedDecimalArcseconds.get(StageArmLength).toDouble
+  //   val bxᒾ = bx * bx
+  //
+  //   val mx  = Angle.signedDecimalArcseconds.get(PickoffArmLength).toDouble
+  //   val mxᒾ = mx * mx
+  //
+  //   val (x, y) =
+  //     Offset.signedDecimalArcseconds
+  //       .get(
+  //         tʹ.rotate(posAngle) + guideStar - (offsetPos - ifuOffset(fpu)).rotate(posAngle)
+  //       )
+  //       .bimap(x => -x.toDouble, _.toDouble)
+  //
+  //   val r  = hypot(x, y)
+  //   val rᒾ = r * r
+  //   val α  = atan2(x, -y)
+  //
+  //   val φ =
+  //     math.acos(
+  //       (rᒾ - (bxᒾ + mxᒾ)) / (2.0 * bx * mx) match {
+  //         case a if a < -1.0 => -1.0
+  //         case a if a > 1.0  => 1.0
+  //         case a             => a
+  //       }
+  //     ) * (if (port === PortDisposition.Side) -1.0 else 1.0)
+  //
+  //   val θ = {
+  //     val θʹ = asin((mx / r) * sin(φ))
+  //     if (mxᒾ > (rᒾ + bxᒾ)) PI - θʹ else θʹ
+  //   }
+  //
+  //   Angle.fromDoubleRadians(-φ + θ + α + PI / 2.0)
+  // }
+
+}
+
+object probeArm extends F2OiwfsProbeArm

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2OiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2OiwfsProbeArm.scala
@@ -16,7 +16,6 @@ import lucuma.core.geom.syntax.all.*
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import lucuma.core.math.units.*
-import spire.math.*
 import spire.std.bigDecimal.*
 
 /**
@@ -25,8 +24,8 @@ import spire.std.bigDecimal.*
 trait F2OiwfsProbeArm:
 
   private def arm(plateScale: F2PlateScale): ShapeExpression = {
-    val scaledLength = ProbePickoffArmLength.withPlateScale(plateScale).toAngle
-    val hm = (PickoffMirrorSize.withPlateScale(plateScale) / 2.0).toAngle
+    val scaledLength = (ProbePickoffArmLength ⨱ plateScale).toAngle
+    val hm = (PickoffMirrorSize ⨱ plateScale).toAngle.bisect
     val htw = ProbeArmTaperedWidth.bisect
 
     val (x0, y0) = (hm, -htw)
@@ -40,7 +39,7 @@ trait F2OiwfsProbeArm:
   }
 
   private def pickoff(plateScale: F2PlateScale): ShapeExpression =
-    val scaledMirrorSize = PickoffMirrorSize.withPlateScale(plateScale).toAngle
+    val scaledMirrorSize = (PickoffMirrorSize ⨱ plateScale).toAngle
     ShapeExpression.centeredRectangle(scaledMirrorSize, scaledMirrorSize)
 
   /**
@@ -84,7 +83,7 @@ trait F2OiwfsProbeArm:
     val Q = {
       val P = {
         val scaledFlippedPAO = {
-          val scaledPAO = ProbeArmOffset.withPlateScale(plateScale).value
+          val scaledPAO = (ProbeArmOffset ⨱ plateScale).value
           if (port === PortDisposition.Bottom) -scaledPAO else scaledPAO
         }
         val angle = -posAngle
@@ -94,8 +93,8 @@ trait F2OiwfsProbeArm:
       val guideStar = (gsOffset - offset.rotate(posAngle)).inverse().toDoubleArcseconds
       val D = ((guideStar._1 - P._1), (guideStar._2 - P._2))
 
-      val scaledPBAL = ProbeBaseArmLength.withPlateScale(plateScale).value
-      val scaledPPAL = ProbePickoffArmLength.withPlateScale(plateScale).value
+      val scaledPBAL = (ProbeBaseArmLength ⨱ plateScale).value
+      val scaledPPAL = (ProbePickoffArmLength ⨱ plateScale).value
       val distance   = BigDecimal(math.sqrt((D._1.pow(2) + D._2.pow(2)).toDouble)).min(scaledPBAL + scaledPPAL)
       val a = (scaledPBAL.pow(2) - scaledPPAL.pow(2) + distance.pow(2)) / (2 * distance)
       val h = (if (port === PortDisposition.Bottom) -1 else 1) *

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
@@ -35,39 +35,39 @@ trait F2PatrolField:
     // -- use full circle for upper smaller one (using only half circle for upper part of figure can
     // -- end in two disjoint areas due to calculation imprecisions, we have to make sure areas overlap
     // -- properly to yield the figure we want).
-    val upperPAOffset = (-PickOffPivotPoint, ZeroM).withPlateScaleOffset(plateScale)
+    val upperPAOffset = (-PickOffPivotPoint, ZeroM) ⤇ plateScale
     val upperPA =
       ShapeExpression.centeredEllipse(
-        (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
-        (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle
-      )
+        ((UpperPatrolAreaRadius * Two) ⨱ plateScale).toAngle,
+        ((UpperPatrolAreaRadius * Two) ⨱ plateScale).toAngle
+      ) ↗ upperPAOffset
 
-    val lowerPAOffset = (-BasePivotPoint, ZeroM).withPlateScaleOffset(plateScale)
+    val lowerPAOffset = (-BasePivotPoint, ZeroM) ⤇ plateScale
     val lowerPA =
       ShapeExpression.centeredClosedArc(
-        (LowerPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
-        (LowerPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
+        ((LowerPatrolAreaRadius * Two) ⨱ plateScale).toAngle,
+        ((LowerPatrolAreaRadius * Two) ⨱ plateScale).toAngle,
         Angle.Angle0,
         Angle.Angle180
-      )
+      ) ↗ lowerPAOffset
 
     // define the two bounding shapes (one circle and a box)
     val ew =
       ShapeExpression.centeredEllipse(
-        (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle,
-        (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle
+        ((EntranceWindowRadius * Two) ⨱ plateScale).toAngle,
+        ((EntranceWindowRadius * Two) ⨱ plateScale).toAngle
       )
 
     val paLimitOffset =
-      ((EntranceWindowRadius-PatrolAreaHiLimit)/2, ZeroM).withPlateScaleOffset(plateScale)
+      ((EntranceWindowRadius-PatrolAreaHiLimit)/2, ZeroM) ⤇ plateScale
 
     val paLimit =
       ShapeExpression.centeredRectangle(
-        (EntranceWindowRadius + PatrolAreaHiLimit).withPlateScale(plateScale).toAngle,
-        (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle
-      )
+        ((EntranceWindowRadius + PatrolAreaHiLimit) ⨱ plateScale).toAngle,
+        ((EntranceWindowRadius * Two) ⨱ plateScale).toAngle
+      )↗  paLimitOffset
 
-    (((upperPA ↗ upperPAOffset) ∪ (lowerPA ↗ lowerPAOffset)) ∩ ew ) ∩ (paLimit ↗ paLimitOffset)
+    ((upperPA ∪ lowerPA) ∩ ew) ∩ paLimit
   }
 
   /**

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
@@ -1,0 +1,172 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom.f2
+
+import cats.syntax.all.*
+import coulomb.*
+import coulomb.conversion.UnitConversion
+import coulomb.policy.spire.standard.given
+import coulomb.syntax.*
+import coulomb.units.accepted.*
+import coulomb.units.si.prefixes.*
+import lucuma.core.enums.F2LyotWheel
+import lucuma.core.enums.PortDisposition
+import lucuma.core.geom.*
+import lucuma.core.geom.syntax.all.*
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.int.*
+import lucuma.core.math.units.*
+import spire.std.bigDecimal.*
+
+// import scala.language.implicitConversions
+
+/**
+  * F2 area that could be reachable by the patrol arm
+  * https://www.gemini.edu/instrumentation/flamingos-2/capability
+  */
+trait F2PatrolField {
+            // Although normally this function only returns flips and offsets, I'm going to do the scaling to the LyotWheel plate scale here
+            // final Flamingos2 f2 = (Flamingos2) ctx.getInstrument();
+            // final double plateScale = f2.getLyotWheel().getPlateScale();
+            // final AffineTransform xform = AffineTransform.getScaleInstance(plateScale, plateScale);
+            //
+            // // Flip it for the port?
+            // // Validate(ctx.getAoComponent() == null) -> getFlipConfig(false)
+            // final boolean flip = f2.getFlipConfig(false);
+            // if (flip) {
+            //     //Flip in X only
+            //     xform.concatenate(AffineTransform.getScaleInstance(-1.0, 1.0));
+            // }
+            //
+            // final int sign = flip ? -1 : 1;
+            // final double rotationAngleInRadians = f2.getRotationConfig(false).toRadians().getMagnitude();
+            // final AffineTransform rotateForPortAndFlip = AffineTransform.getRotateInstance(rotationAngleInRadians * sign);
+            // xform.concatenate(rotateForPortAndFlip);
+            //
+            // // Apply complete transform
+            // return new Some<>(new PatrolField(xform.createTransformedShape(getPatrolField().getArea())));
+
+
+  /**
+    * GMOS area where the probe arm can reach centered at 0
+    */
+  def candidatesArea: ShapeExpression =
+    // 4.9 arcmin radius
+    // NOTE There is some debate on whether this should be 4.8
+    ShapeExpression.centeredEllipse((4.9 * 60 * 2).toInt.arcsec,
+                                    (4.9 * 60 * 2).toInt.arcsec
+    )
+
+  /**
+    * GMOS area where the probe arm can reach centered with a given posAngle and offset
+    */
+  def candidatesAreaAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
+    candidatesArea ↗ offsetPos ⟲ posAngle
+
+  /**
+    * GMOS area reachable by the problem arm for a set of posAngles and offsets
+    */
+  def candidatesAreaAt(posAngles: List[Angle], offsetPositions: List[Offset]): ShapeExpression =
+    (for {
+      a <- posAngles
+      o <- offsetPositions
+    } yield candidatesAreaAt(a, o)).fold(ShapeExpression.Empty)(_ ∪ _)
+
+    //
+    // static{
+    //     // define the "upper" and "lower" half-circles defining the patrol are
+    //     // -- use full circle for upper smaller one (using only half circle for upper part of figure can
+    //     // -- end in two disjoint areas due to calculation imprecisions, we have to make sure areas overlap
+    //     // -- properly to yield the figure we want).
+    //     Ellipse2D.Double upperPa = new Ellipse2D.Double(
+    //             PICK_OFF_PIVOT_POINT - UPPER_PATROL_AREA_RADIUS, -UPPER_PATROL_AREA_RADIUS,
+    //             UPPER_PATROL_AREA_RADIUS*2., UPPER_PATROL_AREA_RADIUS*2.);
+    //     // -- and combine with lower half-circle of bigger one
+    //     Arc2D.Double lowerPA = new Arc2D.Double(
+    //             BASE_PIVOT_POINT - LOWER_PATROL_AREA_RADIUS, -LOWER_PATROL_AREA_RADIUS,
+    //             LOWER_PATROL_AREA_RADIUS*2., LOWER_PATROL_AREA_RADIUS*2.,
+    //             180, 180, Arc2D.CHORD);
+    //
+    //     // define the two bounding shapes (one circle and a box)
+    //     Ellipse2D.Double ew = new Ellipse2D.Double(
+    //             -ENTRANCE_WINDOW_RADIUS, -ENTRANCE_WINDOW_RADIUS,
+    //             ENTRANCE_WINDOW_RADIUS*2., ENTRANCE_WINDOW_RADIUS*2.0);
+    //
+    //     Rectangle2D.Double paLimit = new Rectangle2D.Double(
+    //             -ENTRANCE_WINDOW_RADIUS, -ENTRANCE_WINDOW_RADIUS,
+    //             ENTRANCE_WINDOW_RADIUS+PATROL_AREA_HI_LIMIT, 2*ENTRANCE_WINDOW_RADIUS);
+    //
+    //     // combination of lower and upper patrol areas (two half-circles)...
+    //     Area pfArea = new Area(upperPa);
+    //     pfArea.add(new Area(lowerPA));
+    //     // .. intersected with bounding areas gives the patrol field
+    //     pfArea.intersect(new Area(ew));
+    //     pfArea.intersect(new Area(paLimit));
+    //
+    //     // there we go...
+    //     patrolField = new PatrolField(pfArea);
+    // }
+
+  /**
+    * F2 patrol field shape centered at the base position.
+    */
+  def patrolField(plateScale: Quantity[BigDecimal, ArcSecondPerMillimeter]): ShapeExpression =
+    // define the "upper" and "lower" half-circles defining the patrol are
+    // -- use full circle for upper smaller one (using only half circle for upper part of figure can
+    // -- end in two disjoint areas due to calculation imprecisions, we have to make sure areas overlap
+    // -- properly to yield the figure we want).
+    val Two = BigDecimal(2)
+    println( (UpperPatrolAreaRadius).withPlateScale(plateScale).toAngle.toMicroarcseconds / 1e6)
+    val pfOffset = (PickOffPivotPoint, UpperPatrolAreaRadius * Two).withPlateScale(plateScale)
+    val upperPA = ShapeExpression.centeredEllipse(
+                (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
+                (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle)
+                // (UpperPatrolAreaRadius*Two, UpperPatrolAreaRadius*Two).withPlateScale(plateScale))
+
+    val lowerPA = ShapeExpression.ellipseAt(
+                (BasePivotPoint - LowerPatrolAreaRadius, -LowerPatrolAreaRadius).withPlateScale(plateScale),
+                (LowerPatrolAreaRadius*Two, LowerPatrolAreaRadius*Two).withPlateScale(plateScale))
+
+    // val i: Int = EntranceWindowRadius*Two
+    // define the two bounding shapes (one circle and a box)
+    val ew = ShapeExpression.ellipseAt(
+                (-EntranceWindowRadius, -EntranceWindowRadius).withPlateScale(plateScale),
+                (EntranceWindowRadius*Two, EntranceWindowRadius*Two).withPlateScale(plateScale))
+    val paLimit = ShapeExpression.rectangleAt(
+                (-EntranceWindowRadius, -EntranceWindowRadius).withPlateScale(plateScale),
+                (EntranceWindowRadius + PatrolAreaHiLimit, EntranceWindowRadius * Two).withPlateScale(plateScale))
+
+    ((upperPA ∪ lowerPA) ∩ ew) ∩ paLimit
+    println(pfOffset)
+    upperPA ↗ Offset(pfOffset._1, pfOffset._2)
+
+
+  /**
+    * F2 patrol field shape, in context.
+    *
+    * @param posAngle position angle where positive is counterclockwise
+    * @param offsetPos offset position from the base, if any
+    * @param fpu focal plane unit, if any
+    * @param port port disposition
+    *
+    * @return probe field shape rotated and offset
+    */
+  def patrolFieldAt(
+    posAngle:  Angle,
+    offsetPos: Offset,
+    lyotWheel: F2LyotWheel,
+    // fpu:       Option[Either[GmosNorthFpu, GmosSouthFpu]],
+    port:      PortDisposition
+  ): ShapeExpression = {
+    val plateScale = BigDecimal(lyotWheel.plateScale).withUnit[ArcSecondPerMillimeter]
+    // val pf = patrolField ↗ (ifuOffset(fpu) - Offset(94950.mas.p, 89880.mas.q))
+    val pf = patrolField(plateScale) // ↗ (ifuOffset(fpu) - Offset(94950.mas.p, 89880.mas.q))
+    val s  = if (port === PortDisposition.Side) pf.flipQ else pf
+    s ↗ offsetPos ⟲ posAngle
+  }
+
+}
+
+object patrolField extends F2PatrolField

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
@@ -30,7 +30,7 @@ trait F2PatrolField:
   /**
     * F2 patrol field shape centered at the base position.
     */
-  def patrolField(plateScale: F2PlateScale): ShapeExpression =
+  def patrolField(plateScale: F2PlateScale): ShapeExpression = {
     // define the "upper" and "lower" half-circles defining the patrol are
     // -- use full circle for upper smaller one (using only half circle for upper part of figure can
     // -- end in two disjoint areas due to calculation imprecisions, we have to make sure areas overlap
@@ -68,6 +68,7 @@ trait F2PatrolField:
       )
 
     (((upperPA ↗ upperPAOffset) ∪ (lowerPA ↗ lowerPAOffset)) ∩ ew ) ∩ (paLimit ↗ paLimitOffset)
+  }
 
   /**
     * F2 patrol field shape, in context.
@@ -84,11 +85,10 @@ trait F2PatrolField:
     offsetPos: Offset,
     lyotWheel: F2LyotWheel,
     port:      PortDisposition
-  ): ShapeExpression = {
+  ): ShapeExpression =
     val plateScale = BigDecimal(lyotWheel.plateScale).withUnit[ArcSecondPerMillimeter]
     val pf = patrolField(plateScale)
     val s  = if (port === PortDisposition.Bottom) pf.flipP else pf
     s ↗ offsetPos ⟲ posAngle
-  }
 
 object patrolField extends F2PatrolField

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
@@ -16,42 +16,16 @@ import lucuma.core.geom.*
 import lucuma.core.geom.syntax.all.*
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
-import lucuma.core.math.syntax.int.*
 import lucuma.core.math.units.*
 import spire.std.bigDecimal.*
-
-// import scala.language.implicitConversions
 
 /**
   * F2 area that could be reachable by the patrol arm
   * https://www.gemini.edu/instrumentation/flamingos-2/capability
   */
-trait F2PatrolField {
-
-  /**
-    * GMOS area where the probe arm can reach centered at 0
-    */
-  def candidatesArea: ShapeExpression =
-    // 4.9 arcmin radius
-    // NOTE There is some debate on whether this should be 4.8
-    ShapeExpression.centeredEllipse((4.9 * 60 * 2).toInt.arcsec,
-                                    (4.9 * 60 * 2).toInt.arcsec
-    )
-
-  /**
-    * GMOS area where the probe arm can reach centered with a given posAngle and offset
-    */
-  def candidatesAreaAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
-    candidatesArea ↗ offsetPos ⟲ posAngle
-
-  /**
-    * GMOS area reachable by the problem arm for a set of posAngles and offsets
-    */
-  def candidatesAreaAt(posAngles: List[Angle], offsetPositions: List[Offset]): ShapeExpression =
-    (for {
-      a <- posAngles
-      o <- offsetPositions
-    } yield candidatesAreaAt(a, o)).fold(ShapeExpression.Empty)(_ ∪ _)
+trait F2PatrolField:
+  val Two = BigDecimal(2)
+  val ZeroM = BigDecimal(0).withUnit[Micrometer]
 
   /**
     * F2 patrol field shape centered at the base position.
@@ -61,30 +35,37 @@ trait F2PatrolField {
     // -- use full circle for upper smaller one (using only half circle for upper part of figure can
     // -- end in two disjoint areas due to calculation imprecisions, we have to make sure areas overlap
     // -- properly to yield the figure we want).
-    val Two = BigDecimal(2)
-    val ZeroM = BigDecimal(0).withUnit[Micrometer]
     val upperPAOffset = (-PickOffPivotPoint, ZeroM).withPlateScaleOffset(plateScale)
-    val upperPA = ShapeExpression.centeredEllipse(
-                (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
-                (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle)
+    val upperPA =
+      ShapeExpression.centeredEllipse(
+        (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
+        (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle
+      )
 
     val lowerPAOffset = (-BasePivotPoint, ZeroM).withPlateScaleOffset(plateScale)
-    val lowerPA = ShapeExpression.centeredClosedArc(
-                (LowerPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
-                (LowerPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
-                Angle.Angle0,
-                Angle.Angle180)
+    val lowerPA =
+      ShapeExpression.centeredClosedArc(
+        (LowerPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
+        (LowerPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
+        Angle.Angle0,
+        Angle.Angle180
+      )
 
     // define the two bounding shapes (one circle and a box)
-    val ew = ShapeExpression.centeredEllipse(
-                (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle,
-                (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle
-              )
+    val ew =
+      ShapeExpression.centeredEllipse(
+        (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle,
+        (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle
+      )
 
-    val paLimitOffset = ((EntranceWindowRadius - PatrolAreaHiLimit), ZeroM).withPlateScaleOffset(plateScale)
-    val paLimit = ShapeExpression.centeredRectangle(
-                (EntranceWindowRadius + PatrolAreaHiLimit).withPlateScale(plateScale).toAngle,
-                  (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle)
+    val paLimitOffset =
+      ((EntranceWindowRadius-PatrolAreaHiLimit)/2, ZeroM).withPlateScaleOffset(plateScale)
+
+    val paLimit =
+      ShapeExpression.centeredRectangle(
+        (EntranceWindowRadius + PatrolAreaHiLimit).withPlateScale(plateScale).toAngle,
+        (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle
+      )
 
     (((upperPA ↗ upperPAOffset) ∪ (lowerPA ↗ lowerPAOffset)) ∩ ew ) ∩ (paLimit ↗ paLimitOffset)
 
@@ -93,7 +74,7 @@ trait F2PatrolField {
     *
     * @param posAngle position angle where positive is counterclockwise
     * @param offsetPos offset position from the base, if any
-    * @param fpu focal plane unit, if any
+    * @param lyot Lyot Wheel position, to get the plate scale
     * @param port port disposition
     *
     * @return probe field shape rotated and offset
@@ -106,10 +87,8 @@ trait F2PatrolField {
   ): ShapeExpression = {
     val plateScale = BigDecimal(lyotWheel.plateScale).withUnit[ArcSecondPerMillimeter]
     val pf = patrolField(plateScale)
-    val s  = if (port === PortDisposition.Side) pf.flipQ else pf
+    val s  = if (port === PortDisposition.Bottom) pf.flipP else pf
     s ↗ offsetPos ⟲ posAngle
   }
-
-}
 
 object patrolField extends F2PatrolField

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
@@ -56,7 +56,7 @@ trait F2PatrolField {
   /**
     * F2 patrol field shape centered at the base position.
     */
-  def patrolField(plateScale: Quantity[BigDecimal, ArcSecondPerMillimeter]): ShapeExpression =
+  def patrolField(plateScale: F2PlateScale): ShapeExpression =
     // define the "upper" and "lower" half-circles defining the patrol are
     // -- use full circle for upper smaller one (using only half circle for upper part of figure can
     // -- end in two disjoint areas due to calculation imprecisions, we have to make sure areas overlap

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2PatrolField.scala
@@ -27,27 +27,6 @@ import spire.std.bigDecimal.*
   * https://www.gemini.edu/instrumentation/flamingos-2/capability
   */
 trait F2PatrolField {
-            // Although normally this function only returns flips and offsets, I'm going to do the scaling to the LyotWheel plate scale here
-            // final Flamingos2 f2 = (Flamingos2) ctx.getInstrument();
-            // final double plateScale = f2.getLyotWheel().getPlateScale();
-            // final AffineTransform xform = AffineTransform.getScaleInstance(plateScale, plateScale);
-            //
-            // // Flip it for the port?
-            // // Validate(ctx.getAoComponent() == null) -> getFlipConfig(false)
-            // final boolean flip = f2.getFlipConfig(false);
-            // if (flip) {
-            //     //Flip in X only
-            //     xform.concatenate(AffineTransform.getScaleInstance(-1.0, 1.0));
-            // }
-            //
-            // final int sign = flip ? -1 : 1;
-            // final double rotationAngleInRadians = f2.getRotationConfig(false).toRadians().getMagnitude();
-            // final AffineTransform rotateForPortAndFlip = AffineTransform.getRotateInstance(rotationAngleInRadians * sign);
-            // xform.concatenate(rotateForPortAndFlip);
-            //
-            // // Apply complete transform
-            // return new Some<>(new PatrolField(xform.createTransformedShape(getPatrolField().getArea())));
-
 
   /**
     * GMOS area where the probe arm can reach centered at 0
@@ -74,41 +53,6 @@ trait F2PatrolField {
       o <- offsetPositions
     } yield candidatesAreaAt(a, o)).fold(ShapeExpression.Empty)(_ ∪ _)
 
-    //
-    // static{
-    //     // define the "upper" and "lower" half-circles defining the patrol are
-    //     // -- use full circle for upper smaller one (using only half circle for upper part of figure can
-    //     // -- end in two disjoint areas due to calculation imprecisions, we have to make sure areas overlap
-    //     // -- properly to yield the figure we want).
-    //     Ellipse2D.Double upperPa = new Ellipse2D.Double(
-    //             PICK_OFF_PIVOT_POINT - UPPER_PATROL_AREA_RADIUS, -UPPER_PATROL_AREA_RADIUS,
-    //             UPPER_PATROL_AREA_RADIUS*2., UPPER_PATROL_AREA_RADIUS*2.);
-    //     // -- and combine with lower half-circle of bigger one
-    //     Arc2D.Double lowerPA = new Arc2D.Double(
-    //             BASE_PIVOT_POINT - LOWER_PATROL_AREA_RADIUS, -LOWER_PATROL_AREA_RADIUS,
-    //             LOWER_PATROL_AREA_RADIUS*2., LOWER_PATROL_AREA_RADIUS*2.,
-    //             180, 180, Arc2D.CHORD);
-    //
-    //     // define the two bounding shapes (one circle and a box)
-    //     Ellipse2D.Double ew = new Ellipse2D.Double(
-    //             -ENTRANCE_WINDOW_RADIUS, -ENTRANCE_WINDOW_RADIUS,
-    //             ENTRANCE_WINDOW_RADIUS*2., ENTRANCE_WINDOW_RADIUS*2.0);
-    //
-    //     Rectangle2D.Double paLimit = new Rectangle2D.Double(
-    //             -ENTRANCE_WINDOW_RADIUS, -ENTRANCE_WINDOW_RADIUS,
-    //             ENTRANCE_WINDOW_RADIUS+PATROL_AREA_HI_LIMIT, 2*ENTRANCE_WINDOW_RADIUS);
-    //
-    //     // combination of lower and upper patrol areas (two half-circles)...
-    //     Area pfArea = new Area(upperPa);
-    //     pfArea.add(new Area(lowerPA));
-    //     // .. intersected with bounding areas gives the patrol field
-    //     pfArea.intersect(new Area(ew));
-    //     pfArea.intersect(new Area(paLimit));
-    //
-    //     // there we go...
-    //     patrolField = new PatrolField(pfArea);
-    // }
-
   /**
     * F2 patrol field shape centered at the base position.
     */
@@ -118,30 +62,31 @@ trait F2PatrolField {
     // -- end in two disjoint areas due to calculation imprecisions, we have to make sure areas overlap
     // -- properly to yield the figure we want).
     val Two = BigDecimal(2)
-    println( (UpperPatrolAreaRadius).withPlateScale(plateScale).toAngle.toMicroarcseconds / 1e6)
-    val pfOffset = (PickOffPivotPoint, UpperPatrolAreaRadius * Two).withPlateScale(plateScale)
+    val ZeroM = BigDecimal(0).withUnit[Micrometer]
+    val upperPAOffset = (-PickOffPivotPoint, ZeroM).withPlateScaleOffset(plateScale)
     val upperPA = ShapeExpression.centeredEllipse(
                 (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
                 (UpperPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle)
-                // (UpperPatrolAreaRadius*Two, UpperPatrolAreaRadius*Two).withPlateScale(plateScale))
 
-    val lowerPA = ShapeExpression.ellipseAt(
-                (BasePivotPoint - LowerPatrolAreaRadius, -LowerPatrolAreaRadius).withPlateScale(plateScale),
-                (LowerPatrolAreaRadius*Two, LowerPatrolAreaRadius*Two).withPlateScale(plateScale))
+    val lowerPAOffset = (-BasePivotPoint, ZeroM).withPlateScaleOffset(plateScale)
+    val lowerPA = ShapeExpression.centeredClosedArc(
+                (LowerPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
+                (LowerPatrolAreaRadius * Two).withPlateScale(plateScale).toAngle,
+                Angle.Angle0,
+                Angle.Angle180)
 
-    // val i: Int = EntranceWindowRadius*Two
     // define the two bounding shapes (one circle and a box)
-    val ew = ShapeExpression.ellipseAt(
-                (-EntranceWindowRadius, -EntranceWindowRadius).withPlateScale(plateScale),
-                (EntranceWindowRadius*Two, EntranceWindowRadius*Two).withPlateScale(plateScale))
-    val paLimit = ShapeExpression.rectangleAt(
-                (-EntranceWindowRadius, -EntranceWindowRadius).withPlateScale(plateScale),
-                (EntranceWindowRadius + PatrolAreaHiLimit, EntranceWindowRadius * Two).withPlateScale(plateScale))
+    val ew = ShapeExpression.centeredEllipse(
+                (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle,
+                (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle
+              )
 
-    ((upperPA ∪ lowerPA) ∩ ew) ∩ paLimit
-    println(pfOffset)
-    upperPA ↗ Offset(pfOffset._1, pfOffset._2)
+    val paLimitOffset = ((EntranceWindowRadius - PatrolAreaHiLimit), ZeroM).withPlateScaleOffset(plateScale)
+    val paLimit = ShapeExpression.centeredRectangle(
+                (EntranceWindowRadius + PatrolAreaHiLimit).withPlateScale(plateScale).toAngle,
+                  (EntranceWindowRadius * Two).withPlateScale(plateScale).toAngle)
 
+    (((upperPA ↗ upperPAOffset) ∪ (lowerPA ↗ lowerPAOffset)) ∩ ew ) ∩ (paLimit ↗ paLimitOffset)
 
   /**
     * F2 patrol field shape, in context.
@@ -157,12 +102,10 @@ trait F2PatrolField {
     posAngle:  Angle,
     offsetPos: Offset,
     lyotWheel: F2LyotWheel,
-    // fpu:       Option[Either[GmosNorthFpu, GmosSouthFpu]],
     port:      PortDisposition
   ): ShapeExpression = {
     val plateScale = BigDecimal(lyotWheel.plateScale).withUnit[ArcSecondPerMillimeter]
-    // val pf = patrolField ↗ (ifuOffset(fpu) - Offset(94950.mas.p, 89880.mas.q))
-    val pf = patrolField(plateScale) // ↗ (ifuOffset(fpu) - Offset(94950.mas.p, 89880.mas.q))
+    val pf = patrolField(plateScale)
     val s  = if (port === PortDisposition.Side) pf.flipQ else pf
     s ↗ offsetPos ⟲ posAngle
   }

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2ScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2ScienceAreaGeometry.scala
@@ -1,0 +1,113 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom.f2
+
+import coulomb.*
+import coulomb.policy.spire.standard.given
+import coulomb.syntax.*
+import coulomb.units.accepted.*
+import coulomb.units.si.prefixes.*
+import lucuma.core.enums.F2Fpu
+import lucuma.core.enums.F2LyotWheel
+import lucuma.core.geom.*
+import lucuma.core.geom.syntax.all.*
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import lucuma.core.math.units.*
+import spire.math.*
+import spire.std.bigDecimal.*
+
+/**
+  * F2 science area geometry.
+  */
+trait F2ScienceAreaGeometry {
+
+  // base target
+  def base: ShapeExpression =
+    ShapeExpression.point(Offset.Zero)
+
+  def pointAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
+    base ↗ offsetPos ⟲ posAngle
+
+
+  def scienceAreaDimensions(lyotWheel: F2LyotWheel, fpu: Option[F2Fpu]):
+    (Angle, Angle) =
+    lyotWheel match {
+      case F2LyotWheel.F16 | F2LyotWheel.F32High | F2LyotWheel.F32Low =>
+        val pixelScale = lyotWheel.pixelScale
+        val plateScale = BigDecimal(lyotWheel.plateScale).withUnit[ArcSecondPerMillimeter]
+        fpu match {
+          case None | Some(F2Fpu.Pinhole) | Some(F2Fpu.SubPixPinhole) =>
+            val size = ImagingFOVSize.withPlateScale(plateScale)
+            (size.toAngle, size.toAngle)
+          case Some(fpu) =>
+            (Angle.fromBigDecimalArcseconds(fpu.slitWidth * pixelScale),
+             LongSlitFOVHeight.withPlateScale(plateScale).toAngle)
+        }
+      case _ => (Angle.Angle0, Angle.Angle0)
+    }
+
+  def shapeAt(
+    posAngle:  Angle,
+    offsetPos: Offset,
+    lyotWheel: F2LyotWheel,
+    fpu:       Option[F2Fpu]
+  ): ShapeExpression =
+    val plateScale = BigDecimal(lyotWheel.plateScale).withUnit[ArcSecondPerMillimeter]
+    val scienceAreaWidth = scienceAreaDimensions(lyotWheel, fpu)._1
+    val shape = fpu match {
+      case None => imaging(plateScale)
+      // case _    => mosFOV(plateScale) // TODO: handle MOS
+      case Some(fpu)    => longslit(plateScale, scienceAreaWidth)
+    }
+    shape ↗ offsetPos ⟲ posAngle
+
+  /**
+   * Create the F2 imaging field of view.
+   * @param plateScale the plate scale in arcsec/mm
+   * @return           a shape representing the FOV
+   */
+  private def imaging(plateScale: Quantity[BigDecimal, ArcSecondPerMillimeter]): ShapeExpression = {
+    val size: Quantity[BigDecimal, ArcSecond]   = ImagingFOVSize.toUnit[Millimeter] * plateScale
+    val radius = size / 2.0
+    ShapeExpression.centeredEllipse(-radius.toAngle, size.toAngle)
+  }
+
+  /**
+   * Create the F2 MOS field of view shape.
+   * @param plateScale the plate scale in arcsec/mm
+   * @return           a shape representing the FOV
+   */
+  def mos(plateScale: Quantity[BigDecimal, ArcSecondPerMillimeter]): ShapeExpression = {
+    val width  = MOSFOVWidth * plateScale
+    val height = ImagingFOVSize * plateScale
+    val radius = height / 2.0
+
+    // The FOV is the intersection of a rectangle and a circle.
+    val circle = ShapeExpression.centeredEllipse(-radius.toAngle, height.toAngle)
+    val rectangle = ShapeExpression.rectangleAt((-width.toAngle.bisect.p, -radius.toAngle.q), (width.toAngle.p, height.toAngle.q))
+    circle ∩ rectangle
+  }
+
+  /**
+   * Create the F2 long slit field of view shape.
+   * @param plateScale       the plate scale in arcsec/mm
+   * @param pixelScale       the pixel scale in arcsec/pixel, slit width is expressed in pixels
+   * @param scienceAreaWidth the width of the science area for the F2 configuration
+   * @return                 a shape representing the FOV
+   */
+  private def longslit(
+    plateScale: Quantity[BigDecimal, ArcSecondPerMillimeter],
+    scienceAreaWidth: Angle
+  ): ShapeExpression = {
+    val slitHeight = LongSlitFOVHeight.withPlateScale(plateScale)
+    val y          = -LongSlitFOVNorthPos.withPlateScale(plateScale)
+
+    ShapeExpression.centeredRectangle(scienceAreaWidth, slitHeight.toAngle) ↗ Offset.Zero.copy(q = y.toAngle.q)
+  }
+
+}
+
+object scienceArea extends F2ScienceAreaGeometry
+

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2ScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2ScienceAreaGeometry.scala
@@ -39,7 +39,7 @@ trait F2ScienceAreaGeometry:
           case Some(fpu)                                              =>
             (Angle.fromBigDecimalArcseconds(fpu.slitWidth * pixelScale),
              LongSlitFOVHeight.withPlateScale(plateScale).toAngle)
-      case _                                                          => 
+      case _                                                          =>
         (Angle.Angle0, Angle.Angle0)
 
   def shapeAt(
@@ -70,15 +70,18 @@ trait F2ScienceAreaGeometry:
    * @param plateScale the plate scale in arcsec/mm
    * @return           a shape representing the FOV
    */
-  def mos(plateScale: F2PlateScale): ShapeExpression =
-    val width  = MOSFOVWidth * plateScale
-    val height = ImagingFOVSize * plateScale
-    val radius = height / 2.0
-
-    // The FOV is the intersection of a rectangle and a circle.
-    val circle = ShapeExpression.centeredEllipse(-radius.toAngle, height.toAngle)
-    val rectangle = ShapeExpression.rectangleAt((-width.toAngle.bisect.p, -radius.toAngle.q), (width.toAngle.p, height.toAngle.q))
-    circle ∩ rectangle
+  // def mos(plateScale: F2PlateScale): ShapeExpression = {
+  //   // TODO Implement, the logic comes from the ocs but there is no current way to set MOS in the model
+  //   https://github.com/gemini-hlsw/ocs/blob/develop/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2ScienceAreaGeometry.scala#L67
+  //   val width  = MOSFOVWidth * plateScale
+  //   val height = ImagingFOVSize * plateScale
+  //   val radius = height / 2.0
+  //
+  //   // The FOV is the intersection of a rectangle and a circle.
+  //   val circle = ShapeExpression.centeredEllipse(-radius.toAngle, height.toAngle)
+  //   val rectangle = ShapeExpression.rectangleAt((-width.toAngle.bisect.p, -radius.toAngle.q), (width.toAngle.p, height.toAngle.q))
+  //   circle ∩ rectangle
+  // }
 
   /**
    * Create the F2 long slit field of view shape.
@@ -91,7 +94,7 @@ trait F2ScienceAreaGeometry:
     scienceAreaWidth: Angle
   ): ShapeExpression =
     val slitHeight = LongSlitFOVHeight.withPlateScale(plateScale)
-    val y          = -LongSlitFOVNorthPos.withPlateScale(plateScale)
+    val y          = (-LongSlitFOVNorthPos / 2).withPlateScale(plateScale)
 
     ShapeExpression.centeredRectangle(scienceAreaWidth, slitHeight.toAngle) ↗ Offset.Zero.copy(q = y.toAngle.q)
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2ScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2ScienceAreaGeometry.scala
@@ -34,11 +34,11 @@ trait F2ScienceAreaGeometry:
         val plateScale = BigDecimal(lyotWheel.plateScale).withUnit[ArcSecondPerMillimeter]
         fpu match
           case None | Some(F2Fpu.Pinhole) | Some(F2Fpu.SubPixPinhole) =>
-            val size = ImagingFOVSize.withPlateScale(plateScale)
+            val size = ImagingFOVSize ⨱ plateScale
             (size.toAngle, size.toAngle)
           case Some(fpu)                                              =>
             (Angle.fromBigDecimalArcseconds(fpu.slitWidth * pixelScale),
-             LongSlitFOVHeight.withPlateScale(plateScale).toAngle)
+              (LongSlitFOVHeight ⨱ plateScale).toAngle)
       case _                                                          =>
         (Angle.Angle0, Angle.Angle0)
 
@@ -62,7 +62,7 @@ trait F2ScienceAreaGeometry:
    * @return           a shape representing the FOV
    */
   private def imaging(plateScale: F2PlateScale): ShapeExpression =
-    val size = ImagingFOVSize.withPlateScale(plateScale)
+    val size = ImagingFOVSize ⨱ plateScale
     ShapeExpression.centeredEllipse(size.toAngle, size.toAngle)
 
   /**
@@ -93,8 +93,8 @@ trait F2ScienceAreaGeometry:
     plateScale: F2PlateScale,
     scienceAreaWidth: Angle
   ): ShapeExpression =
-    val slitHeight = LongSlitFOVHeight.withPlateScale(plateScale)
-    val y          = (-LongSlitFOVNorthPos / 2).withPlateScale(plateScale)
+    val slitHeight = LongSlitFOVHeight ⨱ plateScale
+    val y          = (-LongSlitFOVNorthPos / 2) ⨱ plateScale
 
     ShapeExpression.centeredRectangle(scienceAreaWidth, slitHeight.toAngle) ↗ Offset.Zero.copy(q = y.toAngle.q)
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2ScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/F2ScienceAreaGeometry.scala
@@ -27,10 +27,6 @@ trait F2ScienceAreaGeometry {
   def base: ShapeExpression =
     ShapeExpression.point(Offset.Zero)
 
-  def pointAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
-    base ↗ offsetPos ⟲ posAngle
-
-
   def scienceAreaDimensions(lyotWheel: F2LyotWheel, fpu: Option[F2Fpu]):
     (Angle, Angle) =
     lyotWheel match {
@@ -68,7 +64,7 @@ trait F2ScienceAreaGeometry {
    * @param plateScale the plate scale in arcsec/mm
    * @return           a shape representing the FOV
    */
-  private def imaging(plateScale: Quantity[BigDecimal, ArcSecondPerMillimeter]): ShapeExpression = {
+  private def imaging(plateScale: F2PlateScale): ShapeExpression = {
     val size: Quantity[BigDecimal, ArcSecond]   = ImagingFOVSize.toUnit[Millimeter] * plateScale
     val radius = size / 2.0
     ShapeExpression.centeredEllipse(-radius.toAngle, size.toAngle)
@@ -79,7 +75,7 @@ trait F2ScienceAreaGeometry {
    * @param plateScale the plate scale in arcsec/mm
    * @return           a shape representing the FOV
    */
-  def mos(plateScale: Quantity[BigDecimal, ArcSecondPerMillimeter]): ShapeExpression = {
+  def mos(plateScale: F2PlateScale): ShapeExpression = {
     val width  = MOSFOVWidth * plateScale
     val height = ImagingFOVSize * plateScale
     val radius = height / 2.0
@@ -93,12 +89,11 @@ trait F2ScienceAreaGeometry {
   /**
    * Create the F2 long slit field of view shape.
    * @param plateScale       the plate scale in arcsec/mm
-   * @param pixelScale       the pixel scale in arcsec/pixel, slit width is expressed in pixels
    * @param scienceAreaWidth the width of the science area for the F2 configuration
    * @return                 a shape representing the FOV
    */
   private def longslit(
-    plateScale: Quantity[BigDecimal, ArcSecondPerMillimeter],
+    plateScale: F2PlateScale,
     scienceAreaWidth: Angle
   ): ShapeExpression = {
     val slitHeight = LongSlitFOVHeight.withPlateScale(plateScale)

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/package.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom.f2
+
+import coulomb.*
+import coulomb.policy.spire.standard.given
+import coulomb.syntax.*
+import coulomb.units.accepted.*
+import coulomb.units.si.prefixes.*
+import lucuma.core.math.syntax.int.*
+import lucuma.core.math.units.Micrometer
+import spire.std.bigDecimal.*
+
+// Size of probe arm components in mm.
+val PickoffMirrorSize          = 19.8
+val ProbePickoffArmTotalLength = 203.40
+val ProbeBaseArmLength         = 109.63
+val ProbePickoffArmLength      = ProbePickoffArmTotalLength - PickoffMirrorSize/2.0
+val ProbeArmOffset             = 256.87
+
+// Width and length of tapered end of probe arm in arcsec.
+val ProbeArmTaperedWidth       = 15000.mas
+val ProbeArmTaperedLength      = 180000.mas
+
+// Geometry features for F2, in mm.
+val LongSlitFOVHeight   = BigDecimal(164100).withUnit[Micrometer]
+val LongSlitFOVSouthPos = BigDecimal(112000).withUnit[Micrometer]
+val LongSlitFOVNorthPos = BigDecimal(52100).withUnit[Micrometer]
+val ImagingFOVSize      = BigDecimal(230120).withUnit[Micrometer]
+val MOSFOVWidth         = BigDecimal(75160).withUnit[Micrometer]
+
+// The diameter of the circle centered over the base position, in mm
+val EntranceWindowRadius = BigDecimal(139700).withUnit[Micrometer]
+// The offsets of the patrol area circles, in mm
+val BasePivotPoint = BigDecimal(250593.4).withUnit[Micrometer]
+val PickOffPivotPoint = BasePivotPoint - BigDecimal(77665.3).withUnit[Micrometer]
+// The diameter of the upper (smaller) patrol area circle, in mm
+val UpperPatrolAreaRadius = BigDecimal(191028.6).withUnit[Micrometer]
+// The diameter of the lower (larger) patrol area circle, in mm
+val LowerPatrolAreaRadius = BigDecimal(268693.9).withUnit[Micrometer]
+// The high limit of the bounding box to the right
+val PatrolAreaHiLimit = BigDecimal(113000).withUnit[Micrometer]
+
+object all extends F2ScienceAreaGeometry with F2PatrolField
+

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/package.scala
@@ -9,8 +9,8 @@ import coulomb.syntax.*
 import coulomb.units.accepted.*
 import coulomb.units.si.prefixes.*
 import lucuma.core.math.syntax.int.*
-import lucuma.core.math.units.Micrometer
 import lucuma.core.math.units.ArcSecondPerMillimeter
+import lucuma.core.math.units.Micrometer
 import spire.std.bigDecimal.*
 
 // Size of probe arm components in mm.
@@ -32,16 +32,16 @@ val ImagingFOVSize      = BigDecimal(230120).withUnit[Micrometer]
 val MOSFOVWidth         = BigDecimal(75160).withUnit[Micrometer]
 
 // The diameter of the circle centered over the base position, in mm
-val EntranceWindowRadius = BigDecimal(139700).withUnit[Micrometer]
+val EntranceWindowRadius  = BigDecimal(139700).withUnit[Micrometer]
 // The offsets of the patrol area circles, in mm
-val BasePivotPoint = BigDecimal(250593.4).withUnit[Micrometer]
-val PickOffPivotPoint = BasePivotPoint - BigDecimal(77665.3).withUnit[Micrometer]
+val BasePivotPoint        = BigDecimal(250593.4).withUnit[Micrometer]
+val PickOffPivotPoint     = BasePivotPoint - BigDecimal(77665.3).withUnit[Micrometer]
 // The diameter of the upper (smaller) patrol area circle, in mm
 val UpperPatrolAreaRadius = BigDecimal(191028.6).withUnit[Micrometer]
 // The diameter of the lower (larger) patrol area circle, in mm
 val LowerPatrolAreaRadius = BigDecimal(268693.9).withUnit[Micrometer]
 // The high limit of the bounding box to the right
-val PatrolAreaHiLimit = BigDecimal(113000).withUnit[Micrometer]
+val PatrolAreaHiLimit     = BigDecimal(113000).withUnit[Micrometer]
 
 type F2PlateScale = Quantity[BigDecimal, ArcSecondPerMillimeter]
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/f2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/f2/package.scala
@@ -10,14 +10,15 @@ import coulomb.units.accepted.*
 import coulomb.units.si.prefixes.*
 import lucuma.core.math.syntax.int.*
 import lucuma.core.math.units.Micrometer
+import lucuma.core.math.units.ArcSecondPerMillimeter
 import spire.std.bigDecimal.*
 
 // Size of probe arm components in mm.
-val PickoffMirrorSize          = 19.8
-val ProbePickoffArmTotalLength = 203.40
-val ProbeBaseArmLength         = 109.63
+val PickoffMirrorSize          = BigDecimal(19800).withUnit[Micrometer]
+val ProbePickoffArmTotalLength = BigDecimal(203400).withUnit[Micrometer]
+val ProbeBaseArmLength         = BigDecimal(109630).withUnit[Micrometer]
 val ProbePickoffArmLength      = ProbePickoffArmTotalLength - PickoffMirrorSize/2.0
-val ProbeArmOffset             = 256.87
+val ProbeArmOffset             = BigDecimal(256870).withUnit[Micrometer]
 
 // Width and length of tapered end of probe arm in arcsec.
 val ProbeArmTaperedWidth       = 15000.mas
@@ -41,6 +42,8 @@ val UpperPatrolAreaRadius = BigDecimal(191028.6).withUnit[Micrometer]
 val LowerPatrolAreaRadius = BigDecimal(268693.9).withUnit[Micrometer]
 // The high limit of the bounding box to the right
 val PatrolAreaHiLimit = BigDecimal(113000).withUnit[Micrometer]
+
+type F2PlateScale = Quantity[BigDecimal, ArcSecondPerMillimeter]
 
 object all extends F2ScienceAreaGeometry with F2PatrolField
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosCandidatesArea.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosCandidatesArea.scala
@@ -13,7 +13,7 @@ import lucuma.core.math.syntax.int.*
   * GMOS area that could be reachable by the patrol arm
   * https://www.gemini.edu/instrumentation/gmos/capability#Guiding
   */
-trait GmosCandidatesArea {
+trait GmosCandidatesArea:
 
   /**
     * GMOS area where the probe arm can reach centered at 0
@@ -21,8 +21,9 @@ trait GmosCandidatesArea {
   def candidatesArea: ShapeExpression =
     // 4.9 arcmin radius
     // NOTE There is some debate on whether this should be 4.8
-    ShapeExpression.centeredEllipse((4.9 * 60 * 2).toInt.arcsec,
-                                    (4.9 * 60 * 2).toInt.arcsec
+    ShapeExpression.centeredEllipse(
+      (4.9 * 60 * 2).toInt.arcsec,
+      (4.9 * 60 * 2).toInt.arcsec
     )
 
   /**
@@ -38,6 +39,4 @@ trait GmosCandidatesArea {
     (for {
       a <- posAngles
       o <- offsetPositions
-    } yield candidatesAreaAt(a, o)).fold(ShapeExpression.Empty)(_ ∪ _)
-}
-
+    } yield candidatesAreaAt(a, o)).fold(ShapeExpression.Empty)(_ ∩ _)

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShapeInterpreter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShapeInterpreter.scala
@@ -42,19 +42,20 @@ object JtsShapeInterpreter extends ShapeInterpreter {
 
     e match {
       // Constructors
-      case Empty           => EmptyGeometry
-      case Ellipse(a, b)   => safeRectangularBoundedShape(a, b)(_.createEllipse)
-      case Polygon(os)     => safePolygon(os)
-      case Rectangle(a, b) => safeRectangularBoundedShape(a, b)(_.createRectangle)
-      case Point(a)        => a.point
-      case BoundingBox(e) =>
+      case Empty                 => EmptyGeometry
+      case Ellipse(a, b)         => safeRectangularBoundedShape(a, b)(_.createEllipse)
+      case ClosedArc(a, b, c, d) => safeRectangularBoundedShape(a, b)(_.createArcPolygon(c.toDoubleRadians, d.toDoubleRadians))
+      case Polygon(os)           => safePolygon(os)
+      case Rectangle(a, b)       => safeRectangularBoundedShape(a, b)(_.createRectangle)
+      case Point(a)              => a.point
+      case BoundingBox(e)        =>
         val (a, b) = Jts.boundingOffsets(toGeometry(e))
         safeRectangularBoundedShape(a, b)(_.createRectangle)
 
       // Combinations
-      case Difference(a, b)   => toGeometry(a).difference(toGeometry(b))
-      case Intersection(a, b) => toGeometry(a).intersection(toGeometry(b))
-      case Union(a, b)        => toGeometry(a).union(toGeometry(b))
+      case Difference(a, b)      => toGeometry(a).difference(toGeometry(b))
+      case Intersection(a, b)    => toGeometry(a).intersection(toGeometry(b))
+      case Union(a, b)           => toGeometry(a).union(toGeometry(b))
 
       // Transformations
       case FlipP(e)                    =>

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/package.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom
+
+import coulomb.*
+import coulomb.syntax.*
+import lucuma.core.math.units.*
+
+val TelescopePlateScale: Quantity[BigDecimal, ArcSecondPerMillimeter] =
+  BigDecimal(1.611444).withUnit[ArcSecondPerMillimeter]
+

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/ShapeExpression.scala
@@ -178,6 +178,22 @@ trait shapeexpression {
     */
     def centeredEllipse(w: Angle, h: Angle): ShapeExpression =
       Translate(ellipse(w, h), Offset(-w.bisect.p, -h.bisect.q))
+
+    /**
+    * Constructs a closed arc contained in a rectangle of width w and height h with a corner at (0,0) from angle a to angle b.
+    *
+    * @group Constructors
+    */
+    def closedArc(w: Angle, h: Angle, a: Angle, b: Angle): ShapeExpression =
+      ClosedArc(Offset.Zero, Offset(w.p, h.q), a, b)
+
+    /**
+    * Constructs a closed arc contained in a rectangle of width w and height h with a corner at (0,0) from angle a to angle b.
+    *
+    * @group Constructors
+    */
+    def centeredClosedArc(w: Angle, h: Angle, a: Angle, b: Angle): ShapeExpression =
+      Translate(ClosedArc(Offset.Zero, Offset(w.p, h.q), a, b), Offset(-w.bisect.p, -h.bisect.q))
 }
 
 object shapeexpression extends shapeexpression

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
@@ -29,12 +29,22 @@ object all extends shapeexpression:
     def withPlateScale(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): Quantity[BigDecimal, ArcSecond] =
       q.toUnit[Millimeter] * ps
 
+    inline def ⨱(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): Quantity[BigDecimal, ArcSecond] =
+      withPlateScale(ps)
+
   extension[U](q: (Quantity[BigDecimal, U], Quantity[BigDecimal, U]))(using UnitConversion[BigDecimal, U, Millimeter])
     def withPlateScale(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): (Offset.P, Offset.Q) =
       (q._1.withPlateScale(ps).toAngle.p, q._2.withPlateScale(ps).toAngle.q)
 
-    def withPlateScaleOffset(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): Offset =
+    inline def ⨱(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): (Offset.P, Offset.Q) =
+      withPlateScale(ps)
+
+    def offsetWithPlateScale(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): Offset =
       Offset(q._1.withPlateScale(ps).toAngle.p, q._2.withPlateScale(ps).toAngle.q)
+
+    inline def ⤇(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): Offset =
+      offsetWithPlateScale(ps)
+
 
   extension[U](o: Offset)
     def toDoubleArcseconds: (BigDecimal, BigDecimal) =

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
@@ -1,12 +1,38 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.core.geom
+package lucuma.core.geom.syntax
 
-package object syntax {
 
-  // Syntax used in the JTS / JVM implementation only.
+import coulomb.*
+import coulomb.conversion.UnitConversion
+import coulomb.policy.spire.standard.given
+import coulomb.units.accepted.*
+import lucuma.core.geom.*
+import lucuma.core.math.Offset
+import lucuma.core.math.units.*
+import spire.std.bigDecimal.*
 
-  object all extends shapeexpression
+// import scala.language.implicitConversions
 
-}
+// Syntax used in the JTS / JVM implementation only.
+object all extends shapeexpression:
+  extension[U](q: Quantity[BigDecimal, U])(using UnitConversion[BigDecimal, U, Millimeter])
+    def toTelescopePlane: Quantity[BigDecimal, ArcSecond] =
+      q.toUnit[Millimeter] * TelescopePlateScale
+
+  extension[U](q: (Quantity[BigDecimal, U], Quantity[BigDecimal, U]))(using UnitConversion[BigDecimal, U, Millimeter])
+    def toTelescopePlaneOffset: (Offset.P, Offset.Q) =
+      (q._1.toTelescopePlane.toAngle.p, q._2.toTelescopePlane.toAngle.q)
+
+  extension[U](q: Quantity[BigDecimal, U])(using UnitConversion[BigDecimal, U, Millimeter])
+    def withPlateScale(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): Quantity[BigDecimal, ArcSecond] =
+      q.toUnit[Millimeter] * ps
+
+  extension[U](q: (Quantity[BigDecimal, U], Quantity[BigDecimal, U]))(using UnitConversion[BigDecimal, U, Millimeter])
+    def withPlateScale(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): (Offset.P, Offset.Q) =
+      (q._1.withPlateScale(ps).toAngle.p, q._2.withPlateScale(ps).toAngle.q)
+
+    def withPlateScaleOffset(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): Offset =
+      Offset(q._1.withPlateScale(ps).toAngle.p, q._2.withPlateScale(ps).toAngle.q)
+

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
@@ -8,10 +8,12 @@ import coulomb.*
 import coulomb.conversion.UnitConversion
 import coulomb.policy.spire.standard.given
 import coulomb.units.accepted.*
+import coulomb.syntax.*
 import lucuma.core.geom.*
 import lucuma.core.math.Offset
 import lucuma.core.math.units.*
 import spire.std.bigDecimal.*
+import lucuma.core.math.Angle
 
 // import scala.language.implicitConversions
 
@@ -36,3 +38,6 @@ object all extends shapeexpression:
     def withPlateScaleOffset(ps: Quantity[BigDecimal, ArcSecondPerMillimeter]): Offset =
       Offset(q._1.withPlateScale(ps).toAngle.p, q._2.withPlateScale(ps).toAngle.q)
 
+  extension[U](o: Offset)
+    def toDoubleArcseconds: (Quantity[BigDecimal, ArcSecond], Quantity[BigDecimal, ArcSecond]) =
+      (Angle.signedDecimalArcseconds.get(o.p.toAngle).withUnit[ArcSecond], Angle.signedDecimalArcseconds.get(o.q.toAngle).withUnit[ArcSecond])

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
@@ -7,15 +7,13 @@ package lucuma.core.geom.syntax
 import coulomb.*
 import coulomb.conversion.UnitConversion
 import coulomb.policy.spire.standard.given
-import coulomb.units.accepted.*
 import coulomb.syntax.*
+import coulomb.units.accepted.*
 import lucuma.core.geom.*
+import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import lucuma.core.math.units.*
 import spire.std.bigDecimal.*
-import lucuma.core.math.Angle
-
-// import scala.language.implicitConversions
 
 // Syntax used in the JTS / JVM implementation only.
 object all extends shapeexpression:
@@ -39,5 +37,5 @@ object all extends shapeexpression:
       Offset(q._1.withPlateScale(ps).toAngle.p, q._2.withPlateScale(ps).toAngle.q)
 
   extension[U](o: Offset)
-    def toDoubleArcseconds: (Quantity[BigDecimal, ArcSecond], Quantity[BigDecimal, ArcSecond]) =
-      (Angle.signedDecimalArcseconds.get(o.p.toAngle).withUnit[ArcSecond], Angle.signedDecimalArcseconds.get(o.q.toAngle).withUnit[ArcSecond])
+    def toDoubleArcseconds: (BigDecimal, BigDecimal) =
+      (Angle.signedDecimalArcseconds.get(o.p.toAngle), Angle.signedDecimalArcseconds.get(o.q.toAngle))

--- a/modules/core/shared/src/main/scala/lucuma/core/math/units.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/units.scala
@@ -57,15 +57,14 @@ trait units {
   type Year
   given DerivedUnit[Year, 365 * Day, "year", "y"] = DerivedUnit()
 
-  type ArcSecond
-  given DerivedUnit[ArcSecond, Degree / 3600, "arc second", "arcsec"] = DerivedUnit()
-
   type DeciArcSecond  = Deci * ArcSecond
   type MilliArcSecond = Milli * ArcSecond
   type MicroArcSecond = Micro * ArcSecond
 
   type MilliArcSecondPerYear = MilliArcSecond / Year
   type MicroArcSecondPerYear = MicroArcSecond / Year
+
+  type ArcSecondPerMillimeter = ArcSecond / Millimeter
 
   // Integrated Brightness units
   type VegaMagnitude
@@ -165,6 +164,11 @@ trait units {
     }
   }
 
+  extension (q: Quantity[BigDecimal, ArcSecond])
+    inline def toAngle: Angle = Angle.fromBigDecimalArcseconds(q.value)
+
+  extension (c: (Quantity[BigDecimal, ArcSecond], Quantity[BigDecimal, ArcSecond]))
+    inline def toOffset: Offset = Offset(c._1.toAngle.p, c._2.toAngle.q)
 }
 
 object units extends units

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -55,15 +55,14 @@ trait GmosLSShapes extends InstrumentShapes:
 trait F2LSShapes extends InstrumentShapes:
   import lucuma.core.geom.f2.*
 
-  val posAngle: Angle = Angle.Angle0
-    // 30.deg
-    // 145.deg
+  val posAngle: Angle =
+    145.deg
 
   val guideStarOffset: Offset =
     Offset(170543999.µas.p, -24177003.µas.q)
 
-  val offsetPos: Offset = Offset.Zero
-    // Offset(-60.arcsec.p, 60.arcsec.q)
+  val offsetPos: Offset =
+    Offset(-60.arcsec.p, 60.arcsec.q)
 
   val fpu: Option[F2Fpu] = F2Fpu.LongSlit8.some
   val lyot: F2LyotWheel = F2LyotWheel.F16
@@ -104,6 +103,7 @@ class JtsDemo extends Frame("JTS Demo") {
   def canvas(boundingBox: Boolean) = new Canvas {
     setBackground(Color.lightGray)
     setSize(canvasSize, canvasSize)
+    setFocusable(true)
     addKeyListener(new KeyAdapter() {
       override def keyPressed(e: KeyEvent): Unit =
         e.getKeyCode match {

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -72,10 +72,10 @@ trait F2LSShapes extends InstrumentShapes:
 
   val shapes: List[ShapeExpression] =
     List(
-      // probeArm.shapeAt(posAngle, guideStarOffset, offsetPos, fpu, port),
+      ShapeExpression.centeredRectangle(1.arcsec, 1.arcsec).translate(guideStarOffset),
+      probeArm.shapeAt(posAngle, guideStarOffset, offsetPos, lyot, port),
       patrolField.patrolFieldAt(posAngle, offsetPos, lyot, port),
       scienceArea.shapeAt(posAngle, offsetPos, lyot, fpu),
-      // probeArm.candidatesAreaAt(posAngle, offsetPos)
     )
 
 /**
@@ -207,8 +207,7 @@ class JtsDemo extends Frame("JTS Demo") {
         System.exit(0)
     })
 
-    // add(BorderLayout.CENTER, canvas(args.contains("--boxes")))
-    add(BorderLayout.CENTER, canvas(true)) //args.contains("--boxes")))
+    add(BorderLayout.CENTER, canvas(args.contains("--boxes")))
 
     setVisible(true)
   }

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -4,7 +4,6 @@
 package lucuma.core.geom.jts
 package demo
 
-import cats.syntax.all.*
 import lucuma.core.enums.F2Fpu
 import lucuma.core.enums.F2LyotWheel
 import lucuma.core.enums.GmosNorthFpu
@@ -59,20 +58,20 @@ trait F2LSShapes extends InstrumentShapes:
     145.deg
 
   val guideStarOffset: Offset =
-    Offset(170543999.µas.p, -24177003.µas.q)
+    Offset(Angle.fromDoubleDegrees(0.03205404776434761).p, Angle.fromDoubleDegrees(359.995624807521).q)
 
   val offsetPos: Offset =
     Offset(-60.arcsec.p, 60.arcsec.q)
 
-  val fpu: Option[F2Fpu] = F2Fpu.LongSlit8.some
+  val fpu: Option[F2Fpu] = Some(F2Fpu.LongSlit8)
   val lyot: F2LyotWheel = F2LyotWheel.F16
 
   val port: PortDisposition =
-    PortDisposition.Side
+    PortDisposition.Bottom
 
   val shapes: List[ShapeExpression] =
     List(
-      ShapeExpression.centeredRectangle(1.arcsec, 1.arcsec).translate(guideStarOffset),
+      ShapeExpression.centeredRectangle(1.arcsec, 1.arcsec).translate(guideStarOffset), // guide star
       probeArm.shapeAt(posAngle, guideStarOffset, offsetPos, lyot, port),
       patrolField.patrolFieldAt(posAngle, offsetPos, lyot, port),
       scienceArea.shapeAt(posAngle, offsetPos, lyot, fpu),


### PR DESCRIPTION
Here is a port of the ocs geometry to gpp. It includes geometry for:

* science area for imaging and longslit
* Probe arm geometry
* Patrol field geometry

Still missing is MOS support and the candidates area. Some examples comparing OT and gpp

## LongSlit posAngle 145, offset (-60, 60), side port
![f2ot1](https://github.com/user-attachments/assets/5609439b-f756-4155-a032-e40b53cfc8fd)
![f2gpp1](https://github.com/user-attachments/assets/af5a5580-d2b1-4f3a-b159-3b0ca3656a91)

## LongSlit posAngle 145, offset (-60, 60), bottom port
![f2ot4](https://github.com/user-attachments/assets/7ffd93a1-0d02-4ef2-9a7a-ad54c58f88a7)
![f2gpp4](https://github.com/user-attachments/assets/7434853d-6b82-4ca4-b6b8-d0fc4a93a617)

## Imaging posAngle 145, offset (-60, 60), bottom port
![f2ot3](https://github.com/user-attachments/assets/4211591f-241d-4c9c-a6d9-27af78117f26)
![f2gpp3](https://github.com/user-attachments/assets/6f3e71bd-db30-4018-98cf-3b100685c934)
