### PR TITLE
Add CustomSedAttachment

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/UnnormalizedSED.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/UnnormalizedSED.scala
@@ -149,18 +149,18 @@ object UnnormalizedSED {
 
   given Eq[UnnormalizedSED] =
     Eq.instance {
-      case (a @ StellarLibrary(_), b @ StellarLibrary(_))   => a === b
-      case (a @ CoolStarModel(_), b @ CoolStarModel(_))     => a === b
-      case (a @ Galaxy(_), b @ Galaxy(_))                   => a === b
-      case (a @ Planet(_), b @ Planet(_))                   => a === b
-      case (a @ Quasar(_), b @ Quasar(_))                   => a === b
-      case (a @ HIIRegion(_), b @ HIIRegion(_))             => a === b
-      case (a @ PlanetaryNebula(_), b @ PlanetaryNebula(_)) => a === b
-      case (a @ PowerLaw(_), b @ PowerLaw(_))               => a === b
-      case (a @ BlackBody(_), b @ BlackBody(_))             => a === b
-      case (a @ UserDefined(_), b @ UserDefined(_))         => a === b
+      case (a @ StellarLibrary(_), b @ StellarLibrary(_))               => a === b
+      case (a @ CoolStarModel(_), b @ CoolStarModel(_))                 => a === b
+      case (a @ Galaxy(_), b @ Galaxy(_))                               => a === b
+      case (a @ Planet(_), b @ Planet(_))                               => a === b
+      case (a @ Quasar(_), b @ Quasar(_))                               => a === b
+      case (a @ HIIRegion(_), b @ HIIRegion(_))                         => a === b
+      case (a @ PlanetaryNebula(_), b @ PlanetaryNebula(_))             => a === b
+      case (a @ PowerLaw(_), b @ PowerLaw(_))                           => a === b
+      case (a @ BlackBody(_), b @ BlackBody(_))                         => a === b
+      case (a @ UserDefined(_), b @ UserDefined(_))                     => a === b
       case (a @ UserDefinedAttachment(_), b @ UserDefinedAttachment(_)) => a === b
-      case _                                                => false
+      case _                                                            => false
     }
 
   /** @group Optics */

--- a/modules/core/shared/src/main/scala/lucuma/core/model/UnnormalizedSED.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/UnnormalizedSED.scala
@@ -136,6 +136,17 @@ object UnnormalizedSED {
       Focus[UserDefined](_.fluxDensities)
   }
 
+  final case class UserDefinedAttachment(attachmentId: Attachment.Id)
+      extends UnnormalizedSED
+
+  object UserDefinedAttachment {
+    given Eq[UserDefinedAttachment] = Eq.by(_.attachmentId)
+
+    /** @group Optics */
+    val attachmentId: Lens[UserDefinedAttachment, Attachment.Id] =
+      Focus[UserDefinedAttachment](_.attachmentId)
+  }
+
   given Eq[UnnormalizedSED] =
     Eq.instance {
       case (a @ StellarLibrary(_), b @ StellarLibrary(_))   => a === b
@@ -148,6 +159,7 @@ object UnnormalizedSED {
       case (a @ PowerLaw(_), b @ PowerLaw(_))               => a === b
       case (a @ BlackBody(_), b @ BlackBody(_))             => a === b
       case (a @ UserDefined(_), b @ UserDefined(_))         => a === b
+      case (a @ UserDefinedAttachment(_), b @ UserDefinedAttachment(_)) => a === b
       case _                                                => false
     }
 
@@ -190,4 +202,8 @@ object UnnormalizedSED {
   /** @group Optics */
   val userDefined: Prism[UnnormalizedSED, UserDefined] =
     GenPrism[UnnormalizedSED, UserDefined]
+
+  /** @group Optics */
+  val userDefinedAttachment: Prism[UnnormalizedSED, UserDefinedAttachment] =
+    GenPrism[UnnormalizedSED, UserDefinedAttachment]
 }

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbUnnormalizedSED.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbUnnormalizedSED.scala
@@ -18,14 +18,16 @@ import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbRefined
 import lucuma.core.math.arb.ArbWavelength
 import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.arb.ArbGid
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 
 trait ArbUnnormalizedSED {
   import ArbEnumerated.given
-  import UnnormalizedSED.*
+  import ArbGid.given
   import ArbRefined.given
   import ArbWavelength.given
+  import UnnormalizedSED.*
 
   given Arbitrary[StellarLibrary] =
     Arbitrary(arbitrary[StellarLibrarySpectrum].map(StellarLibrary(_)))
@@ -93,6 +95,12 @@ trait ArbUnnormalizedSED {
   given Cogen[UserDefined] =
     Cogen[Map[Wavelength, PosBigDecimal]].contramap(_.fluxDensities.toSortedMap)
 
+  given Arbitrary[UserDefinedAttachment] =
+    Arbitrary(arbitrary[Attachment.Id].map(UserDefinedAttachment(_)))
+
+  given Cogen[UserDefinedAttachment] =
+    Cogen[Attachment.Id].contramap(_.attachmentId)
+
   given Arbitrary[UnnormalizedSED] =
     Arbitrary(
       Gen.oneOf(
@@ -105,7 +113,8 @@ trait ArbUnnormalizedSED {
         arbitrary[PlanetaryNebula],
         arbitrary[PowerLaw],
         arbitrary[BlackBody],
-        arbitrary[UserDefined]
+        arbitrary[UserDefined],
+        arbitrary[UserDefinedAttachment]
       )
     )
 
@@ -128,7 +137,10 @@ trait ArbUnnormalizedSED {
                     PowerLaw,
                     Either[
                       BlackBody,
-                      UserDefined
+                      Either[
+                        UserDefined,
+                        UserDefinedAttachment
+                      ]
                     ]
                   ]
                 ]
@@ -149,7 +161,9 @@ trait ArbUnnormalizedSED {
       case d @ BlackBody(_)       =>
         d.asLeft.asRight.asRight.asRight.asRight.asRight.asRight.asRight.asRight
       case d @ UserDefined(_)     =>
-        d.asRight.asRight.asRight.asRight.asRight.asRight.asRight.asRight.asRight
+        d.asLeft.asRight.asRight.asRight.asRight.asRight.asRight.asRight.asRight.asRight
+      case d @ UserDefinedAttachment(_) =>
+        d.asRight.asRight.asRight.asRight.asRight.asRight.asRight.asRight.asRight.asRight
     }
 }
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/UnnormalizedSEDSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/UnnormalizedSEDSuite.scala
@@ -85,4 +85,8 @@ final class UnnormalizedSEDSuite extends DisciplineSuite {
     "UnnormalizedSED.userDefined",
     PrismTests(UnnormalizedSED.userDefined)
   )
+  checkAll(
+    "UnnormalizedSED.userDefinedAttachment",
+    PrismTests(UnnormalizedSED.userDefinedAttachment)
+  )
 }


### PR DESCRIPTION
This allows us to store a reference to an attachment in the ODB and model it in Explore. ITC will ultimately receive this and resolve it by invoking the ODB.

We want to keep the case with explicit values since we want to support 3rd party invocations to the ITC with custom SEDs.