### PR TITLE
Add support for F2-MOS

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/F2Decker.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/F2Decker.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import cats.syntax.eq.*
+import lucuma.core.util.Enumerated
+
+/**
+ * Enumerated type for Flamingos2 decker option.
+ * @group Enumerations
+ */
+sealed abstract class F2Decker(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object F2Decker {
+
+  /** @group Constructors */ case object Imaging extends F2Decker("Imaging", "Imaging", "Imaging", false)
+  /** @group Constructors */ case object LongSlit extends F2Decker("LongSlit", "Long Slit", "LongSlit", false)
+  /** @group Constructors */ case object MOS extends F2Decker("MOS", "MOS", "MOS", false)
+
+  /** All members of F2Decker, in canonical order. */
+  val all: List[F2Decker] =
+    List(Imaging, LongSlit, MOS)
+
+  /** Select the member of F2Decker with the given tag, if any. */
+  def fromTag(s: String): Option[F2Decker] =
+    all.find(_.tag === s)
+
+  /** Select the member of F2Decker with the given tag, throwing if absent. */
+  def unsafeFromTag(s: String): F2Decker =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s"F2Decker: Invalid tag: '$s'"))
+
+  /** @group Typeclass Instances */
+  given Enumerated[F2Decker] =
+    new Enumerated[F2Decker] {
+      def all = F2Decker.all
+      def tag(a: F2Decker) = a.tag
+      override def unsafeFromTag(s: String): F2Decker =
+        F2Decker.unsafeFromTag(s)
+    }
+
+}

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/F2Fpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/F2Fpu.scala
@@ -16,20 +16,21 @@ sealed abstract class F2Fpu(
   val shortName: String,
   val longName: String,
   val slitWidth: Int, // pixels
-  val decker: String,
+  val decker: F2Decker,
   val obsolete: Boolean
 ) extends Product with Serializable
 
 object F2Fpu {
 
-  /** @group Constructors */ case object Pinhole extends F2Fpu("Pinhole", "Pinhole", "2-Pixel Pinhole Grid", 0, "Imaging", false)
-  /** @group Constructors */ case object SubPixPinhole extends F2Fpu("SubPixPinhole", "Sub-Pix Pinhole", "Sub-Pixel Pinhole Gr", 0, "Imaging", false)
-  /** @group Constructors */ case object LongSlit1 extends F2Fpu("LongSlit1", "Long Slit 1px", "1-Pixel Long Slit", 1, "Long Slit", false)
-  /** @group Constructors */ case object LongSlit2 extends F2Fpu("LongSlit2", "Long Slit 2px", "2-Pixel Long Slit", 2, "Long Slit", false)
-  /** @group Constructors */ case object LongSlit3 extends F2Fpu("LongSlit3", "Long Slit 3px", "3-Pixel Long Slit", 3, "Long Slit", false)
-  /** @group Constructors */ case object LongSlit4 extends F2Fpu("LongSlit4", "Long Slit 4px", "4-Pixel Long Slit", 4, "Long Slit", false)
-  /** @group Constructors */ case object LongSlit6 extends F2Fpu("LongSlit6", "Long Slit 6px", "6-Pixel Long Slit", 6, "Long Slit", false)
-  /** @group Constructors */ case object LongSlit8 extends F2Fpu("LongSlit8", "Long Slit 8px", "8-Pixel Long Slit", 8, "Long Slit", false)
+  /** @group Constructors */ case object Pinhole extends F2Fpu("Pinhole", "Pinhole", "2-Pixel Pinhole Grid", 0, F2Decker.Imaging, false)
+  /** @group Constructors */ case object SubPixPinhole extends F2Fpu("SubPixPinhole", "Sub-Pix Pinhole", "Sub-Pixel Pinhole Gr", 0, F2Decker.Imaging, false)
+  /** @group Constructors */ case object LongSlit1 extends F2Fpu("LongSlit1", "Long Slit 1px", "1-Pixel Long Slit", 1, F2Decker.LongSlit, false)
+  /** @group Constructors */ case object LongSlit2 extends F2Fpu("LongSlit2", "Long Slit 2px", "2-Pixel Long Slit", 2, F2Decker.LongSlit, false)
+  /** @group Constructors */ case object LongSlit3 extends F2Fpu("LongSlit3", "Long Slit 3px", "3-Pixel Long Slit", 3, F2Decker.LongSlit, false)
+  /** @group Constructors */ case object LongSlit4 extends F2Fpu("LongSlit4", "Long Slit 4px", "4-Pixel Long Slit", 4, F2Decker.LongSlit, false)
+  /** @group Constructors */ case object LongSlit6 extends F2Fpu("LongSlit6", "Long Slit 6px", "6-Pixel Long Slit", 6, F2Decker.LongSlit, false)
+  /** @group Constructors */ case object LongSlit8 extends F2Fpu("LongSlit8", "Long Slit 8px", "8-Pixel Long Slit", 8, F2Decker.LongSlit, false)
+  /** @group Constructors */ case object CustomMask extends F2Fpu("CustomMask", "Custom Mask", "Custom Mask", 8, F2Decker.MOS, false)
 
   /** All members of F2Fpu, in canonical order. */
   val all: List[F2Fpu] =
@@ -44,7 +45,7 @@ object F2Fpu {
     fromTag(s).getOrElse(throw new NoSuchElementException(s"F2Fpu: Invalid tag: '$s'"))
 
   /** @group Typeclass Instances */
-  implicit val F2FpuEnumerated: Enumerated[F2Fpu] =
+  given Enumerated[F2Fpu] =
     new Enumerated[F2Fpu] {
       def all = F2Fpu.all
       def tag(a: F2Fpu) = a.tag

--- a/modules/core/shared/src/main/scala/lucuma/core/math/Offset.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Offset.scala
@@ -90,6 +90,9 @@ object Offset extends OffsetOptics {
   given Order[Offset] =
     Order.by(o => (o.p, o.q))
 
+  def symmetric(a: Angle): Offset =
+    Offset(Component(a), Component(a))
+
   /** Component of an angular offset. */
   opaque type Component[A] = Long
 

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -58,7 +58,7 @@ trait F2LSShapes extends InstrumentShapes:
     145.deg
 
   val guideStarOffset: Offset =
-    Offset(Angle.fromDoubleDegrees(0.03205404776434761).p, Angle.fromDoubleDegrees(359.995624807521).q)
+    Offset(170543999.µas.p, -24177003.µas.q)
 
   val offsetPos: Offset =
     Offset(-60.arcsec.p, 60.arcsec.q)


### PR DESCRIPTION
Add enums to indicate the use of MOS (Or CustomMask) and update the geometry:

OT:
<img width="498" alt="f2ot5" src="https://github.com/user-attachments/assets/8de582a8-f4be-415f-a052-e01f6693de2b" />

gpp:
![f2gpp5](https://github.com/user-attachments/assets/2495e497-09ba-4539-90c5-14088defd194)
