### PR TITLE
Shortcut 4428: Remove (most) obsolete flags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.116"
+ThisBuild / tlBaseVersion                         := "0.117"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GcalArc.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GcalArc.scala
@@ -9,8 +9,8 @@ import lucuma.core.util.Enumerated
  * Enumerated type for calibration unit arc lamps.
  * @group Enumerations
  */
-enum GcalArc(val tag: String, val shortName: String, val longName: String, val obsolete: Boolean) derives Enumerated:
-  /** @group Constructors */ case ArArc extends GcalArc("ArArc", "Ar arc", "Ar arc", false)
-  /** @group Constructors */ case ThArArc extends GcalArc("ThArArc", "ThAr arc", "ThAr arc", false)
-  /** @group Constructors */ case CuArArc extends GcalArc("CuArArc", "CuAr arc", "CuAr arc", false)
-  /** @group Constructors */ case XeArc extends GcalArc("XeArc", "Xe arc", "Xe arc", false)
+enum GcalArc(val tag: String, val shortName: String, val longName: String) derives Enumerated:
+  /** @group Constructors */ case ArArc extends GcalArc("ArArc", "Ar arc", "Ar arc")
+  /** @group Constructors */ case ThArArc extends GcalArc("ThArArc", "ThAr arc", "ThAr arc")
+  /** @group Constructors */ case CuArArc extends GcalArc("CuArArc", "CuAr arc", "CuAr arc")
+  /** @group Constructors */ case XeArc extends GcalArc("XeArc", "Xe arc", "Xe arc")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GcalContinuum.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GcalContinuum.scala
@@ -9,8 +9,8 @@ import lucuma.core.util.Enumerated
  * Enumerated type for calibration unit continuum lamps.
  * @group Enumerations
  */
-enum GcalContinuum(val tag: String, val shortName: String, val longName: String, val obsolete: Boolean) derives Enumerated:
-  /** @group Constructors */ case IrGreyBodyLow extends GcalContinuum("IrGreyBodyLow", "IR grey body - low", "IR grey body - low", false)
-  /** @group Constructors */ case IrGreyBodyHigh extends GcalContinuum("IrGreyBodyHigh", "IR grey body - high", "IR grey body - high", false)
-  /** @group Constructors */ case QuartzHalogen5W extends GcalContinuum("QuartzHalogen5", "5W Quartz Halogen", "5W Quartz Halogen", false)
-  /** @group Constructors */ case QuartzHalogen100W extends GcalContinuum("QuartzHalogen100", "100W Quartz Halogen", "100W Quartz Halogen", false)
+enum GcalContinuum(val tag: String, val shortName: String, val longName: String) derives Enumerated:
+  /** @group Constructors */ case IrGreyBodyLow     extends GcalContinuum("IrGreyBodyLow", "IR grey body - low", "IR grey body - low")
+  /** @group Constructors */ case IrGreyBodyHigh    extends GcalContinuum("IrGreyBodyHigh", "IR grey body - high", "IR grey body - high")
+  /** @group Constructors */ case QuartzHalogen5W   extends GcalContinuum("QuartzHalogen5", "5W Quartz Halogen", "5W Quartz Halogen")
+  /** @group Constructors */ case QuartzHalogen100W extends GcalContinuum("QuartzHalogen100", "100W Quartz Halogen", "100W Quartz Halogen")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GcalDiffuser.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GcalDiffuser.scala
@@ -9,6 +9,6 @@ import lucuma.core.util.Enumerated
  * Enumerated type for calibration unit diffusers.
  * @group Enumerations
  */
-enum GcalDiffuser(val tag: String, val shortName: String, val longName: String, val obsolete: Boolean) derives Enumerated:
-  /** @group Constructors */ case Ir extends GcalDiffuser("Ir", "IR", "IR", false)
-  /** @group Constructors */ case Visible extends GcalDiffuser("Visible", "Visible", "Visible", false)
+enum GcalDiffuser(val tag: String, val shortName: String, val longName: String) derives Enumerated:
+  /** @group Constructors */ case Ir      extends GcalDiffuser("Ir", "IR", "IR")
+  /** @group Constructors */ case Visible extends GcalDiffuser("Visible", "Visible", "Visible")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GcalFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GcalFilter.scala
@@ -9,15 +9,12 @@ import lucuma.core.util.Enumerated
  * Enumerated type for calibration unit filter.
  * @group Enumerations
  */
-enum GcalFilter(val tag: String, val shortName: String, val longName: String, val obsolete: Boolean) derives Enumerated:
-  /** @group Constructors */ case None extends GcalFilter("None", "none", "none", false)
-  /** @group Constructors */ case Gmos extends GcalFilter("Gmos", "GMOS balance", "GMOS balance", false)
-  /** @group Constructors */ case Hros extends GcalFilter("Hros", "HROS balance", "HROS balance", true)
-  /** @group Constructors */ case Nir extends GcalFilter("Nir", "NIR balance", "NIR balance", false)
-  /** @group Constructors */ case Nd10 extends GcalFilter("Nd10", "ND1.0", "ND1.0", false)
-  /** @group Constructors */ case Nd16 extends GcalFilter("Nd16", "ND1.6", "ND1.6", true)
-  /** @group Constructors */ case Nd20 extends GcalFilter("Nd20", "ND2.0", "ND2.0", false)
-  /** @group Constructors */ case Nd30 extends GcalFilter("Nd30", "ND3.0", "ND3.0", false)
-  /** @group Constructors */ case Nd40 extends GcalFilter("Nd40", "ND4.0", "ND4.0", false)
-  /** @group Constructors */ case Nd45 extends GcalFilter("Nd45", "ND4-5", "ND4-5", false)
-  /** @group Constructors */ case Nd50 extends GcalFilter("Nd50", "ND5.0", "ND5.0", true)
+enum GcalFilter(val tag: String, val shortName: String, val longName: String) derives Enumerated:
+  /** @group Constructors */ case None extends GcalFilter("None", "none", "none")
+  /** @group Constructors */ case Gmos extends GcalFilter("Gmos", "GMOS balance", "GMOS balance")
+  /** @group Constructors */ case Nir extends GcalFilter("Nir", "NIR balance", "NIR balance")
+  /** @group Constructors */ case Nd10 extends GcalFilter("Nd10", "ND1.0", "ND1.0")
+  /** @group Constructors */ case Nd20 extends GcalFilter("Nd20", "ND2.0", "ND2.0")
+  /** @group Constructors */ case Nd30 extends GcalFilter("Nd30", "ND3.0", "ND3.0")
+  /** @group Constructors */ case Nd40 extends GcalFilter("Nd40", "ND4.0", "ND4.0")
+  /** @group Constructors */ case Nd45 extends GcalFilter("Nd45", "ND4-5", "ND4-5")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GcalShutter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GcalShutter.scala
@@ -9,6 +9,6 @@ import lucuma.core.util.Enumerated
  * Enumerated type for calibration unit shutter states.
  * @group Enumerations
  */
-enum GcalShutter(val tag: String, val shortName: String, val longName: String, val obsolete: Boolean) derives Enumerated:
-  /** @group Constructors */ case Open extends GcalShutter("Open", "Open", "Open", false)
-  /** @group Constructors */ case Closed extends GcalShutter("Closed", "Closed", "Closed", false)
+enum GcalShutter(val tag: String, val shortName: String, val longName: String) derives Enumerated:
+  /** @group Constructors */ case Open extends GcalShutter("Open", "Open", "Open")
+  /** @group Constructors */ case Closed extends GcalShutter("Closed", "Closed", "Closed")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthFilter.scala
@@ -20,7 +20,6 @@ sealed abstract class GmosNorthFilter(
   val shortName: String,
   val longName: String,
   val wavelength: Wavelength,
-  val obsolete: Boolean,
   val width: BoundedInterval[Wavelength],
   val filterType: FilterType
 ) extends Product with Serializable
@@ -29,44 +28,43 @@ object GmosNorthFilter {
 
   import ConvenienceOps.*
 
-  /** @group Constructors */ case object GPrime           extends GmosNorthFilter("GPrime",           "g",       "g_G0301",                   475_000.pm, false, (398_000,   552_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object RPrime           extends GmosNorthFilter("RPrime",           "r",       "r_G0303",                   630_000.pm, false, (562_000,   698_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object IPrime           extends GmosNorthFilter("IPrime",           "i",       "i_G0302",                   780_000.pm, false, (706_000,   850_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object ZPrime           extends GmosNorthFilter("ZPrime",           "z",       "z_G0304",                   925_000.pm, false,  848_000.gePmRange,           FilterType.BroadBand)
-  /** @group Constructors */ case object Z                extends GmosNorthFilter("Z",                "Z",       "Z_G0322",                   876_000.pm, false, (830_000,   925_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object Y                extends GmosNorthFilter("Y",                "Y",       "Y_G0323",                 1_010_000.pm, false, (970_000, 1_070_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object Ri               extends GmosNorthFilter("Ri",               "r+i",     "ri_G0349",                  705_000.pm, false, (560_000,   850_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object GG455            extends GmosNorthFilter("GG455",            "GG455",   "GG455_G0305",               555_000.pm, false,  460_000.gePmRange,           FilterType.Spectroscopic)
-  /** @group Constructors */ case object OG515            extends GmosNorthFilter("OG515",            "OG515",   "OG515_G0306",               615_000.pm, false,  520_000.gePmRange,           FilterType.Spectroscopic)
-  /** @group Constructors */ case object RG610            extends GmosNorthFilter("RG610",            "RG610",   "RG610_G0307",               710_000.pm, false,  615_000.gePmRange,           FilterType.Spectroscopic)
-  /** @group Constructors */ case object CaT              extends GmosNorthFilter("CaT",              "CaT",     "CaT_G0309",                 860_000.pm, false, (780_000,   933_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object Ha               extends GmosNorthFilter("Ha",               "Ha",      "Ha_G0310",                  656_000.pm, false, (654_000,   661_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object HaC              extends GmosNorthFilter("HaC",              "HaC",     "HaC_G0311",                 662_000.pm, false, (659_000,   665_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object DS920            extends GmosNorthFilter("DS920",            "DS920",   "DS920_G0312",               920_000.pm, false, (912_800,   931_400).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object SII              extends GmosNorthFilter("SII",              "SII",     "SII_G0317",                 672_000.pm, false, (669_400,   673_700).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object OIII             extends GmosNorthFilter("OIII",             "OIII",    "OIII_G0318",                499_000.pm, false, (496_500,   501_500).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object OIIIC            extends GmosNorthFilter("OIIIC",            "OIIIC",   "OIIIC_G0319",               514_000.pm, false, (509_000,   519_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object HeII             extends GmosNorthFilter("HeII",             "HeII",    "HeII_G0320",                468_000.pm, false, (464_000,   472_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object HeIIC            extends GmosNorthFilter("HeIIC",            "HeIIC",   "HeIIC_G0321",               478_000.pm, false, (474_000,   482_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object OVI              extends GmosNorthFilter("OVI",              "OVI",     "OVI_G0345",                 684_000.pm, false, (681_600,   686_500).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object OVIC             extends GmosNorthFilter("OVIC",             "OVIC",    "OVIC_G0346",                679_000.pm, false, (676_100,   680_900).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object HartmannA_RPrime extends GmosNorthFilter("HartmannA_RPrime", "r+HartA", "HartmannA_G0313 + r_G0303", 630_000.pm, false,  630_000.gePmRange,           FilterType.Engineering)
-  /** @group Constructors */ case object HartmannB_RPrime extends GmosNorthFilter("HartmannB_RPrime", "r+HartB", "HartmannB_G0314 + r_G0303", 630_000.pm, false,  630_000.gePmRange,           FilterType.Engineering)
-  /** @group Constructors */ case object GPrime_GG455     extends GmosNorthFilter("GPrime_GG455",     "g+GG455", "g_G0301 + GG455_G0305",     506_000.pm, false, (460_000,   552_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object GPrime_OG515     extends GmosNorthFilter("GPrime_OG515",     "g+OG515", "g_G0301 + OG515_G0306",     536_000.pm, false, (520_000,   552_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object RPrime_RG610     extends GmosNorthFilter("RPrime_RG610",     "r+RG610", "r_G0303 + RG610_G0307",     657_000.pm, false, (615_000,   698_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object IPrime_CaT       extends GmosNorthFilter("IPrime_CaT",       "i+CaT",   "i_G0302 + CaT_G0309",       815_000.pm, false, (780_000,   850_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object ZPrime_CaT       extends GmosNorthFilter("ZPrime_CaT",       "z+CaT",   "z_G0305 + CaT_G0309",       890_000.pm, false, (848_000,   933_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object UPrime           extends GmosNorthFilter("UPrime",           "u",       "u_G0308",                   350_000.pm, true,  (336_000,   385_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object GPrime           extends GmosNorthFilter("GPrime",           "g",       "g_G0301",                   475_000.pm, (398_000,   552_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object RPrime           extends GmosNorthFilter("RPrime",           "r",       "r_G0303",                   630_000.pm, (562_000,   698_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object IPrime           extends GmosNorthFilter("IPrime",           "i",       "i_G0302",                   780_000.pm, (706_000,   850_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object ZPrime           extends GmosNorthFilter("ZPrime",           "z",       "z_G0304",                   925_000.pm, 848_000.gePmRange,            FilterType.BroadBand)
+  /** @group Constructors */ case object Z                extends GmosNorthFilter("Z",                "Z",       "Z_G0322",                   876_000.pm, (830_000,   925_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object Y                extends GmosNorthFilter("Y",                "Y",       "Y_G0323",                 1_010_000.pm, (970_000, 1_070_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object Ri               extends GmosNorthFilter("Ri",               "r+i",     "ri_G0349",                  705_000.pm, (560_000,   850_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object GG455            extends GmosNorthFilter("GG455",            "GG455",   "GG455_G0305",               555_000.pm, 460_000.gePmRange,            FilterType.Spectroscopic)
+  /** @group Constructors */ case object OG515            extends GmosNorthFilter("OG515",            "OG515",   "OG515_G0306",               615_000.pm, 520_000.gePmRange,            FilterType.Spectroscopic)
+  /** @group Constructors */ case object RG610            extends GmosNorthFilter("RG610",            "RG610",   "RG610_G0307",               710_000.pm, 615_000.gePmRange,            FilterType.Spectroscopic)
+  /** @group Constructors */ case object CaT              extends GmosNorthFilter("CaT",              "CaT",     "CaT_G0309",                 860_000.pm, (780_000,   933_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object Ha               extends GmosNorthFilter("Ha",               "Ha",      "Ha_G0310",                  656_000.pm, (654_000,   661_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object HaC              extends GmosNorthFilter("HaC",              "HaC",     "HaC_G0311",                 662_000.pm, (659_000,   665_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object DS920            extends GmosNorthFilter("DS920",            "DS920",   "DS920_G0312",               920_000.pm, (912_800,   931_400).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object SII              extends GmosNorthFilter("SII",              "SII",     "SII_G0317",                 672_000.pm, (669_400,   673_700).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object OIII             extends GmosNorthFilter("OIII",             "OIII",    "OIII_G0318",                499_000.pm, (496_500,   501_500).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object OIIIC            extends GmosNorthFilter("OIIIC",            "OIIIC",   "OIIIC_G0319",               514_000.pm, (509_000,   519_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object HeII             extends GmosNorthFilter("HeII",             "HeII",    "HeII_G0320",                468_000.pm, (464_000,   472_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object HeIIC            extends GmosNorthFilter("HeIIC",            "HeIIC",   "HeIIC_G0321",               478_000.pm, (474_000,   482_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object OVI              extends GmosNorthFilter("OVI",              "OVI",     "OVI_G0345",                 684_000.pm, (681_600,   686_500).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object OVIC             extends GmosNorthFilter("OVIC",             "OVIC",    "OVIC_G0346",                679_000.pm, (676_100,   680_900).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object HartmannA_RPrime extends GmosNorthFilter("HartmannA_RPrime", "r+HartA", "HartmannA_G0313 + r_G0303", 630_000.pm, 630_000.gePmRange,            FilterType.Engineering)
+  /** @group Constructors */ case object HartmannB_RPrime extends GmosNorthFilter("HartmannB_RPrime", "r+HartB", "HartmannB_G0314 + r_G0303", 630_000.pm, 630_000.gePmRange,            FilterType.Engineering)
+  /** @group Constructors */ case object GPrime_GG455     extends GmosNorthFilter("GPrime_GG455",     "g+GG455", "g_G0301 + GG455_G0305",     506_000.pm, (460_000,   552_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object GPrime_OG515     extends GmosNorthFilter("GPrime_OG515",     "g+OG515", "g_G0301 + OG515_G0306",     536_000.pm, (520_000,   552_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object RPrime_RG610     extends GmosNorthFilter("RPrime_RG610",     "r+RG610", "r_G0303 + RG610_G0307",     657_000.pm, (615_000,   698_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object IPrime_CaT       extends GmosNorthFilter("IPrime_CaT",       "i+CaT",   "i_G0302 + CaT_G0309",       815_000.pm, (780_000,   850_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object ZPrime_CaT       extends GmosNorthFilter("ZPrime_CaT",       "z+CaT",   "z_G0305 + CaT_G0309",       890_000.pm, (848_000,   933_000).pmRange, FilterType.Combination)
 
   /** All members of GmosNorthFilter, in canonical order. */
   val all: List[GmosNorthFilter] =
-    List(GPrime, RPrime, IPrime, ZPrime, Z, Y, Ri, GG455, OG515, RG610, CaT, Ha, HaC, DS920, SII, OIII, OIIIC, HeII, HeIIC, OVI, OVIC, HartmannA_RPrime, HartmannB_RPrime, GPrime_GG455, GPrime_OG515, RPrime_RG610, IPrime_CaT, ZPrime_CaT, UPrime)
+    List(GPrime, RPrime, IPrime, ZPrime, Z, Y, Ri, GG455, OG515, RG610, CaT, Ha, HaC, DS920, SII, OIII, OIIIC, HeII, HeIIC, OVI, OVIC, HartmannA_RPrime, HartmannB_RPrime, GPrime_GG455, GPrime_OG515, RPrime_RG610, IPrime_CaT, ZPrime_CaT)
 
   /** Acquisition filter options. */
   val acquisition: NonEmptyList[GmosNorthFilter] =
     NonEmptyList.fromListUnsafe(
-      List(GPrime, RPrime, IPrime, ZPrime, UPrime).filter(!_.obsolete)
+      List(GPrime, RPrime, IPrime, ZPrime)
     )
 
   /** Select the member of GmosNorthFilter with the given tag, if any. */

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthGrating.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthGrating.scala
@@ -30,8 +30,7 @@ sealed abstract class GmosNorthGrating(
   val dispersion:           Quantity[Rational, NanometersPerPixel],
   val simultaneousCoverage: WavelengthDelta,
   val blazeWavelength:      Wavelength,
-  val referenceResolution:  PosInt,
-  val obsolete:             Boolean
+  val referenceResolution:  PosInt
 ) extends Product with Serializable {
 
   /**
@@ -74,8 +73,7 @@ object GmosNorthGrating {
     dispersion           = pmToDispersion( 26),
     simultaneousCoverage = nmToWavelengthDelta( 164),
     blazeWavelength      = blazeNm( 463),
-    referenceResolution  = resolution(3744),
-    obsolete             = false
+    referenceResolution  = resolution(3744)
   )
 
   /** @group Constructors */
@@ -87,21 +85,7 @@ object GmosNorthGrating {
     dispersion           = pmToDispersion( 38),
     simultaneousCoverage = nmToWavelengthDelta( 235),
     blazeWavelength      = blazeNm(757),
-    referenceResolution  = resolution(4396),
-    obsolete             = false
-  )
-
-  /** @group Constructors */
-  case object B600_G5303  extends GmosNorthGrating(
-    tag                  = "B600_G5303",
-    shortName            = "B600",
-    longName             = "B600_G5303",
-    rulingDensity        = 600,
-    dispersion           = pmToDispersion( 45),
-    simultaneousCoverage = nmToWavelengthDelta( 276),
-    blazeWavelength      = blazeNm( 461),
-    referenceResolution  = resolution(1688),
-    obsolete             = true
+    referenceResolution  = resolution(4396)
   )
 
   /** @group Constructors */
@@ -113,8 +97,7 @@ object GmosNorthGrating {
     dispersion           = pmToDispersion( 50),
     simultaneousCoverage = nmToWavelengthDelta( 317),
     blazeWavelength      = blazeNm( 461),
-    referenceResolution  = resolution(1688),
-    obsolete             = false
+    referenceResolution  = resolution(1688)
   )
 
   /** @group Constructors */
@@ -126,8 +109,7 @@ object GmosNorthGrating {
     dispersion           = pmToDispersion( 52),
     simultaneousCoverage = nmToWavelengthDelta( 328),
     blazeWavelength      = blazeNm( 926),
-    referenceResolution  = resolution(3744),
-    obsolete             = false
+    referenceResolution  = resolution(3744)
   )
 
   /** @group Constructors */
@@ -139,8 +121,7 @@ object GmosNorthGrating {
     dispersion           = pmToDispersion( 62),
     simultaneousCoverage = nmToWavelengthDelta( 390),
     blazeWavelength      = blazeNm( 422),
-    referenceResolution  = resolution(1520),
-    obsolete             = false
+    referenceResolution  = resolution(1520)
   )
 
   /** @group Constructors */
@@ -152,21 +133,7 @@ object GmosNorthGrating {
     dispersion           = pmToDispersion( 74),
     simultaneousCoverage = nmToWavelengthDelta( 472),
     blazeWavelength      = blazeNm( 764),
-    referenceResolution  = resolution(1918),
-    obsolete             = false
-  )
-
-  /** @group Constructors */
-  case object R150_G5306  extends GmosNorthGrating(
-    tag                  = "R150_G5306",
-    shortName            = "R150",
-    longName             = "R150_G5306",
-    rulingDensity        = 150,
-    dispersion           = pmToDispersion(174),
-    simultaneousCoverage = nmToWavelengthDelta(1071),
-    blazeWavelength      = blazeNm( 717),
-    referenceResolution  = resolution(631),
-    obsolete             = true
+    referenceResolution  = resolution(1918)
   )
 
   /** @group Constructors */
@@ -178,13 +145,12 @@ object GmosNorthGrating {
     dispersion           = pmToDispersion(193),
     simultaneousCoverage = nmToWavelengthDelta(1219),
     blazeWavelength      = blazeNm( 717),
-    referenceResolution  = resolution(631),
-    obsolete             = false
+    referenceResolution  = resolution(631)
   )
 
   /** All members of GmosNorthDisperser, in canonical order. */
   lazy val all: List[GmosNorthGrating] =
-    List(B1200_G5301, R831_G5302, B600_G5303, B600_G5307, R600_G5304, B480_G5309, R400_G5305, R150_G5306, R150_G5308)
+    List(B1200_G5301, R831_G5302, B600_G5307, R600_G5304, B480_G5309, R400_G5305, R150_G5308)
 
   /** Select the member of GmosNorthDisperser with the given tag, if any. */
   def fromTag(s: String): Option[GmosNorthGrating] =

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthGrating.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthGrating.scala
@@ -89,18 +89,6 @@ object GmosNorthGrating {
   )
 
   /** @group Constructors */
-  case object B600_G5307  extends GmosNorthGrating(
-    tag                  = "B600_G5307",
-    shortName            = "B600",
-    longName             = "B600_G5307",
-    rulingDensity        = 600,
-    dispersion           = pmToDispersion( 50),
-    simultaneousCoverage = nmToWavelengthDelta( 317),
-    blazeWavelength      = blazeNm( 461),
-    referenceResolution  = resolution(1688)
-  )
-
-  /** @group Constructors */
   case object R600_G5304  extends GmosNorthGrating(
     tag                  = "R600_G5304",
     shortName            = "R600",
@@ -150,7 +138,7 @@ object GmosNorthGrating {
 
   /** All members of GmosNorthDisperser, in canonical order. */
   lazy val all: List[GmosNorthGrating] =
-    List(B1200_G5301, R831_G5302, B600_G5307, R600_G5304, B480_G5309, R400_G5305, R150_G5308)
+    List(B1200_G5301, R831_G5302, R600_G5304, B480_G5309, R400_G5305, R150_G5308)
 
   /** Select the member of GmosNorthDisperser with the given tag, if any. */
   def fromTag(s: String): Option[GmosNorthGrating] =

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthStageMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthStageMode.scala
@@ -14,20 +14,17 @@ import lucuma.core.util.Enumerated
 sealed abstract class GmosNorthStageMode(
   val tag: String,
   val shortName: String,
-  val longName: String,
-  val obsolete: Boolean
+  val longName: String
 ) extends Product with Serializable
 
 object GmosNorthStageMode {
 
-  /** @group Constructors */ case object NoFollow extends GmosNorthStageMode("NoFollow", "No Follow", "Do Not Follow", false)
-  /** @group Constructors */ case object FollowXyz extends GmosNorthStageMode("FollowXyz", "Follow XYZ", "Follow in XYZ(focus)", true)
-  /** @group Constructors */ case object FollowXy extends GmosNorthStageMode("FollowXy", "Follow XY", "Follow in XY", false)
-  /** @group Constructors */ case object FollowZ extends GmosNorthStageMode("FollowZ", "Follow Z", "Follow in Z Only", true)
+  /** @group Constructors */ case object NoFollow extends GmosNorthStageMode("NoFollow", "No Follow", "Do Not Follow")
+  /** @group Constructors */ case object FollowXy extends GmosNorthStageMode("FollowXy", "Follow XY", "Follow in XY")
 
   /** All members of GmosNorthStageMode, in canonical order. */
   val all: List[GmosNorthStageMode] =
-    List(NoFollow, FollowXyz, FollowXy, FollowZ)
+    List(NoFollow, FollowXy)
 
   /** Select the member of GmosNorthStageMode with the given tag, if any. */
   def fromTag(s: String): Option[GmosNorthStageMode] =

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosRoi.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosRoi.scala
@@ -14,23 +14,20 @@ import lucuma.core.util.Enumerated
 sealed abstract class GmosRoi(
   val tag: String,
   val shortName: String,
-  val longName: String,
-  val obsolete: Boolean
+  val longName: String
 ) extends Product with Serializable
 
 object GmosRoi {
 
-  /** @group Constructors */ case object FullFrame extends GmosRoi("FullFrame", "full", "Full Frame Readout", false)
-  /** @group Constructors */ case object Ccd2 extends GmosRoi("Ccd2", "ccd2", "CCD 2", false)
-  /** @group Constructors */ case object CentralSpectrum extends GmosRoi("CentralSpectrum", "cspec", "Central Spectrum", false)
-  /** @group Constructors */ case object CentralStamp extends GmosRoi("CentralStamp", "stamp", "Central Stamp", false)
-  /** @group Constructors */ case object TopSpectrum extends GmosRoi("TopSpectrum", "tspec", "Top Spectrum", true)
-  /** @group Constructors */ case object BottomSpectrum extends GmosRoi("BottomSpectrum", "bspec", "Bottom Spectrum", true)
-  /** @group Constructors */ case object Custom extends GmosRoi("Custom", "custom", "Custom ROI", false)
+  /** @group Constructors */ case object FullFrame       extends GmosRoi("FullFrame", "full", "Full Frame Readout")
+  /** @group Constructors */ case object Ccd2            extends GmosRoi("Ccd2", "ccd2", "CCD 2")
+  /** @group Constructors */ case object CentralSpectrum extends GmosRoi("CentralSpectrum", "cspec", "Central Spectrum")
+  /** @group Constructors */ case object CentralStamp    extends GmosRoi("CentralStamp", "stamp", "Central Stamp")
+  /** @group Constructors */ case object Custom          extends GmosRoi("Custom", "custom", "Custom ROI")
 
   /** All members of GmosRoi, in canonical order. */
   val all: List[GmosRoi] =
-    List(FullFrame, Ccd2, CentralSpectrum, CentralStamp, TopSpectrum, BottomSpectrum, Custom)
+    List(FullFrame, Ccd2, CentralSpectrum, CentralStamp, Custom)
 
   /** Select the member of GmosRoi with the given tag, if any. */
   def fromTag(s: String): Option[GmosRoi] =

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthFilter.scala
@@ -20,7 +20,6 @@ sealed abstract class GmosSouthFilter(
   val shortName: String,
   val longName: String,
   val wavelength: Wavelength,
-  val obsolete: Boolean,
   val width: BoundedInterval[Wavelength],
   val filterType: FilterType
 ) extends Product with Serializable
@@ -29,45 +28,44 @@ object GmosSouthFilter {
 
   import ConvenienceOps.*
 
-  /** @group Constructors */ case object UPrime           extends GmosSouthFilter("UPrime",           "u",       "u_G0332",                    350_000.pm, false, (336_000,   385_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object GPrime           extends GmosSouthFilter("GPrime",           "g",       "g_G0325",                    475_000.pm, false, (398_000,   552_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object RPrime           extends GmosSouthFilter("RPrime",           "r",       "r_G0326",                    630_000.pm, false, (562_000,   698_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object IPrime           extends GmosSouthFilter("IPrime",           "i",       "i_G0327",                    780_000.pm, false, (706_000,   850_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object ZPrime           extends GmosSouthFilter("ZPrime",           "z",       "z_G0328",                    925_000.pm, false,  848_000.gePmRange,           FilterType.BroadBand)
-  /** @group Constructors */ case object Z                extends GmosSouthFilter("Z",                "Z",       "Z_G0343",                    876_000.pm, false, (830_000,   925_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object Y                extends GmosSouthFilter("Y",                "Y",       "Y_G0344",                  1_010_000.pm, false, (970_000, 1_070_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object GG455            extends GmosSouthFilter("GG455",            "GG455",   "GG455_G0329",                555_000.pm, false,  460_000.gePmRange,           FilterType.Spectroscopic)
-  /** @group Constructors */ case object OG515            extends GmosSouthFilter("OG515",            "OG515",   "OG515_G0330",                615_000.pm, false,  520_000.gePmRange,           FilterType.Spectroscopic)
-  /** @group Constructors */ case object RG610            extends GmosSouthFilter("RG610",            "RG610",   "RG610_G0331",                710_000.pm, false,  615_000.gePmRange,           FilterType.Spectroscopic)
-  /** @group Constructors */ case object RG780            extends GmosSouthFilter("RG780",            "RG780",   "RG780_G0334",                880_000.pm, false,  780_000.gePmRange,           FilterType.Spectroscopic)
-  /** @group Constructors */ case object CaT              extends GmosSouthFilter("CaT",              "CaT",     "CaT_G0333",                  860_000.pm, false, (780_000,   933_000).pmRange, FilterType.BroadBand)
-  /** @group Constructors */ case object HartmannA_RPrime extends GmosSouthFilter("HartmannA_RPrime", "r+HartA", "HartmannA_G0337 + r_G0326",  630_000.pm, false,  630_000.gePmRange,           FilterType.Engineering)
-  /** @group Constructors */ case object HartmannB_RPrime extends GmosSouthFilter("HartmannB_RPrime", "r+HartB", "HartmannB_G0338 + r_G0326",  630_000.pm, false,  630_000.gePmRange,           FilterType.Engineering)
-  /** @group Constructors */ case object GPrime_GG455     extends GmosSouthFilter("GPrime_GG455",     "g+GG455", "g_G0325 + GG455_G0329",      506_000.pm, false, (460_000,   552_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object GPrime_OG515     extends GmosSouthFilter("GPrime_OG515",     "g+OG515", "g_G0325 + OG515_G0330",      536_000.pm, false, (520_000,   552_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object RPrime_RG610     extends GmosSouthFilter("RPrime_RG610",     "r+RG610", "r_G0326 + RG610_G0331",      657_000.pm, false, (615_000,   698_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object IPrime_RG780     extends GmosSouthFilter("IPrime_RG780",     "i+RG780", "i_G0327 + RG780_G0334",      819_000.pm, false, (777_000,   851_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object IPrime_CaT       extends GmosSouthFilter("IPrime_CaT",       "i+CaT",   "i_G0327 + CaT_G0333",        815_000.pm, false, (780_000,   850_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object ZPrime_CaT       extends GmosSouthFilter("ZPrime_CaT",       "z+Cat",   "z_G0328 + CaT_G0333",        890_000.pm, false, (848_000,   933_000).pmRange, FilterType.Combination)
-  /** @group Constructors */ case object Ha               extends GmosSouthFilter("Ha",               "Ha",      "Ha_G0336",                   656_000.pm, false, (654_000,   661_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object SII              extends GmosSouthFilter("SII",              "SII",     "SII_G0335",                  672_000.pm, false, (669_400,   673_700).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object HaC              extends GmosSouthFilter("HaC",              "HaC",     "HaC_G0337",                  662_000.pm, false, (659_000,   665_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object OIII             extends GmosSouthFilter("OIII",             "OIII",    "OIII_G0338",                 499_000.pm, false, (496_500,   501_500).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object OIIIC            extends GmosSouthFilter("OIIIC",            "OIIIC",   "OIIIC_G0339",                514_000.pm, false, (509_000,   519_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object HeII             extends GmosSouthFilter("HeII",             "HeII",    "HeII_G0340",                 468_000.pm, false, (464_000,   472_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object HeIIC            extends GmosSouthFilter("HeIIC",            "HeIIC",   "HeIIC_G0341",                478_000.pm, false, (474_000,   482_000).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object Lya395           extends GmosSouthFilter("Lya395",           "Lya395",  "Lya395_G0342",               396_000.pm, true,   386_000.gePmRange,           FilterType.NarrowBand)
-  /** @group Constructors */ case object OVI              extends GmosSouthFilter("OVI",              "OVI",     "OVI_G0347",                  684_000.pm, false, (681_600,   686_500).pmRange, FilterType.NarrowBand)
-  /** @group Constructors */ case object OVIC             extends GmosSouthFilter("OVIC",             "OVIC",    "OVI_G0348",                  679_000.pm, false, (676_100,   680_900).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object UPrime           extends GmosSouthFilter("UPrime",           "u",       "u_G0332",                    350_000.pm, (336_000,   385_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object GPrime           extends GmosSouthFilter("GPrime",           "g",       "g_G0325",                    475_000.pm, (398_000,   552_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object RPrime           extends GmosSouthFilter("RPrime",           "r",       "r_G0326",                    630_000.pm, (562_000,   698_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object IPrime           extends GmosSouthFilter("IPrime",           "i",       "i_G0327",                    780_000.pm, (706_000,   850_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object ZPrime           extends GmosSouthFilter("ZPrime",           "z",       "z_G0328",                    925_000.pm, 848_000.gePmRange,            FilterType.BroadBand)
+  /** @group Constructors */ case object Z                extends GmosSouthFilter("Z",                "Z",       "Z_G0343",                    876_000.pm, (830_000,   925_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object Y                extends GmosSouthFilter("Y",                "Y",       "Y_G0344",                  1_010_000.pm, (970_000, 1_070_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object GG455            extends GmosSouthFilter("GG455",            "GG455",   "GG455_G0329",                555_000.pm, 460_000.gePmRange,            FilterType.Spectroscopic)
+  /** @group Constructors */ case object OG515            extends GmosSouthFilter("OG515",            "OG515",   "OG515_G0330",                615_000.pm, 520_000.gePmRange,            FilterType.Spectroscopic)
+  /** @group Constructors */ case object RG610            extends GmosSouthFilter("RG610",            "RG610",   "RG610_G0331",                710_000.pm, 615_000.gePmRange,            FilterType.Spectroscopic)
+  /** @group Constructors */ case object RG780            extends GmosSouthFilter("RG780",            "RG780",   "RG780_G0334",                880_000.pm, 780_000.gePmRange,            FilterType.Spectroscopic)
+  /** @group Constructors */ case object CaT              extends GmosSouthFilter("CaT",              "CaT",     "CaT_G0333",                  860_000.pm, (780_000,   933_000).pmRange, FilterType.BroadBand)
+  /** @group Constructors */ case object HartmannA_RPrime extends GmosSouthFilter("HartmannA_RPrime", "r+HartA", "HartmannA_G0337 + r_G0326",  630_000.pm, 630_000.gePmRange,            FilterType.Engineering)
+  /** @group Constructors */ case object HartmannB_RPrime extends GmosSouthFilter("HartmannB_RPrime", "r+HartB", "HartmannB_G0338 + r_G0326",  630_000.pm, 630_000.gePmRange,            FilterType.Engineering)
+  /** @group Constructors */ case object GPrime_GG455     extends GmosSouthFilter("GPrime_GG455",     "g+GG455", "g_G0325 + GG455_G0329",      506_000.pm, (460_000,   552_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object GPrime_OG515     extends GmosSouthFilter("GPrime_OG515",     "g+OG515", "g_G0325 + OG515_G0330",      536_000.pm, (520_000,   552_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object RPrime_RG610     extends GmosSouthFilter("RPrime_RG610",     "r+RG610", "r_G0326 + RG610_G0331",      657_000.pm, (615_000,   698_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object IPrime_RG780     extends GmosSouthFilter("IPrime_RG780",     "i+RG780", "i_G0327 + RG780_G0334",      819_000.pm, (777_000,   851_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object IPrime_CaT       extends GmosSouthFilter("IPrime_CaT",       "i+CaT",   "i_G0327 + CaT_G0333",        815_000.pm, (780_000,   850_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object ZPrime_CaT       extends GmosSouthFilter("ZPrime_CaT",       "z+Cat",   "z_G0328 + CaT_G0333",        890_000.pm, (848_000,   933_000).pmRange, FilterType.Combination)
+  /** @group Constructors */ case object Ha               extends GmosSouthFilter("Ha",               "Ha",      "Ha_G0336",                   656_000.pm, (654_000,   661_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object SII              extends GmosSouthFilter("SII",              "SII",     "SII_G0335",                  672_000.pm, (669_400,   673_700).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object HaC              extends GmosSouthFilter("HaC",              "HaC",     "HaC_G0337",                  662_000.pm, (659_000,   665_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object OIII             extends GmosSouthFilter("OIII",             "OIII",    "OIII_G0338",                 499_000.pm, (496_500,   501_500).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object OIIIC            extends GmosSouthFilter("OIIIC",            "OIIIC",   "OIIIC_G0339",                514_000.pm, (509_000,   519_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object HeII             extends GmosSouthFilter("HeII",             "HeII",    "HeII_G0340",                 468_000.pm, (464_000,   472_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object HeIIC            extends GmosSouthFilter("HeIIC",            "HeIIC",   "HeIIC_G0341",                478_000.pm, (474_000,   482_000).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object OVI              extends GmosSouthFilter("OVI",              "OVI",     "OVI_G0347",                  684_000.pm, (681_600,   686_500).pmRange, FilterType.NarrowBand)
+  /** @group Constructors */ case object OVIC             extends GmosSouthFilter("OVIC",             "OVIC",    "OVI_G0348",                  679_000.pm, (676_100,   680_900).pmRange, FilterType.NarrowBand)
 
   /** All members of GmosSouthFilter, in canonical order. */
   val all: List[GmosSouthFilter] =
-    List(UPrime, GPrime, RPrime, IPrime, ZPrime, Z, Y, GG455, OG515, RG610, RG780, CaT, HartmannA_RPrime, HartmannB_RPrime, GPrime_GG455, GPrime_OG515, RPrime_RG610, IPrime_RG780, IPrime_CaT, ZPrime_CaT, Ha, SII, HaC, OIII, OIIIC, HeII, HeIIC, Lya395, OVI, OVIC)
+    List(UPrime, GPrime, RPrime, IPrime, ZPrime, Z, Y, GG455, OG515, RG610, RG780, CaT, HartmannA_RPrime, HartmannB_RPrime, GPrime_GG455, GPrime_OG515, RPrime_RG610, IPrime_RG780, IPrime_CaT, ZPrime_CaT, Ha, SII, HaC, OIII, OIIIC, HeII, HeIIC, OVI, OVIC)
 
   /** Acquisition filter options. */
   val acquisition: NonEmptyList[GmosSouthFilter] =
     NonEmptyList.fromListUnsafe(
-      List(UPrime, GPrime, RPrime, IPrime, ZPrime).filter(!_.obsolete)
+      List(UPrime, GPrime, RPrime, IPrime, ZPrime)
     )
 
   /** Select the member of GmosSouthFilter with the given tag, if any. */

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthGrating.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthGrating.scala
@@ -30,8 +30,7 @@ sealed abstract class GmosSouthGrating(
   val dispersion:           Quantity[Rational, NanometersPerPixel],
   val simultaneousCoverage: WavelengthDelta,
   val blazeWavelength:      Wavelength,
-  val referenceResolution:  PosInt,
-  val obsolete:             Boolean
+  val referenceResolution:  PosInt
 ) extends Product with Serializable {
 
   /**
@@ -74,8 +73,7 @@ object GmosSouthGrating {
     dispersion           = pmToDispersion( 26),
     simultaneousCoverage = nmToWavelengthDelta( 159),
     blazeWavelength      = blazeNm( 463),
-    referenceResolution  = resolution(3744),
-    obsolete             = false
+    referenceResolution  = resolution(3744)
   )
 
   /** @group Constructors */
@@ -87,8 +85,7 @@ object GmosSouthGrating {
     dispersion           = pmToDispersion( 38),
     simultaneousCoverage = nmToWavelengthDelta( 230),
     blazeWavelength      = blazeNm(757),
-    referenceResolution  = resolution(4396),
-    obsolete             = false
+    referenceResolution  = resolution(4396)
   )
 
   /** @group Constructors */
@@ -100,8 +97,7 @@ object GmosSouthGrating {
     dispersion           = pmToDispersion( 50),
     simultaneousCoverage = nmToWavelengthDelta( 307),
     blazeWavelength      = blazeNm( 461),
-    referenceResolution  = resolution(1688),
-    obsolete             = false
+    referenceResolution  = resolution(1688)
   )
 
   /** @group Constructors */
@@ -113,8 +109,7 @@ object GmosSouthGrating {
     dispersion           = pmToDispersion( 52),
     simultaneousCoverage = nmToWavelengthDelta( 318),
     blazeWavelength      = blazeNm( 926),
-    referenceResolution  = resolution(3744),
-    obsolete             = false
+    referenceResolution  = resolution(3744)
   )
 
   /** @group Constructors */
@@ -126,8 +121,7 @@ object GmosSouthGrating {
     dispersion           = pmToDispersion( 62),
     simultaneousCoverage = nmToWavelengthDelta( 390),
     blazeWavelength      = blazeNm( 422),
-    referenceResolution  = resolution(1520),
-    obsolete             = false
+    referenceResolution  = resolution(1520)
   )
 
   /** @group Constructors */
@@ -139,8 +133,7 @@ object GmosSouthGrating {
     dispersion           = pmToDispersion( 74),
     simultaneousCoverage = nmToWavelengthDelta( 462),
     blazeWavelength      = blazeNm( 764),
-    referenceResolution  = resolution(1918),
-    obsolete             = false
+    referenceResolution  = resolution(1918)
   )
 
   /** @group Constructors */
@@ -152,8 +145,7 @@ object GmosSouthGrating {
     dispersion           = pmToDispersion(193),
     simultaneousCoverage = nmToWavelengthDelta(1190),
     blazeWavelength      = blazeNm( 717),
-    referenceResolution  = resolution(631),
-    obsolete             = false
+    referenceResolution  = resolution(631)
   )
 
   /** All members of GmosSouthDisperser, in canonical order. */

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthStageMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthStageMode.scala
@@ -14,20 +14,18 @@ import lucuma.core.util.Enumerated
 sealed abstract class GmosSouthStageMode(
   val tag: String,
   val shortName: String,
-  val longName: String,
-  val obsolete: Boolean
+  val longName: String
 ) extends Product with Serializable
 
 object GmosSouthStageMode {
 
-  /** @group Constructors */ case object NoFollow extends GmosSouthStageMode("NoFollow", "No Follow", "Do Not Follow", false)
-  /** @group Constructors */ case object FollowXyz extends GmosSouthStageMode("FollowXyz", "Follow XYZ", "Follow in XYZ(focus)", false)
-  /** @group Constructors */ case object FollowXy extends GmosSouthStageMode("FollowXy", "Follow XY", "Follow in XY", true)
-  /** @group Constructors */ case object FollowZ extends GmosSouthStageMode("FollowZ", "Follow Z", "Follow in Z Only", false)
+  /** @group Constructors */ case object NoFollow extends GmosSouthStageMode("NoFollow", "No Follow", "Do Not Follow")
+  /** @group Constructors */ case object FollowXyz extends GmosSouthStageMode("FollowXyz", "Follow XYZ", "Follow in XYZ(focus)")
+  /** @group Constructors */ case object FollowZ extends GmosSouthStageMode("FollowZ", "Follow Z", "Follow in Z Only")
 
   /** All members of GmosSouthStageMode, in canonical order. */
   val all: List[GmosSouthStageMode] =
-    List(NoFollow, FollowXyz, FollowXy, FollowZ)
+    List(NoFollow, FollowXyz, FollowZ)
 
   /** Select the member of GmosSouthStageMode with the given tag, if any. */
   def fromTag(s: String): Option[GmosSouthStageMode] =

--- a/modules/core/shared/src/main/scala/lucuma/core/util/Enumerated.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/Enumerated.scala
@@ -93,9 +93,3 @@ object Enumerated {
   extension [A](a: A)(using ev: Enumerated[A])
     def tag: String = ev.tag(a)
 }
-
-/** @group Typeclasses */
-trait Obsoletable[A] {
-  def isActive(a: A): Boolean
-  final def isObsolete(a: A): Boolean = !isActive(a)
-}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/BinningSuite.scala
@@ -21,10 +21,10 @@ final class BinningSuite extends FunSuite {
   def bandNormalized[T]: BandNormalized[T] =
     BandNormalized(none, SortedMap.empty)
 
-  //  Examples with B600
-  //  slit=0.50, fwhm=0.6: 2 2
+  //  Examples with R831
+  //  slit=0.50, fwhm=0.6: 1 2
   //  slit=0.75, fwhm=1.0: 2 4
-  //  slit=1.00, fwhm=1.5: 4 4
+  //  slit=1.00, fwhm=1.5: 2 4
 
   private def testLongslit(
     fpu:        GmosNorthFpu,
@@ -38,46 +38,46 @@ final class BinningSuite extends FunSuite {
     assertEquals(xy, (expectX, expectY))
   }
 
-  test("longslit, B600, slit=0.50, fwhm=0.6: 2 2") {
+  test("longslit, R831, slit=0.50, fwhm=0.6: 1 2") {
     testLongslit(
       GmosNorthFpu.LongSlit_0_50,
       SourceProfile.Gaussian(Angle.microarcseconds.reverseGet(600_000L), bandNormalized),
       ImageQuality.PointOne,
-      GmosNorthGrating.B600_G5307,
-      GmosXBinning.Two,
+      GmosNorthGrating.R831_G5302,
+      GmosXBinning.One,
       GmosYBinning.Two
     )
   }
 
-  test("longslit, B600, slit=0.75, fwhm=1.0: 2 4") {
+  test("longslit, R831, slit=0.75, fwhm=1.0: 2 4") {
     testLongslit(
       GmosNorthFpu.LongSlit_0_75,
       SourceProfile.Gaussian(Angle.microarcseconds.reverseGet(1_000_000L), bandNormalized),
       ImageQuality.PointOne,
-      GmosNorthGrating.B600_G5307,
+      GmosNorthGrating.R831_G5302,
       GmosXBinning.Two,
       GmosYBinning.Four
     )
   }
 
-  test("longslit, B600, slit=1.00, fwhm=1.5: 4 4") {
+  test("longslit, R831, slit=1.00, fwhm=1.5: 2 4") {
     testLongslit(
       GmosNorthFpu.LongSlit_1_00,
       SourceProfile.Gaussian(Angle.microarcseconds.reverseGet(1_500_000L), bandNormalized),
       ImageQuality.PointOne,
-      GmosNorthGrating.B600_G5307,
-      GmosXBinning.Four,
+      GmosNorthGrating.R831_G5302,
+      GmosXBinning.Two,
       GmosYBinning.Four
     )
   }
 
-  test("longslit, B600, slit=0.50, Uniform:  2 4") {
+  test("longslit, R831, slit=0.50, Uniform:  2 4") {
     testLongslit(
       GmosNorthFpu.LongSlit_0_50,
       SourceProfile.Uniform(bandNormalized),
       ImageQuality.PointOne,
-      GmosNorthGrating.B600_G5307,
-      GmosXBinning.Two,
+      GmosNorthGrating.R831_G5302,
+      GmosXBinning.One,
       GmosYBinning.Four
     )
   }
@@ -95,12 +95,12 @@ final class BinningSuite extends FunSuite {
     )
   }
 
-  test("longslit, B600, slit=0.50, fwhm=0.0: 1 1") {
+  test("longslit, R831, slit=0.50, fwhm=0.0: 1 1") {
     testLongslit(
       GmosNorthFpu.LongSlit_0_50,
       SourceProfile.Gaussian(Angle.Angle0, bandNormalized),
       ImageQuality.PointOne,
-      GmosNorthGrating.B600_G5307,
+      GmosNorthGrating.R831_G5302,
       GmosXBinning.One,
       GmosYBinning.One
     )


### PR DESCRIPTION
[Shortcut 4428](https://app.shortcut.com/lucuma/story/4428/remove-gmos-n-r150-g5306-from-api?vc_group_by=week&ct_workflow=all&cf_workflow=500000071) requests the removal from the API of a specific obsolete GMOS North grating.  I think by extension it is requesting the removal of all obsolete items.  So far, I've just removed GMOS and GCal obsolete items since we only support GMOS Longslit at the moment.

We can do this now because there are no old observations that use any of the obsolete items and we've been absolved of the need to import old programs.

The "obsolete" flag was a very poor man's "Resource" workaround in `ocs`.  In GPP this is tied up with dynamic enums and needs to be resolved one way or another once we get the initial public release out.  For now though, it isn't serving any purpose?  We were doing essentially nothing with it.

Thoughts?