### PR TITLE
Add some more `InputValidSplitEpi` instances

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidSplitEpi.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/validation/InputValidSplitEpi.scala
@@ -8,9 +8,14 @@ import cats.syntax.all.*
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.Validate as RefinedValidate
 import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.NonNegative
 import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
+import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.numeric.NonNegLong
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.PosLong
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.optics.*
 import lucuma.core.syntax.string.*
@@ -108,6 +113,40 @@ object InputValidSplitEpi {
     refinedInt[Positive]
 
   /**
+   * `InputValidSplitEpi` for `NonNegInt`
+   */
+  val nonNegInt: InputValidSplitEpi[NonNegInt] =
+    refinedInt[NonNegative]
+
+
+  /**
+   * `InputValidSplitEpi` for `Long`
+   */
+  val long: InputValidSplitEpi[Long] =
+    InputValidSplitEpi(
+      s => fixIntString(s).toLongOption.toRight(NonEmptyChain("Must be an integer".refined)),
+      _.toString
+    )
+
+  /**
+   * Build a `InputValidSplitEpi` for `Long Refined P`
+   */
+  def refinedLong[P](implicit v: RefinedValidate[Long, P]): InputValidSplitEpi[Long Refined P] =
+    long.refined[P](_ => NonEmptyChain("Invalid format".refined))
+
+  /**
+   * `InputValidSplitEpi` for `PosLong`.
+   */
+  val posLong: InputValidSplitEpi[PosLong] =
+    refinedLong[Positive]
+
+  /**
+   * `InputValidSplitEpi` for `NonNegLong`.
+   */
+  val nonNegLong: InputValidSplitEpi[NonNegLong] =
+    refinedLong[NonNegative]
+
+  /**
    * `InputValidSplitEpi` for `BigDecimal`.
    *
    * Does not, and cannot, format to a particular number of decimal places. For that you need a
@@ -132,6 +171,12 @@ object InputValidSplitEpi {
    */
   val posBigDecimal: InputValidSplitEpi[PosBigDecimal] =
     refinedBigDecimal[Positive]
+
+  /**
+   * `InputValidSplitEpi` for `NonNegBigDecimal`
+   */
+  val nonNegBigDecimal: InputValidSplitEpi[NonNegBigDecimal] =
+    refinedBigDecimal[NonNegative]
 
   /**
    * `InputValidSplitEpi` for `BigDecimal`, formatting with only one integer digit.

--- a/modules/testkit/src/main/scala/lucuma/core/math/arb/LimitedBigDecimals.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/math/arb/LimitedBigDecimals.scala
@@ -3,6 +3,7 @@
 
 package lucuma.core.math.arb
 
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import org.scalacheck.*
 
@@ -22,4 +23,12 @@ trait LimitedBigDecimals:
         .map(_.abs)
         .suchThat(_ > 0)
         .map(PosBigDecimal.unsafeFrom)
+    )
+
+  given Arbitrary[NonNegBigDecimal] =
+    Arbitrary(
+      given_Arbitrary_BigDecimal.arbitrary
+        .map(_.abs)
+        .suchThat(_ >= 0)
+        .map(NonNegBigDecimal.unsafeFrom)
     )

--- a/modules/tests/shared/src/test/scala/lucuma/core/validation/InputValidSplitEpiInstancesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/validation/InputValidSplitEpiInstancesSuite.scala
@@ -15,8 +15,13 @@ final class InputValidSplitEpiInstancesSuite extends DisciplineSuite with Limite
   checkAll("nonEmptyString", ValidSplitEpiTests(InputValidSplitEpi.nonEmptyString).validSplitEpi)
   checkAll("int", ValidSplitEpiTests(InputValidSplitEpi.int).validSplitEpi)
   checkAll("posInt", ValidSplitEpiTests(InputValidSplitEpi.posInt).validSplitEpi)
+  checkAll("nonNegInt", ValidSplitEpiTests(InputValidSplitEpi.nonNegInt).validSplitEpi)
+  checkAll("long", ValidSplitEpiTests(InputValidSplitEpi.long).validSplitEpi)
+  checkAll("posLong", ValidSplitEpiTests(InputValidSplitEpi.posLong).validSplitEpi)
+  checkAll("nonNegLong", ValidSplitEpiTests(InputValidSplitEpi.nonNegLong).validSplitEpi)
   checkAll("bigDecimal", ValidSplitEpiTests(InputValidSplitEpi.bigDecimal).validSplitEpi)
   checkAll("posBigDecimal", ValidSplitEpiTests(InputValidSplitEpi.posBigDecimal).validSplitEpi)
+  checkAll("nonNegBigDecimal", ValidSplitEpiTests(InputValidSplitEpi.nonNegBigDecimal).validSplitEpi)
   checkAll(
     "bigDecimalWithScientificNotation",
     ValidSplitEpiTests(InputValidSplitEpi.bigDecimalWithScientificNotation).validSplitEpi


### PR DESCRIPTION
A couple of these were already in explore with `// TODO: Move to core`. I'll remove those from explore in my next explore PR.