### PR TITLE
Shortcut 4365: Require custom mask filename

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/f2/F2FpuMask.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/f2/F2FpuMask.scala
@@ -41,7 +41,7 @@ sealed trait F2FpuMask:
     fold(none, _ => none, _.some)
 
   def customFilename: Option[NonEmptyString] =
-    custom.flatMap(_.filename)
+    custom.map(_.filename)
 
   def customSlitWidth: Option[F2CustomSlitWidth] =
     custom.map(_.slitWidth)
@@ -68,13 +68,13 @@ object F2FpuMask:
     def value: Iso[Builtin, F2Fpu] =
       Iso[Builtin, F2Fpu](_.value)(Builtin.apply)
 
-  case class Custom(filename: Option[NonEmptyString], slitWidth: F2CustomSlitWidth) extends F2FpuMask
+  case class Custom(filename: NonEmptyString, slitWidth: F2CustomSlitWidth) extends F2FpuMask
 
   object Custom:
     given Eq[Custom] = Eq.by(x => (x.filename, x.slitWidth))
 
     /** @group Optics */
-    val filename: Lens[Custom, Option[NonEmptyString]] =
+    val filename: Lens[Custom, NonEmptyString] =
       Focus[Custom](_.filename)
 
     /** @group Optics */

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/f2/arb/ArbF2FpuMask.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/f2/arb/ArbF2FpuMask.scala
@@ -23,18 +23,18 @@ trait ArbF2FpuMask:
         F2FpuMask.Imaging,
         Gen.oneOf(Enumerated[F2Fpu].all).map(F2FpuMask.Builtin(_)),
         for
-          f <- arbitrary[Option[NonEmptyString]]
+          f <- arbitrary[NonEmptyString]
           s <- arbitrary[F2CustomSlitWidth]
         yield F2FpuMask.Custom(f, s)
       )
     )
 
   given Cogen[F2FpuMask] =
-    Cogen[Option[Either[F2Fpu, (Option[String], F2CustomSlitWidth)]]]
+    Cogen[Option[Either[F2Fpu, (String, F2CustomSlitWidth)]]]
       .contramap {
         case F2FpuMask.Imaging => none
         case F2FpuMask.Builtin(b) => b.asLeft.some
-        case F2FpuMask.Custom(f, s) => (f.map(_.value), s).asRight.some
+        case F2FpuMask.Custom(f, s) => (f.value, s).asRight.some
       }
 
 object ArbF2FpuMask extends ArbF2FpuMask


### PR DESCRIPTION
Changes the F2 custom mask to require a filename.  This matches GMOS and, I think, in reality there is a mask definition file which must be identified.

This isn't needed for F2 long slit, but it is needed to fully define the F2 dynamic configuration for steps and those must be recorded as steps are executed.