### PR TITLE
Shortcut 6292: Delete G5323

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.140"
+ThisBuild / tlBaseVersion                         := "0.141"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthGrating.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthGrating.scala
@@ -50,17 +50,6 @@ enum GmosSouthGrating(
     referenceResolution  = resolution(4396)
   )
 
-  case B600_G5323  extends GmosSouthGrating(
-    tag                  = "B600_G5323",
-    shortName            = "B600",
-    longName             = "B600_G5323",
-    rulingDensity        = 600,
-    dispersion           = pmToDispersion( 50),
-    simultaneousCoverage = nmToWavelengthDelta( 307),
-    blazeWavelength      = blazeNm( 461),
-    referenceResolution  = resolution(1688)
-  )
-
   case R600_G5324  extends GmosSouthGrating(
     tag                  = "R600_G5324",
     shortName            = "R600",


### PR DESCRIPTION
Removes the GMOS South G5323 grating option.