### PR TITLE
[Shortcut 4973] Add `DeclaredComplete` execution state

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ExecutionState.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ExecutionState.scala
@@ -27,3 +27,9 @@ enum ExecutionState(val tag: String) derives Enumerated:
 
   /** No more data is expected for this observation or sequence. */
   case Completed   extends ExecutionState("completed")
+
+  /**
+   * The observation has been explicitly declared complete by a user even
+   * though more atoms and/or steps remain.
+   */
+  case DeclaredComplete extends ExecutionState("declared_complete")


### PR DESCRIPTION
Adds a new `ExecutionState` element, `DeclaredComplete`.  It is employed when a user has determined that the observation should be considered complete even though there may be remaining steps prescribed by the generator.