### PR TITLE
Limit Timestamp.Max to JS max, remove date range limit from SkyCalc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.144"
+ThisBuild / tlBaseVersion                         := "0.145"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/skycalc/ImprovedSkyCalcMethods.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/skycalc/ImprovedSkyCalcMethods.scala
@@ -6,6 +6,7 @@ package lucuma.core.math.skycalc
 import algebra.instances.all.*
 import lucuma.core.math.Constants.*
 import lucuma.core.math.JulianDate.J2000
+import lucuma.core.util.time.*
 
 import java.time.Instant
 import java.time.LocalTime
@@ -840,14 +841,8 @@ trait ImprovedSkyCalcMethods {
     var inter  = 0L
     var jd     = .0
     var jdfrac = .0
-    val date   = instant.atZone(ZoneOffset.UTC)
-    if (
-      (date.getYear <= 1900) | (date.getYear >= 2100)
-    ) //        printf("Date out of range.  1900 - 2100 only.\n");
-      //        return(0.);
-      throw new IllegalArgumentException(
-        "Date out of range.  1900 - 2100 only."
-      )
+    val date   = instant.toTimestampBounds.atZone(ZoneOffset.UTC)
+
     if (date.getMonthValue <= 2) {
       yr1 = -1
       mo1 = 13

--- a/modules/core/shared/src/main/scala/lucuma/core/model/TimingWindow.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/TimingWindow.scala
@@ -59,9 +59,9 @@ final case class TimingWindow(
   end:       Option[TimingWindowEnd]
 ):
   def duration: Option[TimeSpan] =
-    end.flatMap {
+    end.map {
       case TimingWindowEnd.At(ts)      => TimeSpan.between(start, ts)
-      case TimingWindowEnd.After(d, _) => d.some
+      case TimingWindowEnd.After(d, _) => d
     }
 
   def isValid: Boolean =

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimeSpan.scala
@@ -235,12 +235,12 @@ object TimeSpan {
   }
 
   /**
-   * Obtains the absolute (i.e., positive regardless of order) time span between two Timestamp, if in range.
+   * Obtains the absolute (i.e., positive regardless of order) time span between two Timestamp.
    */
-  def between(t0: Timestamp, t1: Timestamp): Option[TimeSpan] =
+  def between(t0: Timestamp, t1: Timestamp): TimeSpan =
     fromDuration(
       Duration.between(t0.toInstant, t1.toInstant).abs
-    )
+    ).get
 
   val NonNegMicroseconds: Iso[NonNegLong, TimeSpan] =
     Iso[NonNegLong, TimeSpan](fromNonNegMicroseconds)(toNonNegMicroseconds)

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimestampInterval.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimestampInterval.scala
@@ -30,20 +30,10 @@ sealed class TimestampInterval private (val start: Timestamp, val end: Timestamp
   assert(start <= end, s"start time ($start) must be <= end time ($end)")
 
   /**
-   * The amount of time represented by the interval, if possible to fit in a
-   * TimeSpan.
+   * The amount of time represented by the interval.
    */
-  def timeSpan: Option[TimeSpan] =
+  def timeSpan: TimeSpan =
     TimeSpan.between(start, end)
-
-  /**
-   * The amount of time represented by the interval, but capped at
-   * TimeSpan.Max.  Most TimestampIntervals in practice will fall
-   * well short of TimeSpan.Max and this provides a convenient way
-   * of working with time spans that avoids Option.
-   */
-  def boundedTimeSpan: TimeSpan =
-    timeSpan.getOrElse(TimeSpan.Max)
 
   def contains(time: Timestamp): Boolean =
     start <= time && time < end
@@ -151,16 +141,10 @@ sealed class TimestampInterval private (val start: Timestamp, val end: Timestamp
    * Determine the time between the end of the earlier interval and the
    * start of the later, or TimeSpan.Zero if they intersect or abut.
    */
-  def timeBetween(other: TimestampInterval): Option[TimeSpan] = 
-    if (intersects(other)) TimeSpan.Zero.some
+  def timeBetween(other: TimestampInterval): TimeSpan = 
+    if (intersects(other)) TimeSpan.Zero
     else if (this < other) TimeSpan.between(end, other.start)
     else TimeSpan.between(other.end, start)
-
-  /**
-   * `timeBetween` but capped at TimeSpan.Max.
-   */
-  def boundedTimeBetween(other: TimestampInterval): TimeSpan = 
-    timeBetween(other).getOrElse(TimeSpan.Max) 
 
   override def equals(that: Any): Boolean =
     that match {

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimestampInterval.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimestampInterval.scala
@@ -149,8 +149,7 @@ sealed class TimestampInterval private (val start: Timestamp, val end: Timestamp
       
   /**
    * Determine the time between the end of the earlier interval and the
-   * start of the later (None if it doesn't fit in a TimeSpan), or 
-   * TimeSpan.Zero if they intersect or abut.
+   * start of the later, or TimeSpan.Zero if they intersect or abut.
    */
   def timeBetween(other: TimestampInterval): Option[TimeSpan] = 
     if (intersects(other)) TimeSpan.Zero.some

--- a/modules/core/shared/src/main/scala/lucuma/core/util/TimestampUnion.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/TimestampUnion.scala
@@ -9,7 +9,6 @@ import cats.kernel.BoundedSemilattice
 import cats.syntax.eq.*
 import cats.syntax.foldable.*
 import cats.syntax.option.*
-import cats.syntax.traverse.*
 
 import scala.collection.immutable.SortedSet
 
@@ -91,9 +90,9 @@ sealed class TimestampUnion private (val intervals: SortedSet[TimestampInterval]
    * result fits in a `TimeSpan`.
    */
   def sum: Option[TimeSpan] =
-    intervals.toList.traverse(_.timeSpan).flatMap { ts =>
-      ts.foldLeft(TimeSpan.Zero.some) { case (s, t) => s.flatMap(_.add(t)) }
-    }
+    intervals.toList
+      .map(_.timeSpan)
+      .foldLeft(TimeSpan.Zero.some) { case (s, t) => s.flatMap(_.add(t)) }
 
   /**
    * Sums the time spanned by all the intervals in this union, capping the
@@ -101,7 +100,7 @@ sealed class TimestampUnion private (val intervals: SortedSet[TimestampInterval]
    * convenient than `sum`.
    */
   def boundedSum: TimeSpan =
-    intervals.foldMap(_.boundedTimeSpan)
+    intervals.foldMap(_.timeSpan)
 
   def isEmpty: Boolean =
     intervals.isEmpty

--- a/modules/core/shared/src/main/scala/lucuma/core/util/time.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/time.scala
@@ -43,6 +43,8 @@ object time:
     /** Round an Instant to the nearest value of the specified unit. */
     def roundTo(units: TemporalUnit): Instant =
       roundTemporalTo(i, units, _.truncatedTo(_), _.plus(_, _))
+    def toTimestampBounds: Instant =
+      Timestamp.fromInstantTruncatedAndBounded(i).toInstant
 
   extension (ldt: LocalDateTime)
     /** Round a LocalDateTime to the nearest value of the specified unit. */

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
@@ -199,13 +199,14 @@ class TimestampIntervalSuite extends DisciplineSuite {
     // Disjoint, out of order
     assertEquals(interval(29, 30).timeBetween(interval(0, 10)), Some(timeSpan(19)))
 
-    val oor = TimestampInterval.between(Timestamp.Max, Timestamp.Max)
+    val max = TimestampInterval.between(Timestamp.Max, Timestamp.Max)
+    val min = TimestampInterval.between(Timestamp.Min, Timestamp.Min)
 
-    // Out of range, in order
-    assertEquals(interval(0, 1).timeBetween(oor), None)
+    // Max disjoint, in order
+    assertEquals(min.timeBetween(max), Some(timeSpan(Timestamp.Max.toEpochMilli - Timestamp.Min.toEpochMilli)))
 
-    // Out of range, out of order
-    assertEquals(oor.timeBetween(interval(0, 10)), None)
+    // Max disjoint, out of order
+    assertEquals(max.timeBetween(min), Some(timeSpan(Timestamp.Max.toEpochMilli - Timestamp.Min.toEpochMilli)))
   }
 
   test("until abuts from") {

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampIntervalSuite.scala
@@ -173,40 +173,40 @@ class TimestampIntervalSuite extends DisciplineSuite {
 
   test("timeBetween") {
     // Lower Partial
-    assertEquals(interval(1, 10).timeBetween(interval(0,  2)), Some(TimeSpan.Zero))
+    assertEquals(interval(1, 10).timeBetween(interval(0,  2)), TimeSpan.Zero)
 
     // Upper Partial
-    assertEquals(interval(1, 10).timeBetween(interval(9, 11)), Some(TimeSpan.Zero))
+    assertEquals(interval(1, 10).timeBetween(interval(9, 11)), TimeSpan.Zero)
 
     // Proper Superset
-    assertEquals(interval(0, 10).timeBetween(interval(3,  6)), Some(TimeSpan.Zero))
+    assertEquals(interval(0, 10).timeBetween(interval(3,  6)), TimeSpan.Zero)
 
     // Proper Subset
-    assertEquals(interval(3, 6).timeBetween(interval(0, 10)), Some(TimeSpan.Zero))
+    assertEquals(interval(3, 6).timeBetween(interval(0, 10)), TimeSpan.Zero)
 
     // Equal
-    assertEquals(interval(0, 10).timeBetween(interval(0, 10)), Some(TimeSpan.Zero))
+    assertEquals(interval(0, 10).timeBetween(interval(0, 10)), TimeSpan.Zero)
 
     // Abuts, in order
-    assertEquals(interval(0, 10).timeBetween(interval(10, 20)), Some(TimeSpan.Zero))
+    assertEquals(interval(0, 10).timeBetween(interval(10, 20)), TimeSpan.Zero)
 
     // Abuts, out of order
-    assertEquals(interval(10, 20).timeBetween(interval(0, 10)), Some(TimeSpan.Zero))
+    assertEquals(interval(10, 20).timeBetween(interval(0, 10)), TimeSpan.Zero)
 
     // Disjoint, in order
-    assertEquals(interval(0, 10).timeBetween(interval(15, 20)), Some(timeSpan(5)))
+    assertEquals(interval(0, 10).timeBetween(interval(15, 20)), timeSpan(5))
 
     // Disjoint, out of order
-    assertEquals(interval(29, 30).timeBetween(interval(0, 10)), Some(timeSpan(19)))
+    assertEquals(interval(29, 30).timeBetween(interval(0, 10)), timeSpan(19))
 
     val max = TimestampInterval.between(Timestamp.Max, Timestamp.Max)
     val min = TimestampInterval.between(Timestamp.Min, Timestamp.Min)
 
     // Max disjoint, in order
-    assertEquals(min.timeBetween(max), Some(timeSpan(Timestamp.Max.toEpochMilli - Timestamp.Min.toEpochMilli)))
+    assertEquals(min.timeBetween(max), timeSpan(Timestamp.Max.toEpochMilli - Timestamp.Min.toEpochMilli))
 
     // Max disjoint, out of order
-    assertEquals(max.timeBetween(min), Some(timeSpan(Timestamp.Max.toEpochMilli - Timestamp.Min.toEpochMilli)))
+    assertEquals(max.timeBetween(min), timeSpan(Timestamp.Max.toEpochMilli - Timestamp.Min.toEpochMilli))
   }
 
   test("until abuts from") {

--- a/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/util/TimestampUnionSuite.scala
@@ -86,7 +86,7 @@ class TimestampUnionSuite extends DisciplineSuite {
 
   test("boundedSum") {
     forAll { (u: TimestampUnion) =>
-      assertEquals(u.boundedSum, u.intervals.foldMap(_.boundedTimeSpan))
+      assertEquals(u.boundedSum, u.intervals.foldMap(_.timeSpan))
     }
   }
 }


### PR DESCRIPTION
This PR addresses a couple of issues related to dates.

First, it turns out that the Javascript Date has a smaller range than the Java DateTimes, which was throwing exceptions in scalajs for some usages. Currently, the `Timestamp` class limits the times to that representable by a postgres timestamp. Timestamp.Min already fits in a JS Date, but I changed Timestamp.Max to the maximum value of a JS Date - which is still way out of the range of meaningful dates for our purposes. 

A consequence of the above is that the difference between any 2 Timestamps will always fit in a TimeSpan, so I removed the optionality of TimestampInterval.timeSpan and all downstream usages.

The second big issue was that ImprovedSkyCalc threw an exception when converting to julian date if the provided year was outside of the range 1900-2100. This was causing a problem if the user accidentally provided a bad date for the observation time (for example, while editing 2025 they added an extra number without deleting one). After discussion with Andy, I removed the restriction on dates in ModifiedSkyCalc. The `etcorr` method will not work correctly outside of the 1900-2100 range (and will print a message to the console), but we're not too concerned with getting correct values outside of reasonable dates for observing an observation. We could change `etcorr` in the future to handle a larger date range if needed.