### PR TITLE
Shortcut 4365: Remove custom slit width from static config

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/f2/F2StaticConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/f2/F2StaticConfig.scala
@@ -5,19 +5,17 @@ package lucuma.core.model.sequence.f2
 
 import cats.Eq
 import cats.syntax.all.*
-import lucuma.core.enums.*
 import monocle.Focus
 import monocle.Lens
 
 case class F2StaticConfig(
   mosPreImaging:          Boolean,
-  useElectronicOffseting: Boolean,
-  customSlitWidth:        Option[F2CustomSlitWidth]
+  useElectronicOffseting: Boolean
 )
 
 object F2StaticConfig:
   given Eq[F2StaticConfig] =
-    Eq.by(x => (x.mosPreImaging, x.useElectronicOffseting, x.customSlitWidth))
+    Eq.by(x => (x.mosPreImaging, x.useElectronicOffseting))
 
   /** @group Optics */
   val mosPreImaging: Lens[F2StaticConfig, Boolean] =
@@ -26,8 +24,3 @@ object F2StaticConfig:
   /** @group Optics */
   val useElectronicOffsetting: Lens[F2StaticConfig, Boolean] =
     Focus[F2StaticConfig](_.useElectronicOffseting)
-
-  /** @group Optics */
-  val customSlitWidth: Lens[F2StaticConfig, Option[F2CustomSlitWidth]] =
-    Focus[F2StaticConfig](_.customSlitWidth)
-

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/f2/F2StaticConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/f2/F2StaticConfig.scala
@@ -5,11 +5,12 @@ package lucuma.core.model.sequence.f2
 
 import cats.Eq
 import cats.syntax.all.*
+import lucuma.core.enums.MosPreImaging
 import monocle.Focus
 import monocle.Lens
 
 case class F2StaticConfig(
-  mosPreImaging:          Boolean,
+  mosPreImaging:          MosPreImaging,
   useElectronicOffseting: Boolean
 )
 
@@ -18,7 +19,7 @@ object F2StaticConfig:
     Eq.by(x => (x.mosPreImaging, x.useElectronicOffseting))
 
   /** @group Optics */
-  val mosPreImaging: Lens[F2StaticConfig, Boolean] =
+  val mosPreImaging: Lens[F2StaticConfig, MosPreImaging] =
     Focus[F2StaticConfig](_.mosPreImaging)
 
   /** @group Optics */

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/f2/arb/ArbF2StaticConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/f2/arb/ArbF2StaticConfig.scala
@@ -3,26 +3,22 @@
 
 package lucuma.core.model.sequence.f2.arb
 
-import lucuma.core.enums.*
 import lucuma.core.model.sequence.f2.F2StaticConfig
-import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.*
 import org.scalacheck.Cogen
 
 trait ArbF2StaticConfig:
-  import ArbEnumerated.given
 
   given Arbitrary[F2StaticConfig] = Arbitrary(
     for
       mosPreImaging          <- arbitrary[Boolean]
       useElectronicOffseting <- arbitrary[Boolean]
-      customSlitWidth        <- arbitrary[Option[F2CustomSlitWidth]]
-    yield F2StaticConfig(mosPreImaging, useElectronicOffseting, customSlitWidth)
+    yield F2StaticConfig(mosPreImaging, useElectronicOffseting)
   )
 
   given Cogen[F2StaticConfig] =
-    Cogen[(Boolean, Boolean, Option[F2CustomSlitWidth])]
-      .contramap(s => (s.mosPreImaging, s.useElectronicOffseting, s.customSlitWidth))
+    Cogen[(Boolean, Boolean)]
+      .contramap(s => (s.mosPreImaging, s.useElectronicOffseting))
 
 object ArbF2StaticConfig extends ArbF2StaticConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/f2/arb/ArbF2StaticConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/f2/arb/ArbF2StaticConfig.scala
@@ -3,22 +3,26 @@
 
 package lucuma.core.model.sequence.f2.arb
 
+import lucuma.core.enums.MosPreImaging
 import lucuma.core.model.sequence.f2.F2StaticConfig
+import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.*
 import org.scalacheck.Cogen
 
 trait ArbF2StaticConfig:
 
+  import ArbEnumerated.given
+
   given Arbitrary[F2StaticConfig] = Arbitrary(
     for
-      mosPreImaging          <- arbitrary[Boolean]
+      mosPreImaging          <- arbitrary[MosPreImaging]
       useElectronicOffseting <- arbitrary[Boolean]
     yield F2StaticConfig(mosPreImaging, useElectronicOffseting)
   )
 
   given Cogen[F2StaticConfig] =
-    Cogen[(Boolean, Boolean)]
+    Cogen[(MosPreImaging, Boolean)]
       .contramap(s => (s.mosPreImaging, s.useElectronicOffseting))
 
 object ArbF2StaticConfig extends ArbF2StaticConfig


### PR DESCRIPTION
Custom slit width is applicable to (and indeed already defined in) the `F2FpuMask`, which is part of the dynamic config.