### PR TITLE
ShortCut 1957: ExposureTimeMode Update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion                         := "0.114"
+ThisBuild / tlBaseVersion                         := "0.115"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ExposureTimeMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ExposureTimeMode.scala
@@ -6,78 +6,56 @@ package lucuma.core.model
 import cats.Eq
 import cats.syntax.all.*
 import eu.timepit.refined.cats.*
-import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.NonNegInt
 import lucuma.core.math.SignalToNoise
+import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
 import monocle.Focus
 import monocle.Lens
-import monocle.Optional
 import monocle.Prism
 import monocle.macros.GenPrism
 
-sealed trait ExposureTimeMode extends Product with Serializable
+sealed trait ExposureTimeMode extends Product with Serializable:
+  def at:  Wavelength
 
-object ExposureTimeMode {
+object ExposureTimeMode:
 
-  final case class SignalToNoiseMode(value: SignalToNoise)             extends ExposureTimeMode
-  final case class FixedExposureMode(count: PosInt, time: TimeSpan) extends ExposureTimeMode
+  final case class SignalToNoiseMode(value: SignalToNoise, at: Wavelength) extends ExposureTimeMode
+
+  object SignalToNoiseMode:
+    val value: Lens[SignalToNoiseMode, SignalToNoise] = Focus[SignalToNoiseMode](_.value)
+    val at:    Lens[SignalToNoiseMode, Wavelength]    = Focus[SignalToNoiseMode](_.at)
+    given Eq[SignalToNoiseMode]                       = Eq.by(a => (a.value, a.at))
+
+
+  final case class TimeAndCountMode(time: TimeSpan, count: NonNegInt, at: Wavelength) extends ExposureTimeMode
+
+  object TimeAndCountMode:
+    val time:  Lens[TimeAndCountMode, TimeSpan]   = Focus[TimeAndCountMode](_.time)
+    val count: Lens[TimeAndCountMode, NonNegInt]  = Focus[TimeAndCountMode](_.count)
+    val at:    Lens[TimeAndCountMode, Wavelength] = Focus[TimeAndCountMode](_.at)
+    given Eq[TimeAndCountMode]                    = Eq.by(a => (a.time, a.count, a.at))
+
 
   given Eq[ExposureTimeMode] =
-    Eq.instance {
-      case (SignalToNoiseMode(a), SignalToNoiseMode(b))           => a === b
-      case (FixedExposureMode(ac, ad), FixedExposureMode(bc, bd)) => ac === bc && ad === bd
-      case _                                              => false
-    }
+    Eq.instance:
+      case (a@SignalToNoiseMode(_, _),    b@SignalToNoiseMode(_, _))   => a === b
+      case (a@TimeAndCountMode(_, _, _),  b@TimeAndCountMode(_, _, _)) => a === b
+      case _                                                           => false
 
   val signalToNoise: Prism[ExposureTimeMode, SignalToNoiseMode] =
     GenPrism[ExposureTimeMode, SignalToNoiseMode]
 
-  val fixedExposure: Prism[ExposureTimeMode, FixedExposureMode] =
-    GenPrism[ExposureTimeMode, FixedExposureMode]
+  val timeAndCount: Prism[ExposureTimeMode, TimeAndCountMode] =
+    GenPrism[ExposureTimeMode, TimeAndCountMode]
 
-  val signalToNoiseValue: Optional[ExposureTimeMode, SignalToNoise] =
-    Optional[ExposureTimeMode, SignalToNoise] {
-      case SignalToNoiseMode(value) => value.some
-      case FixedExposureMode(_, _)  => none
-    } { nnd =>
+  val at: Lens[ExposureTimeMode, Wavelength] =
+    Lens[ExposureTimeMode, Wavelength] {
+      case SignalToNoiseMode(_, w)   => w
+      case TimeAndCountMode(_, _, w) => w
+    } { w =>
       {
-        case s @ SignalToNoiseMode(_)    => SignalToNoiseMode.value.replace(nnd)(s)
-        case f @ FixedExposureMode(_, _) => f
+        case a @ SignalToNoiseMode(_, _)   => SignalToNoiseMode.at.replace(w)(a)
+        case a @ TimeAndCountMode(_, _, _) => TimeAndCountMode.at.replace(w)(a)
       }
     }
-
-  val exposureCount: Optional[ExposureTimeMode, PosInt] =
-    Optional[ExposureTimeMode, PosInt] {
-      case FixedExposureMode(count, _) => count.some
-      case SignalToNoiseMode(_)        => none
-    } { nni =>
-      {
-        case f @ FixedExposureMode(_, _) => FixedExposureMode.count.replace(nni)(f)
-        case s @ SignalToNoiseMode(_)    => s
-      }
-    }
-
-  val exposureTime: Optional[ExposureTimeMode, TimeSpan] =
-    Optional[ExposureTimeMode, TimeSpan] {
-      case FixedExposureMode(_, time) => time.some
-      case SignalToNoiseMode(_)       => none
-    } { pbd =>
-      {
-        case f @ FixedExposureMode(_, _) => FixedExposureMode.time.replace(pbd)(f)
-        case s @ SignalToNoiseMode(_)    => s
-      }
-    }
-
-  object SignalToNoiseMode {
-    val value: Lens[SignalToNoiseMode, SignalToNoise] = Focus[SignalToNoiseMode](_.value)
-
-    given Eq[SignalToNoiseMode] = Eq.by(_.value)
-  }
-
-  object FixedExposureMode {
-    val count: Lens[FixedExposureMode, PosInt] = Focus[FixedExposureMode](_.count)
-    val time: Lens[FixedExposureMode, TimeSpan]   = Focus[FixedExposureMode](_.time)
-
-    given Eq[FixedExposureMode] = Eq.by(f => (f.count, f.time))
-  }
-}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/ExposureTimeModeSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/ExposureTimeModeSuite.scala
@@ -8,32 +8,31 @@ import eu.timepit.refined.cats.*
 import eu.timepit.refined.scalacheck.all.*
 import lucuma.core.math.arb.ArbRefined
 import lucuma.core.math.arb.ArbSignalToNoise
+import lucuma.core.math.arb.ArbWavelength
 import lucuma.core.model.arb.ArbExposureTimeMode
 import lucuma.core.util.arb.ArbTimeSpan
 import monocle.law.discipline.LensTests
-import monocle.law.discipline.OptionalTests
 import monocle.law.discipline.PrismTests
 import munit.DisciplineSuite
 
-class ExposureTimeModeSuite extends DisciplineSuite {
+class ExposureTimeModeSuite extends DisciplineSuite:
   import ArbExposureTimeMode.given
   import ArbRefined.given
   import ArbSignalToNoise.given
   import ArbTimeSpan.given
+  import ArbWavelength.given
+  import ExposureTimeMode.*
 
   checkAll("Eq[ExposureTimeMode]", EqTests[ExposureTimeMode].eqv)
-  checkAll("ExposureTimeMode.signalToNoise", PrismTests(ExposureTimeMode.signalToNoise))
-  checkAll("ExposureTimeMode.fixedExposure", PrismTests(ExposureTimeMode.fixedExposure))
-  checkAll("ExposureTimeMode.signalToNoiseValue",
-           OptionalTests(ExposureTimeMode.signalToNoiseValue)
-  )
-  checkAll("ExposureTimeMode.exposureCount", OptionalTests(ExposureTimeMode.exposureCount))
-  checkAll("ExposureTimeMode.exposureTime", OptionalTests(ExposureTimeMode.exposureTime))
+  checkAll("ExposureTimeMode.signalToNoise", PrismTests(signalToNoise))
+  checkAll("ExposureTimeMode.timeAndCount",  PrismTests(timeAndCount))
+  checkAll("ExposureTimeMode.at",            LensTests(at))
 
-  checkAll("Eq[SignalToNoise]", EqTests[ExposureTimeMode.SignalToNoiseMode].eqv)
-  checkAll("SignalToNoise.value", LensTests(ExposureTimeMode.SignalToNoiseMode.value))
+  checkAll("Eq[SignalToNoiseMode]",   EqTests[SignalToNoiseMode].eqv)
+  checkAll("SignalToNoiseMode.value", LensTests(SignalToNoiseMode.value))
+  checkAll("SignalToNoiseMode.at",    LensTests(SignalToNoiseMode.at))
 
-  checkAll("Eq[FixedExposure]", EqTests[ExposureTimeMode.FixedExposureMode].eqv)
-  checkAll("FixedExposure.count", LensTests(ExposureTimeMode.FixedExposureMode.count))
-  checkAll("FixedExposure.time", LensTests(ExposureTimeMode.FixedExposureMode.time))
-}
+  checkAll("Eq[TimeAndCountMode]",   EqTests[TimeAndCountMode].eqv)
+  checkAll("TimeAndCountMode.time",  LensTests(TimeAndCountMode.time))
+  checkAll("TimeAndCountMode.count", LensTests(TimeAndCountMode.count))
+  checkAll("TimeAndCountMode.at",    LensTests(TimeAndCountMode.at))


### PR DESCRIPTION
Updates to `ExposureTimeMode` to support [ShortCut 1955](https://app.shortcut.com/lucuma/story/1955/exposure-mode) and [ShortCut 1957](https://app.shortcut.com/lucuma/story/1957/add-exposuremode-to-spectroscopysciencerequirements).  We're ignoring for now the "Exp Count" and "Exp Time" modes and including only "Time & Count" and "S/N".

This may be updated and cannot be merged in any case because the corresponding changes in the ODB (and probably ITC) are extensive and in progress, but I wanted to publish it for possible feedback regardless.