### PR TITLE
Shortcut 4994: remove partner time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.118"
+ThisBuild / tlBaseVersion                         := "0.119"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ChargeClass.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ChargeClass.scala
@@ -10,5 +10,4 @@ import lucuma.core.util.Enumerated
  */
 enum ChargeClass(val tag: String, val name: String, val description: String) derives Enumerated:
   case NonCharged extends ChargeClass("nonCharged", "Non Charged", "Time that is not charged.")
-  case Partner    extends ChargeClass("partner",    "Partner",     "Time charged to a partner country / entity.")
   case Program    extends ChargeClass("program",    "Program",     "Time charged to the science program.")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObserveClass.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObserveClass.scala
@@ -36,7 +36,7 @@ enum ObserveClass(
    */
   val respectsProprietaryPeriod: Boolean
 
-) derives Enumerated {
+) derives Enumerated:
 
   case Science extends ObserveClass(
     "science",
@@ -56,15 +56,6 @@ enum ObserveClass(
     respectsProprietaryPeriod = false
   )
 
-  case PartnerCal extends ObserveClass(
-    "partnerCal",
-    "Nighttime Partner Calibration",
-    "PCAL",
-    ChargeClass.Partner,
-    isCalibration             = true,
-    respectsProprietaryPeriod = false
-  )
-
   case Acquisition extends ObserveClass(
     "acquisition",
     "Acquisition",
@@ -72,15 +63,6 @@ enum ObserveClass(
     ChargeClass.Program,
     isCalibration             = false,
     respectsProprietaryPeriod = true
-  )
-
-  case AcquisitionCal extends ObserveClass(
-    "acquisitionCal",
-    "Acquisition Calibration",
-    "ACAL",
-    ChargeClass.Partner,
-    isCalibration             = true,
-    respectsProprietaryPeriod = false
   )
 
   case DayCal extends ObserveClass(
@@ -92,16 +74,10 @@ enum ObserveClass(
     respectsProprietaryPeriod = false
   )
 
-}
-
-object ObserveClass {
-
-  given Monoid[ObserveClass] with {
+object ObserveClass:
+  given Monoid[ObserveClass] with
     def empty: ObserveClass =
       ObserveClass.DayCal
 
     def combine(c0: ObserveClass, c1: ObserveClass): ObserveClass =
       c0 min c1
-  }
-
-}

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObserveClass.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObserveClass.scala
@@ -10,8 +10,8 @@ import lucuma.core.util.Enumerated
 /**
  * The class of an individual observe and (considering all the observes in an
  * observation) of the observation itself.  The observe classes are listed in
- * priority order.  For example, if one step is a `ProgramCal` and another is
- * a `Science` step, the atom that contains them both is considered `Science`.
+ * priority order.  For example, if one step is a `NightCal` and another is a
+ * `Science` step, the atom that contains them both is considered `Science`.
  */
 enum ObserveClass(
   val tag:          String,
@@ -47,9 +47,9 @@ enum ObserveClass(
     respectsProprietaryPeriod = true
   )
 
-  case ProgramCal extends ObserveClass(
-    "programCal",
-    "Nighttime Program Calibration",
+  case NightCal extends ObserveClass(
+    "nightCal",
+    "Nighttime Calibration",
     "NCAL",
     ChargeClass.Program,
     isCalibration             = true,

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/PlannedTime.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/PlannedTime.scala
@@ -118,10 +118,7 @@ object PlannedTime {
   given Order[PlannedTime] =
     Order.whenEqual[PlannedTime](
       Order.by(pt => ChargeClass.values.toList.foldMap(pt.getOrZero)),  // Order.by(_.sum) picks up Map's sum :-/
-      Order.whenEqual(
-        Order.by(_.getOrZero(ChargeClass.Program)),
-        Order.by(_.getOrZero(ChargeClass.Partner))
-      )
+      Order.by(_.getOrZero(ChargeClass.Program))
     )
 
   val ToCategorizedTime: Iso[PlannedTime, CategorizedTime] =

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/CategorizedTimeSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/CategorizedTimeSuite.scala
@@ -47,7 +47,6 @@ final class CategorizedTimeSuite extends DisciplineSuite {
   test("apply") {
     forAll { (a: CategorizedTime) =>
       assertEquals(a(ChargeClass.Program), a.programTime)
-      assertEquals(a(ChargeClass.Partner), a.partnerTime)
       assertEquals(a(ChargeClass.NonCharged), a.nonCharged)
     }
   }
@@ -60,15 +59,14 @@ final class CategorizedTimeSuite extends DisciplineSuite {
 
   test("sum") {
     forAll { (a: CategorizedTime) =>
-      assertEquals(a.sum, a(ChargeClass.Program) +| a(ChargeClass.Partner) +| a(ChargeClass.NonCharged))
+      assertEquals(a.sum, a(ChargeClass.Program) +| a(ChargeClass.NonCharged))
     }
   }
 
   test("CategorizedTime.Zero equals explicitly specified TimeSpan.Zero charges") {
     assertEquals(
       CategorizedTime(
-        ChargeClass.Program -> TimeSpan.Zero,
-        ChargeClass.Partner -> TimeSpan.Zero,
+        ChargeClass.Program    -> TimeSpan.Zero,
         ChargeClass.NonCharged -> TimeSpan.Zero
       ),
       CategorizedTime.Zero


### PR DESCRIPTION
The concept of "partner time" from `ocs` is [being removed in GPP](https://app.shortcut.com/lucuma/story/4994/remove-partner-time?vc_group_by=week&ct_workflow=all&cf_workflow=500000071).  That implies the removal of the `PartnerCal` and `AcquisitionCal` observe classes which existed to distinguish the charge class from `Program` time.