### PR TITLE
sc-5673 TOO workflow support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.137"
+ThisBuild / tlBaseVersion                         := "0.138"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
@@ -14,9 +14,9 @@ import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.math.Angle
 import lucuma.core.math.Coordinates
+import lucuma.core.math.Region
 import lucuma.core.model.Configuration.ObservingMode.GmosNorthLongSlit
 import lucuma.core.model.Configuration.ObservingMode.GmosSouthLongSlit
-import lucuma.core.math.Region
 
 case class Configuration(conditions: Configuration.Conditions, target: Either[Coordinates, Region], observingMode: Configuration.ObservingMode) derives Eq:
   def subsumes(other: Configuration): Boolean =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ObjectTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ObjectTracking.scala
@@ -8,13 +8,13 @@ import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.all.*
 import lucuma.core.math.Coordinates
+import lucuma.core.math.Region
+import lucuma.core.model.Target.Nonsidereal
+import lucuma.core.model.Target.Opportunity
 import lucuma.core.model.syntax.tracking.*
 import lucuma.core.util.NewType
 
 import java.time.Instant
-import lucuma.core.model.Target.Nonsidereal
-import lucuma.core.model.Target.Opportunity
-import lucuma.core.math.Region
 
 // Tag to indicate the coordinates have been corrected for proper motion
 object CoordinatesAtVizTime extends NewType[Coordinates]

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ObjectTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ObjectTracking.scala
@@ -12,6 +12,9 @@ import lucuma.core.model.syntax.tracking.*
 import lucuma.core.util.NewType
 
 import java.time.Instant
+import lucuma.core.model.Target.Nonsidereal
+import lucuma.core.model.Target.Opportunity
+import lucuma.core.math.Region
 
 // Tag to indicate the coordinates have been corrected for proper motion
 object CoordinatesAtVizTime extends NewType[Coordinates]
@@ -41,17 +44,34 @@ object ObjectTracking:
     def at(i: Instant): Option[CoordinatesAtVizTime] = CoordinatesAtVizTime(coordinates).some
     def baseCoordinates: Coordinates = coordinates
 
+  def fromTarget(target: Target): Option[ObjectTracking] =
+    orRegionFromTarget(target).left.toOption
 
-  def fromTarget(target: Target): ObjectTracking = target match
-    case t: Target.Sidereal => SiderealObjectTracking(t.tracking)
-    case _                  => sys.error("Only sidereal targets supported")
+  def orRegionFromTarget(target: Target): Either[ObjectTracking, Region] =
+    target match
+      case t: Target.Sidereal    => SiderealObjectTracking(t.tracking).asLeft
+      case t: Target.Opportunity => t.region.asRight 
+      case t: Target.Nonsidereal => sys.error("Nonsidereal targets not supported yet.")    
 
-  def fromAsterism(targets: NonEmptyList[Target]): ObjectTracking = 
-    val trackingList = targets.toList.traverse(Target.sidereal.getOption).flatMap(NonEmptyList.fromList)
-    trackingList.fold(sys.error("Only sidereal targets supported")) { sidereals =>
-      if (sidereals.length === 1) SiderealObjectTracking(sidereals.head.tracking)
-      else SiderealAsterismTracking(sidereals.map(_.tracking))
-    }
+  def fromAsterism(targets: NonEmptyList[Target]): Option[ObjectTracking] =
+    orRegionFromAsterism(targets).left.toOption
+
+  def orRegionFromAsterism(targets: NonEmptyList[Target]): Either[ObjectTracking, Region] =
+    targets
+      .collect:
+        case Target.Nonsidereal(_, _, _) => sys.error("Nonsidereal targets not supported yet.")
+        case Target.Opportunity(_, r, _) => r
+      .headOption // first region, if any
+      .toRight:
+        targets
+          .map: t =>
+            Target
+              .sidereal
+              .getOption(t)
+              .getOrElse(sys.error("unpossible, list should only contain sidereal targets"))          
+          match          
+            case NonEmptyList(h, Nil) => SiderealObjectTracking(h.tracking)
+            case NonEmptyList(h, t)   => SiderealAsterismTracking(NonEmptyList(h, t).map(_.tracking))
 
   def constant(coordinates: Coordinates): ObjectTracking =
     ConstantTracking(coordinates)

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
@@ -70,6 +70,6 @@ trait ArbConfiguration:
   
   given Cogen[Configuration] =
     Cogen[(Conditions, Either[Coordinates, Region], ObservingMode)]
-      .contramap(c => (c.conditions, c.refererenceCoordinates, c.observingMode))
+      .contramap(c => (c.conditions, c.target, c.observingMode))
 
 object ArbConfiguration extends ArbConfiguration

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
@@ -9,14 +9,14 @@ import lucuma.core.enums.GmosSouthGrating
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.math.Coordinates
+import lucuma.core.math.Region
 import lucuma.core.math.arb.ArbCoordinates.given
+import lucuma.core.math.arb.ArbRegion.given
 import lucuma.core.model.CloudExtinction
 import lucuma.core.util.arb.ArbEnumerated.given
-import lucuma.core.math.arb.ArbRegion.given
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen.*
-import lucuma.core.math.Region
 
 trait ArbConfiguration:
   import Configuration.Conditions

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
@@ -12,9 +12,11 @@ import lucuma.core.math.Coordinates
 import lucuma.core.math.arb.ArbCoordinates.given
 import lucuma.core.model.CloudExtinction
 import lucuma.core.util.arb.ArbEnumerated.given
+import lucuma.core.math.arb.ArbRegion.given
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen.*
+import lucuma.core.math.Region
 
 trait ArbConfiguration:
   import Configuration.Conditions
@@ -62,12 +64,12 @@ trait ArbConfiguration:
     Arbitrary:
       for
         c <- arbitrary[Conditions]
-        r <- arbitrary[Coordinates]
+        r <- arbitrary[Either[Coordinates, Region]]
         o <- arbitrary[ObservingMode]
       yield (Configuration(c, r, o))
   
   given Cogen[Configuration] =
-    Cogen[(Conditions, Coordinates, ObservingMode)]
+    Cogen[(Conditions, Either[Coordinates, Region], ObservingMode)]
       .contramap(c => (c.conditions, c.refererenceCoordinates, c.observingMode))
 
 object ArbConfiguration extends ArbConfiguration


### PR DESCRIPTION
wip: This updates `Configuration` to accept either coordinates (for a sidereal target) or a `Region` (for opportunity targets). This is a breaking change that has corresponding schema updates in https://github.com/gemini-hlsw/lucuma-odb/pull/1891