### PR TITLE
sc-4512 configuration updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.137"
+ThisBuild / tlBaseVersion                         := "0.138"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/Shape.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/Shape.scala
@@ -3,8 +3,8 @@
 
 package lucuma.core.geom
 
-import lucuma.core.math.Offset
 import lucuma.core.math.Angle
+import lucuma.core.math.Offset
 
 /**
  * Shape description usable for testing point inclusion and calculating the area. Point inclusion is

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/Shape.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/Shape.scala
@@ -4,6 +4,7 @@
 package lucuma.core.geom
 
 import lucuma.core.math.Offset
+import lucuma.core.math.Angle
 
 /**
  * Shape description usable for testing point inclusion and calculating the area. Point inclusion is
@@ -28,5 +29,8 @@ trait Shape {
    * is less useful than comparing across multiple shapes (to determine minimum vignetting).
    */
   def area: Area
+
+  /** Angular distance from the shape's origin to its most distant vertex. */
+  def radius: Angle
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShape.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShape.scala
@@ -5,9 +5,9 @@ package lucuma.core.geom
 package jts
 
 import lucuma.core.geom.jts.syntax.all.*
+import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import org.locationtech.jts.geom.Geometry
-import lucuma.core.math.Angle
 
 /**
  * JTS implementation of Shape.

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShape.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShape.scala
@@ -7,6 +7,7 @@ package jts
 import lucuma.core.geom.jts.syntax.all.*
 import lucuma.core.math.Offset
 import org.locationtech.jts.geom.Geometry
+import lucuma.core.math.Angle
 
 /**
  * JTS implementation of Shape.
@@ -20,6 +21,12 @@ final case class JtsShape(g: Geometry) extends Shape {
 
   override def contains(o: Offset): Boolean =
     g.contains(o.point)
+
+  /** Angular distance from the origin to the most distant vertex. */
+  def radius: Angle =
+    val cs = g.getCoordinates
+    if   cs.isEmpty then Angle.Angle0
+    else cs.maxBy(c => c.x * c.x + c.y * c.y).offset.distance(Offset.Zero)
 
   override def area: Area =
     Area.fromMicroarcsecondsSquared.getOption(g.getArea.round).getOrElse(Area.MinArea)

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/syntax/package.scala
@@ -42,5 +42,14 @@ object syntax {
         f.setEnvelope(envelope(that))
         f
       }
+
+    extension (self: Coordinate)
+
+      def offset: Offset =
+        Offset(
+          Angle.fromMicroarcseconds(-self.x.toLong).p, // unflipped, see above
+          Angle.fromMicroarcseconds(self.y.toLong).q
+        )
+
   }
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
@@ -7,23 +7,23 @@ import cats.Eq
 import cats.derived.*
 import cats.kernel.Order
 import cats.syntax.all.*
+import lucuma.core.enums.Flamingos2Disperser
+import lucuma.core.enums.Flamingos2LyotWheel
+import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosSouthFilter
 import lucuma.core.enums.GmosSouthGrating
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
+import lucuma.core.geom.*
+import lucuma.core.geom.jts.interpreter.given
 import lucuma.core.math.Angle
 import lucuma.core.math.Coordinates
+import lucuma.core.math.Offset
 import lucuma.core.math.Region
 import lucuma.core.model.Configuration.ObservingMode.*
-import lucuma.core.geom.*
-import lucuma.core.math.Offset
 import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
-import lucuma.core.enums.Flamingos2LyotWheel
-import lucuma.core.geom.jts.interpreter.given
-import lucuma.core.enums.GmosNorthFilter
-import lucuma.core.enums.Flamingos2Disperser
-import lucuma.core.enums.GmosSouthFilter
 
 case class Configuration(conditions: Configuration.Conditions, target: Either[Coordinates, Region], observingMode: Configuration.ObservingMode) derives Eq:
   def subsumes(other: Configuration): Boolean =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
@@ -15,15 +15,22 @@ import lucuma.core.enums.WaterVapor
 import lucuma.core.math.Angle
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Region
-import lucuma.core.model.Configuration.ObservingMode.GmosNorthLongSlit
-import lucuma.core.model.Configuration.ObservingMode.GmosSouthLongSlit
+import lucuma.core.model.Configuration.ObservingMode.*
+import lucuma.core.geom.*
+import lucuma.core.math.Offset
+import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
+import lucuma.core.enums.Flamingos2LyotWheel
+import lucuma.core.geom.jts.interpreter.given
+import lucuma.core.enums.GmosNorthFilter
+import lucuma.core.enums.Flamingos2Disperser
+import lucuma.core.enums.GmosSouthFilter
 
 case class Configuration(conditions: Configuration.Conditions, target: Either[Coordinates, Region], observingMode: Configuration.ObservingMode) derives Eq:
   def subsumes(other: Configuration): Boolean =
     conditions >= other.conditions &&
-    observingMode === other.observingMode && {
+    observingMode.subsumes(other.observingMode) && {
     (target, other.target) match
-      case (Left(self), Left(other))   => observingMode.fov.toDoubleDegrees / 2.0 >= self.angularDistance(other).toDoubleDegrees
+      case (Left(self), Left(other))   => observingMode.radius.toDoubleDegrees >= self.angularDistance(other).toDoubleDegrees
       case (Left(self), Right(other))  => false // coords never subsume region
       case (Right(self), Left(other))  => self.contains(other) // region contains coords
       case (Right(self), Right(other)) => self.containsAll(other) // region contains smaller region
@@ -44,23 +51,32 @@ object Configuration:
       Order.reverse: // larger means better here
         Order.by: conds =>
           (conds.cloudExtinction, conds.imageQuality, conds.skyBackground, conds.waterVapor)
+  
+  sealed abstract class ObservingMode(val tpe: ObservingModeType, val radius: Angle):
+    def gmosNorthLongSlit:  Option[GmosNorthLongSlit ] = Some(this).collect { case m: GmosNorthLongSlit  => m }
+    def gmosSouthLongSlit:  Option[GmosSouthLongSlit ] = Some(this).collect { case m: GmosSouthLongSlit  => m }
+    def gmosNorthImaging:   Option[GmosNorthImaging  ] = Some(this).collect { case m: GmosNorthImaging   => m }
+    def gmosSouthImaging:   Option[GmosSouthImaging  ] = Some(this).collect { case m: GmosSouthImaging   => m }
+    def flamingos2LongSlit: Option[Flamingos2LongSlit] = Some(this).collect { case m: Flamingos2LongSlit => m }
 
-  // For now we define field of view as a disc of some angular radius on the sky.
-  sealed abstract class ObservingMode(val tpe: ObservingModeType, val fov: Angle):
-    def gmosNorthLongSlit: Option[GmosNorthLongSlit] = Some(this).collect { case m: GmosNorthLongSlit => m }
-    def gmosSouthLongSlit: Option[GmosSouthLongSlit] = Some(this).collect { case m: GmosSouthLongSlit => m }
+    def subsumes(other: ObservingMode): Boolean =
+      (this, other) match
+        case (GmosNorthLongSlit(g1), GmosNorthLongSlit(g2))   => g1 === g2
+        case (GmosSouthLongSlit(g1), GmosSouthLongSlit(g2))   => g1 === g2
+        case (GmosNorthImaging(f1), GmosNorthImaging(f2))     => f2.forall(f1.contains)
+        case (GmosSouthImaging(f1), GmosSouthImaging(f2))     => f2.forall(f1.contains)
+        case (Flamingos2LongSlit(d1), Flamingos2LongSlit(d2)) => d1 === d2
+        case _                                                => false
 
   object ObservingMode:
 
-    // TODO: right now we're allowing sufficient slop to allow adjusting the target along [half] the length of the slit, but
-    // this also allows moving to a target that's off the slit entirely since we're just measuring a single offset distance.
-    // What we really need here is a polygon, but that's complicated by position angle (which may be allowed to flip or may
-    // be chosen dynamically based on parallactic angle). 
-    case class GmosNorthLongSlit(grating: GmosNorthGrating) extends ObservingMode(lucuma.core.enums.ObservingModeType.GmosNorthLongSlit, Angle.fromDoubleArcseconds(5.5 * 60)) // slit length of 5.5’
-    case class GmosSouthLongSlit(grating: GmosSouthGrating) extends ObservingMode(lucuma.core.enums.ObservingModeType.GmosSouthLongSlit, Angle.fromDoubleArcseconds(5.5 * 60)) // slit length of 5.5’
+    object Radii:
+      val GmosLongSlit = gmos.scienceArea.longSlitFov(Angle.fromMicroarcseconds(2L)).eval.radius // width doesn't matter but should be > 1 µas
+      val GmosImaging  = gmos.scienceArea.imaging.eval.radius
+      val Flamingos2LongSlit = flamingos2.scienceArea.shapeAt(Angle.Angle0, Offset.Zero, Flamingos2LyotWheel.F16, Flamingos2FpuMask.Imaging).eval.radius
 
-    given Eq[ObservingMode] =
-      Eq.instance:
-        case (GmosNorthLongSlit(g1), GmosNorthLongSlit(g2)) => g1 === g2
-        case (GmosSouthLongSlit(g1), GmosSouthLongSlit(g2)) => g1 === g2
-        case _ => false
+    case class GmosNorthLongSlit(grating: GmosNorthGrating) extends ObservingMode(ObservingModeType.GmosNorthLongSlit, Radii.GmosLongSlit)
+    case class GmosSouthLongSlit(grating: GmosSouthGrating) extends ObservingMode(ObservingModeType.GmosSouthLongSlit, Radii.GmosLongSlit) 
+    case class GmosNorthImaging(filters: List[GmosNorthFilter]) extends ObservingMode(ObservingModeType.GmosNorthImaging, Radii.GmosImaging)
+    case class GmosSouthImaging(filters: List[GmosSouthFilter]) extends ObservingMode(ObservingModeType.GmosSouthImaging, Radii.GmosImaging)
+    case class Flamingos2LongSlit(disperser: Flamingos2Disperser) extends ObservingMode(ObservingModeType.Flamingos2LongSlit, Radii.Flamingos2LongSlit)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
@@ -14,9 +14,9 @@ import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.math.Angle
 import lucuma.core.math.Coordinates
+import lucuma.core.math.Region
 import lucuma.core.model.Configuration.ObservingMode.GmosNorthLongSlit
 import lucuma.core.model.Configuration.ObservingMode.GmosSouthLongSlit
-import lucuma.core.math.Region
 
 case class Configuration(conditions: Configuration.Conditions, target: Either[Coordinates, Region], observingMode: Configuration.ObservingMode) derives Eq:
   def subsumes(other: Configuration): Boolean =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ObjectTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ObjectTracking.scala
@@ -8,13 +8,13 @@ import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.all.*
 import lucuma.core.math.Coordinates
+import lucuma.core.math.Region
+import lucuma.core.model.Target.Nonsidereal
+import lucuma.core.model.Target.Opportunity
 import lucuma.core.model.syntax.tracking.*
 import lucuma.core.util.NewType
 
 import java.time.Instant
-import lucuma.core.model.Target.Nonsidereal
-import lucuma.core.model.Target.Opportunity
-import lucuma.core.math.Region
 
 // Tag to indicate the coordinates have been corrected for proper motion
 object CoordinatesAtVizTime extends NewType[Coordinates]

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ObjectTracking.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ObjectTracking.scala
@@ -12,6 +12,9 @@ import lucuma.core.model.syntax.tracking.*
 import lucuma.core.util.NewType
 
 import java.time.Instant
+import lucuma.core.model.Target.Nonsidereal
+import lucuma.core.model.Target.Opportunity
+import lucuma.core.math.Region
 
 // Tag to indicate the coordinates have been corrected for proper motion
 object CoordinatesAtVizTime extends NewType[Coordinates]
@@ -41,17 +44,34 @@ object ObjectTracking:
     def at(i: Instant): Option[CoordinatesAtVizTime] = CoordinatesAtVizTime(coordinates).some
     def baseCoordinates: Coordinates = coordinates
 
+  def fromTarget(target: Target): Option[ObjectTracking] =
+    orRegionFromTarget(target).left.toOption
 
-  def fromTarget(target: Target): ObjectTracking = target match
-    case t: Target.Sidereal => SiderealObjectTracking(t.tracking)
-    case _                  => sys.error("Only sidereal targets supported")
+  def orRegionFromTarget(target: Target): Either[ObjectTracking, Region] =
+    target match
+      case t: Target.Sidereal    => SiderealObjectTracking(t.tracking).asLeft
+      case t: Target.Opportunity => t.region.asRight 
+      case t: Target.Nonsidereal => sys.error("Nonsidereal targets not supported yet.")    
 
-  def fromAsterism(targets: NonEmptyList[Target]): ObjectTracking = 
-    val trackingList = targets.toList.traverse(Target.sidereal.getOption).flatMap(NonEmptyList.fromList)
-    trackingList.fold(sys.error("Only sidereal targets supported")) { sidereals =>
-      if (sidereals.length === 1) SiderealObjectTracking(sidereals.head.tracking)
-      else SiderealAsterismTracking(sidereals.map(_.tracking))
-    }
+  def fromAsterism(targets: NonEmptyList[Target]): Option[ObjectTracking] =
+    orRegionFromAsterism(targets).left.toOption
+
+  def orRegionFromAsterism(targets: NonEmptyList[Target]): Either[ObjectTracking, Region] =
+    targets
+      .collect:
+        case Target.Nonsidereal(_, _, _) => sys.error("Nonsidereal targets not supported yet.")
+        case Target.Opportunity(_, r, _) => r
+      .headOption // first region, if any
+      .toRight:
+        targets
+          .map: t =>
+            Target
+              .sidereal
+              .getOption(t)
+              .getOrElse(sys.error("unpossible, list should only contain sidereal targets"))          
+          match          
+            case NonEmptyList(h, Nil) => SiderealObjectTracking(h.tracking)
+            case NonEmptyList(h, t)   => SiderealAsterismTracking(NonEmptyList(h, t).map(_.tracking))
 
   def constant(coordinates: Coordinates): ObjectTracking =
     ConstantTracking(coordinates)

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
@@ -70,6 +70,6 @@ trait ArbConfiguration:
   
   given Cogen[Configuration] =
     Cogen[(Conditions, Either[Coordinates, Region], ObservingMode)]
-      .contramap(c => (c.conditions, c.refererenceCoordinates, c.observingMode))
+      .contramap(c => (c.conditions, c.target, c.observingMode))
 
 object ArbConfiguration extends ArbConfiguration

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
@@ -4,7 +4,10 @@
 package lucuma.core.model
 package arb
 
+import lucuma.core.enums.Flamingos2Disperser
+import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosSouthFilter
 import lucuma.core.enums.GmosSouthGrating
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
@@ -18,9 +21,6 @@ import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen.*
 import org.scalacheck.rng.Seed
-import lucuma.core.enums.GmosNorthFilter
-import lucuma.core.enums.GmosSouthFilter
-import lucuma.core.enums.Flamingos2Disperser
 
 trait ArbConfiguration:
   import Configuration.Conditions

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
@@ -9,14 +9,14 @@ import lucuma.core.enums.GmosSouthGrating
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.math.Coordinates
+import lucuma.core.math.Region
 import lucuma.core.math.arb.ArbCoordinates.given
+import lucuma.core.math.arb.ArbRegion.given
 import lucuma.core.model.CloudExtinction
 import lucuma.core.util.arb.ArbEnumerated.given
-import lucuma.core.math.arb.ArbRegion.given
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen.*
-import lucuma.core.math.Region
 
 trait ArbConfiguration:
   import Configuration.Conditions

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
@@ -12,9 +12,11 @@ import lucuma.core.math.Coordinates
 import lucuma.core.math.arb.ArbCoordinates.given
 import lucuma.core.model.CloudExtinction
 import lucuma.core.util.arb.ArbEnumerated.given
+import lucuma.core.math.arb.ArbRegion.given
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen.*
+import lucuma.core.math.Region
 
 trait ArbConfiguration:
   import Configuration.Conditions
@@ -62,12 +64,12 @@ trait ArbConfiguration:
     Arbitrary:
       for
         c <- arbitrary[Conditions]
-        r <- arbitrary[Coordinates]
+        r <- arbitrary[Either[Coordinates, Region]]
         o <- arbitrary[ObservingMode]
       yield (Configuration(c, r, o))
   
   given Cogen[Configuration] =
-    Cogen[(Conditions, Coordinates, ObservingMode)]
+    Cogen[(Conditions, Either[Coordinates, Region], ObservingMode)]
       .contramap(c => (c.conditions, c.refererenceCoordinates, c.observingMode))
 
 object ArbConfiguration extends ArbConfiguration


### PR DESCRIPTION
Subsumes #1154 

This updates the `Configuration` model to support TOO targets, as well as GMOS imaging and F2 longslit configurations. This is a breaking change.