### PR TITLE
Target.Opportunity

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/Arc.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Arc.scala
@@ -130,6 +130,16 @@ object Arc extends ArcOptics {
       case (a @ Partial(a1, b1), b @ Partial(a2, b2)) => a === b
       case _ => false
 
+  given [A: Order]: Order[Arc[A]] =
+    case (Empty(), Empty()) => 0
+    case (Full(), Full()) => 0
+    case (Arc.Empty(), _) => -1
+    case (_, Arc.Empty()) =>  1
+    case (Arc.Full(), _)  => 1
+    case (_, Arc.Full())  => -1
+    case (Arc.Partial(a1, b1), Arc.Partial(a2, b2)) => 
+      (a1, b1) compare (a2, b2)
+
 }
 
 trait ArcOptics {

--- a/modules/core/shared/src/main/scala/lucuma/core/math/Region.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Region.scala
@@ -4,6 +4,7 @@
 package lucuma.core.math
 
 import cats.Eq
+import cats.kernel.Order
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
@@ -44,6 +45,10 @@ object Region extends RegionOptics {
 
   given Eq[Region] =
     Eq.by(a => (a.raArc, a.decArc))
+
+  given Order[Region] =
+    Order.by: r => 
+      (r.raArc, r.decArc)
 
 }
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/RegionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/RegionSuite.scala
@@ -5,6 +5,7 @@ package lucuma.core.math
 
 import cats.Eq
 import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.OrderTests
 import lucuma.core.math.arb.*
 import monocle.law.discipline.OptionalTests
 import org.scalacheck.Arbitrary
@@ -20,6 +21,7 @@ final class RegionSuite extends munit.DisciplineSuite:
   val label = s"Region"
   
   checkAll(label, EqTests[Region].eqv)
+  checkAll(label, OrderTests[Region].order)
   checkAll(label, OptionalTests(Region.raArc))
   checkAll(label, OptionalTests(Region.raArcStart))
   checkAll(label, OptionalTests(Region.raArcEnd))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TargetSuite.scala
@@ -37,6 +37,7 @@ class TargetSuite extends DisciplineSuite {
   import ArbProperMotion.given
   import ArbRadialVelocity.given
   import ArbRefined.given
+  import ArbRegion.given
   import ArbRightAscension.given
   import ArbSiderealTracking.given
   import ArbSourceProfile.given
@@ -263,6 +264,110 @@ class TargetSuite extends DisciplineSuite {
     "Target.Nonsidereal.surfaceFluxDensityContinuum",
     OptionalTests(Target.Nonsidereal.surfaceFluxDensityContinuum)
   )
+
+  // Laws for Target.Opportunity
+  checkAll("Eq[Target.Opportunity]", EqTests[Target.Opportunity].eqv)
+  checkAll(
+    "Target.Opportunity.RegionOrder", 
+    OrderTests[Target.Opportunity](using Target.Opportunity.RegionOrder).order
+  )
+  checkAll(
+    "Target.Opportunity.NameOrder", 
+    OrderTests[Target.Opportunity](using Target.Opportunity.NameOrder).order
+  )
+  checkAll("Target.Opportunity.name", LensTests(Target.Opportunity.name))
+  checkAll("Target.Opportunity.region", LensTests(Target.Opportunity.region))
+  checkAll("Target.Opportunity.sourceProfile", LensTests(Target.Opportunity.sourceProfile))
+  checkAll(
+    "Target.Opportunity.integratedSpectralDefinition",
+    OptionalTests(Target.Opportunity.integratedSpectralDefinition)
+  )
+  checkAll(
+    "Target.Opportunity.surfaceSpectralDefinition",
+    OptionalTests(Target.Opportunity.surfaceSpectralDefinition)
+  )
+  checkAll("Target.Opportunity.fwhm", OptionalTests(Target.Opportunity.fwhm))
+  checkAll(
+    "Target.Opportunity.integratedBandNormalizedSpectralDefinition",
+    OptionalTests(Target.Opportunity.integratedBandNormalizedSpectralDefinition)
+  )
+  checkAll(
+    "Target.Opportunity.surfaceBandNormalizedSpectralDefinition",
+    OptionalTests(Target.Opportunity.surfaceBandNormalizedSpectralDefinition)
+  )
+  checkAll(
+    "Target.Opportunity.integratedEmissionLinesSpectralDefinition",
+    OptionalTests(Target.Opportunity.integratedEmissionLinesSpectralDefinition)
+  )
+  checkAll(
+    "Target.Opportunity.surfaceEmissionLinesSpectralDefinition",
+    OptionalTests(Target.Opportunity.surfaceEmissionLinesSpectralDefinition)
+  )
+  checkAll(
+    "Target.Opportunity.unnormalizedSED",
+    OptionalTests(Target.Opportunity.unnormalizedSED)
+  )
+  checkAll(
+    "Target.Opportunity.integratedBrightnesses",
+    OptionalTests(Target.Opportunity.integratedBrightnesses)
+  )
+  checkAll(
+    "Target.Opportunity.surfaceBrightnesses",
+    OptionalTests(Target.Opportunity.surfaceBrightnesses)
+  )
+  checkAll(
+    "Target.Opportunity.integratedBrightnessesT",
+    TraversalTests(Target.Opportunity.integratedBrightnessesT)
+  )
+  checkAll(
+    "Target.Opportunity.surfaceBrightnessesT",
+    TraversalTests(Target.Opportunity.surfaceBrightnessesT)
+  )
+  checkAll(
+    "Target.Opportunity.integratedBrightnessIn",
+    TraversalTests(Target.Opportunity.integratedBrightnessIn(Band.B))
+  )
+  checkAll(
+    "Target.Opportunity.surfaceBrightnessIn",
+    TraversalTests(Target.Opportunity.surfaceBrightnessIn(Band.B))
+  )
+  checkAll(
+    "Target.Opportunity.integratedWavelengthLines",
+    OptionalTests(Target.Opportunity.integratedWavelengthLines)
+  )
+  checkAll(
+    "Target.Opportunity.surfaceWavelengthLines",
+    OptionalTests(Target.Opportunity.surfaceWavelengthLines)
+  )
+  checkAll(
+    "Target.Opportunity.integratedWavelengthLinesT",
+    TraversalTests(Target.Opportunity.integratedWavelengthLinesT)
+  )
+  checkAll(
+    "Target.Opportunity.surfaceWavelengthLinesT",
+    TraversalTests(Target.Opportunity.surfaceWavelengthLinesT)
+  )
+  checkAll(
+    "Target.Opportunity.integratedWavelengthLineIn",
+    TraversalTests(
+      Target.Opportunity.integratedWavelengthLineIn(RedWavelength)
+    )
+  )
+  checkAll(
+    "Target.Opportunity.surfaceWavelengthLineIn",
+    TraversalTests(
+      Target.Opportunity.surfaceWavelengthLineIn(RedWavelength)
+    )
+  )
+  checkAll(
+    "Target.Opportunity.integratedFluxDensityContinuum",
+    OptionalTests(Target.Opportunity.integratedFluxDensityContinuum)
+  )
+  checkAll(
+    "Target.Opportunity.surfaceFluxDensityContinuum",
+    OptionalTests(Target.Opportunity.surfaceFluxDensityContinuum)
+  )
+
 
   // Laws for Target
   checkAll("Target.Id", GidTests[Target.Id].gid)


### PR DESCRIPTION
This adds `Target.Opportunity` which has a `Region` instead of tracking. We already have an unused case (`Nonsidereal`) so the handling in the ODB will be similar for now.