### PR TITLE
Shortcut 5099: Add client id to execution events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.139"
+ThisBuild / tlBaseVersion                         := "0.140"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Client.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Client.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import lucuma.core.util.WithUid
+import lucuma.refined.*
+
+object Client extends WithUid('c'.refined)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ExecutionEvent.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ExecutionEvent.scala
@@ -25,6 +25,7 @@ sealed trait ExecutionEvent derives Eq {
   def received:      Timestamp
   def observationId: Observation.Id
   def visitId:       Visit.Id
+  def clientId:      Option[Client.Id]
 
   import ExecutionEvent.*
 
@@ -36,11 +37,11 @@ sealed trait ExecutionEvent derives Eq {
     datasetEvent:  DatasetEvent  => A
   ): A =
     this match {
-      case e@SlewEvent(_, _, _, _, _)             => slewEvent(e)
-      case e@SequenceEvent(_, _, _, _, _)         => sequenceEvent(e)
-      case e@AtomEvent(_, _, _, _, _, _)          => atomEvent(e)
-      case e@StepEvent(_, _, _, _, _, _, _)       => stepEvent(e)
-      case e@DatasetEvent(_, _, _, _, _, _, _, _) => datasetEvent(e)
+      case e@SlewEvent(_, _, _, _, _, _)             => slewEvent(e)
+      case e@SequenceEvent(_, _, _, _, _, _)         => sequenceEvent(e)
+      case e@AtomEvent(_, _, _, _, _, _, _)          => atomEvent(e)
+      case e@StepEvent(_, _, _, _, _, _, _, _)       => stepEvent(e)
+      case e@DatasetEvent(_, _, _, _, _, _, _, _, _) => datasetEvent(e)
     }
 
 }
@@ -52,6 +53,7 @@ object ExecutionEvent extends WithGid('e'.refined) {
     received:      Timestamp,
     observationId: Observation.Id,
     visitId:       Visit.Id,
+    clientId:      Option[Client.Id],
     stage:         SlewStage
   ) extends ExecutionEvent derives Eq
 
@@ -60,6 +62,7 @@ object ExecutionEvent extends WithGid('e'.refined) {
     received:      Timestamp,
     observationId: Observation.Id,
     visitId:       Visit.Id,
+    clientId:      Option[Client.Id],
     command:       SequenceCommand
   ) extends ExecutionEvent derives Eq
 
@@ -68,6 +71,7 @@ object ExecutionEvent extends WithGid('e'.refined) {
     received:      Timestamp,
     observationId: Observation.Id,
     visitId:       Visit.Id,
+    clientId:      Option[Client.Id],
     atomId:        Atom.Id,
     stage:         AtomStage
   ) extends ExecutionEvent derives Eq
@@ -77,6 +81,7 @@ object ExecutionEvent extends WithGid('e'.refined) {
     received:      Timestamp,
     observationId: Observation.Id,
     visitId:       Visit.Id,
+    clientId:      Option[Client.Id],
     atomId:        Atom.Id,
     stepId:        Step.Id,
     stage:         StepStage
@@ -87,6 +92,7 @@ object ExecutionEvent extends WithGid('e'.refined) {
     received:      Timestamp,
     observationId: Observation.Id,
     visitId:       Visit.Id,
+    clientId:      Option[Client.Id],
     atomId:        Atom.Id,
     stepId:        Step.Id,
     datasetId:     Dataset.Id,

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExecutionEvent.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExecutionEvent.scala
@@ -35,10 +35,11 @@ trait ArbExecutionEvent {
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
         aid <- arbitrary[Atom.Id]
+        cid <- arbitrary[Option[Client.Id]]
         sid <- arbitrary[Step.Id]
         did <- arbitrary[Dataset.Id]
         stg <- arbitrary[DatasetStage]
-      } yield ExecutionEvent.DatasetEvent(eid, rec, oid, vid, aid, sid, did, stg)
+      } yield ExecutionEvent.DatasetEvent(eid, rec, oid, vid, cid, aid, sid, did, stg)
     }
 
   given Cogen[ExecutionEvent.DatasetEvent] =
@@ -47,6 +48,7 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
+      Option[Client.Id],
       Atom.Id,
       Step.Id,
       Dataset.Id,
@@ -56,6 +58,7 @@ trait ArbExecutionEvent {
       a.received,
       a.observationId,
       a.visitId,
+      a.clientId,
       a.atomId,
       a.stepId,
       a.datasetId,
@@ -69,8 +72,9 @@ trait ArbExecutionEvent {
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
+        cid <- arbitrary[Option[Client.Id]]
         cmd <- arbitrary[SequenceCommand]
-      } yield ExecutionEvent.SequenceEvent(eid, rec, oid, vid, cmd)
+      } yield ExecutionEvent.SequenceEvent(eid, rec, oid, vid, cid, cmd)
     }
 
   given Cogen[ExecutionEvent.SequenceEvent] =
@@ -79,12 +83,14 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
+      Option[Client.Id],
       SequenceCommand
     )].contramap { a => (
       a.id,
       a.received,
       a.observationId,
       a.visitId,
+      a.clientId,
       a.command
     )}
 
@@ -95,8 +101,9 @@ trait ArbExecutionEvent {
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
+        cid <- arbitrary[Option[Client.Id]]
         stg <- arbitrary[SlewStage]
-      } yield ExecutionEvent.SlewEvent(eid, rec, oid, vid, stg)
+      } yield ExecutionEvent.SlewEvent(eid, rec, oid, vid, cid, stg)
     }
 
   given Cogen[ExecutionEvent.SlewEvent] =
@@ -105,12 +112,14 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
+      Option[Client.Id],
       SlewStage
     )].contramap { a => (
       a.id,
       a.received,
       a.observationId,
       a.visitId,
+      a.clientId,
       a.stage
     )}
 
@@ -121,9 +130,10 @@ trait ArbExecutionEvent {
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
+        cid <- arbitrary[Option[Client.Id]]
         aid <- arbitrary[Atom.Id]
         stg <- arbitrary[AtomStage]
-      } yield ExecutionEvent.AtomEvent(eid, rec, oid, vid, aid, stg)
+      } yield ExecutionEvent.AtomEvent(eid, rec, oid, vid, cid, aid, stg)
     }
 
   given Cogen[ExecutionEvent.AtomEvent] =
@@ -132,6 +142,7 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
+      Option[Client.Id],
       Atom.Id,
       AtomStage
     )].contramap { a => (
@@ -139,6 +150,7 @@ trait ArbExecutionEvent {
       a.received,
       a.observationId,
       a.visitId,
+      a.clientId,
       a.atomId,
       a.stage
     )}
@@ -151,9 +163,10 @@ trait ArbExecutionEvent {
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
         aid <- arbitrary[Atom.Id]
+        cid <- arbitrary[Option[Client.Id]]
         sid <- arbitrary[Step.Id]
         stg <- arbitrary[StepStage]
-      } yield ExecutionEvent.StepEvent(eid, rec, oid, vid, aid, sid, stg)
+      } yield ExecutionEvent.StepEvent(eid, rec, oid, vid, cid, aid, sid, stg)
     }
 
   given Cogen[ExecutionEvent.StepEvent] =
@@ -162,6 +175,7 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
+      Option[Client.Id],
       Atom.Id,
       Step.Id,
       StepStage
@@ -170,6 +184,7 @@ trait ArbExecutionEvent {
       a.received,
       a.observationId,
       a.visitId,
+      a.clientId,
       a.atomId,
       a.stepId,
       a.stage


### PR DESCRIPTION
Adds an optional client id to the execution events.  If observe specifies a client id when it adds an event, and if that client id has been previously used, the attempt would fail with a duplicated event error.  (Requires a corresponding update to the ODB of course.)  How does this sound?

Note, this reuses the `c` prefix, but in a UUID-based id (the Call For Proposals id is gid-based).  I hope this isn't too confusing. 

```
c-123                                  => call for proposals id
c-530c979f-de98-472f-9c23-a3442f2a9f7f => client id
```