### PR TITLE
Shortcut 4779: Filter obsolete acquisition filters

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthFilter.scala
@@ -65,7 +65,9 @@ object GmosNorthFilter {
 
   /** Acquisition filter options. */
   val acquisition: NonEmptyList[GmosNorthFilter] =
-    NonEmptyList.of(GPrime, RPrime, IPrime, ZPrime, UPrime)
+    NonEmptyList.fromListUnsafe(
+      List(GPrime, RPrime, IPrime, ZPrime, UPrime).filter(!_.obsolete)
+    )
 
   /** Select the member of GmosNorthFilter with the given tag, if any. */
   def fromTag(s: String): Option[GmosNorthFilter] =

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthFilter.scala
@@ -66,7 +66,9 @@ object GmosSouthFilter {
 
   /** Acquisition filter options. */
   val acquisition: NonEmptyList[GmosSouthFilter] =
-    NonEmptyList.of(UPrime, GPrime, RPrime, IPrime, ZPrime)
+    NonEmptyList.fromListUnsafe(
+      List(UPrime, GPrime, RPrime, IPrime, ZPrime).filter(!_.obsolete)
+    )
 
   /** Select the member of GmosSouthFilter with the given tag, if any. */
   def fromTag(s: String): Option[GmosSouthFilter] =


### PR DESCRIPTION
I guess we need `Resource` to do this correctly, but in the meantime ....