### PR TITLE
Shortcut 6168: GMOS R400 tag change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.138"
+ThisBuild / tlBaseVersion                         := "0.139"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthGrating.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthGrating.scala
@@ -72,10 +72,10 @@ enum GmosNorthGrating(
     referenceResolution  = resolution(1520)
   )
 
-  case R400_G5305  extends GmosNorthGrating(
-    tag                  = "R400_G5305",
+  case R400_G5310  extends GmosNorthGrating(
+    tag                  = "R400_G5310",
     shortName            = "R400",
-    longName             = "R400_G5305",
+    longName             = "R400_G5310",
     rulingDensity        = 400,
     dispersion           = pmToDispersion( 74),
     simultaneousCoverage = nmToWavelengthDelta( 472),


### PR DESCRIPTION
Updates the tag for the GMOS North R400 grating to reflect the new value.

Obviously we have not implemented Resource and we are not yet using the database as the ultimate source of truth for enum values.  The plan to address the R400 swap before XT1 then is to simply rename the R400 grating and rewrite history (if any test steps have been written using the old grating).  Does anybody have a better idea?