### PR TITLE
ShortCut-3897: add external user

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ProgramUserRole.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ProgramUserRole.scala
@@ -7,10 +7,11 @@ import lucuma.core.util.Enumerated
 
 enum ProgramUserRole(val tag: String) derives Enumerated:
 
-  case Pi      extends ProgramUserRole("pi")
-  case Coi     extends ProgramUserRole("coi")
-  case CoiRO   extends ProgramUserRole("coi_ro")
-  case SupportPrimary extends ProgramUserRole("support_primary")
+  case Pi               extends ProgramUserRole("pi")
+  case Coi              extends ProgramUserRole("coi")
+  case CoiRO            extends ProgramUserRole("coi_ro")
+  case External         extends ProgramUserRole("external")
+  case SupportPrimary   extends ProgramUserRole("support_primary")
   case SupportSecondary extends ProgramUserRole("support_secondary")
 
 end ProgramUserRole


### PR DESCRIPTION
Adds a new `ProgramUserRole`, the `External` user.  External users would be associated with a program, have the same attributes as other program users (name, email, ORCiD, etc.), be invited and accept invitations, etc. like a user in any other role.  The difference is that external users are not granted permission to see or edit the corresponding program.

The reason to add an `External` role is for a new program user attribute, `hasDataAccess`.  When `true`, the user will be allowed to download the program's data.  [ShortCut 3897](https://app.shortcut.com/lucuma/story/3897/allow-pi-to-elect-who-can-download-proprietary-data) prescribes a data sharing list and applies it even to COIs.  This means that a user may be a COI with full edit permission and yet not allowed to download the data.  Conversely, a user may be external and not allowed to see the program and yet have permission to download the data.

A database query will be provided for the GOA.  Given an ORCiD, GOA will check with the database to see whether the user is allowed to download data.