### PR TITLE
Flaky tests on ScalaJS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,8 +113,14 @@ lazy val testkit = crossProject(JVMPlatform, JSPlatform)
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))
 
 val MUnitFramework = new TestFramework("munit.Framework")
+// MUnit's built-in `.flaky` handling reads MUNIT_FLAKY_OK via System.getenv at test runtime.
+// On the JVM that works: flaky-tagged tests run and their failures are tolerated when the
+// env var is set. On Scala.js, System.getenv always returns empty, so the env var is invisible
+// and flaky tests would fail. To compensate, we exclude flaky-tagged tests at the build level
+// *only on Scala.js* (see jsSettings below) -- this exclusion is evaluated by the sbt JVM via
+// sys.env and passed as a test argument, so it works regardless of the JS runtime.
 val MUnitFlakyOK   = sys.env.get("MUNIT_FLAKY_OK") match {
-  case Some("true") => Tests.Argument(MUnitFramework, "--exclude-tags=ScalaCheckFlaky")
+  case Some("true") => Tests.Argument(MUnitFramework, "--exclude-tags=Flaky")
   case _            => Tests.Argument()
 }
 
@@ -130,9 +136,9 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel" %%% "discipline-munit"  % munitDisciplineVersion % Test,
       "org.typelevel" %%% "munit-cats-effect" % munitCatsEffectVersion % Test
     ),
-    testFrameworks += MUnitFramework,
-    testOptions += MUnitFlakyOK
+    testFrameworks += MUnitFramework
   )
+  .jsSettings(testOptions += MUnitFlakyOK)
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))
   .jvmSettings(
     resolvers += "Gemini Repository".at(
@@ -203,7 +209,8 @@ lazy val horizonsTests = crossProject(JVMPlatform, JSPlatform)
     name := "lucuma-horizons-tests",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "munit-cats-effect"   % munitCatsEffectVersion % Test,
-    )
+    ),
+    testFrameworks += MUnitFramework
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
@@ -212,6 +219,7 @@ lazy val horizonsTests = crossProject(JVMPlatform, JSPlatform)
     )
   )
   .jsSettings(
+    testOptions += MUnitFlakyOK,
     scalacOptions ~= (_.filterNot(Set("-Wdead-code"))),
     libraryDependencies ++= Seq(
       "org.http4s" %%% "http4s-dom" % http4sDomVersion % Test,
@@ -273,9 +281,11 @@ lazy val catalogTests = crossProject(JVMPlatform, JSPlatform)
       "org.http4s"             %%% "http4s-core"         % http4sVersion,
       "com.lihaoyi"            %%% "pprint"              % pprintVersion,
       "org.typelevel"          %%% "cats-time"           % catsTimeVersion
-    )
+    ),
+    testFrameworks += MUnitFramework
   )
   .jsSettings(
+    testOptions += MUnitFlakyOK,
     scalacOptions ~= (_.filterNot(Set("-Wdead-code"))),
     libraryDependencies ++= Seq(
       "org.http4s" %%% "http4s-dom" % http4sDomVersion

--- a/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/ImprovedSkyCalcSuiteJVM.scala
+++ b/modules/tests/jvm/src/test/scala/lucuma/core/math/skycalc/ImprovedSkyCalcSuiteJVM.scala
@@ -14,7 +14,6 @@ import lucuma.core.math.Place
 import lucuma.core.math.arb.ArbCoordinates.given
 import lucuma.core.math.arb.ArbPlace.given
 import lucuma.core.model.ConstantTracking
-import lucuma.core.tests.ScalaCheckFlaky
 import lucuma.core.util.TimeSpan
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop.*
@@ -48,7 +47,7 @@ final class ImprovedSkyCalcSuiteJVM extends ScalaCheckSuite {
     )
   }
 
-  test("Arbitrary sky calculations".tag(ScalaCheckFlaky)) {
+  test("Arbitrary sky calculations".flaky) {
     forAll { (place: Place) =>
       // This SkyCalc should be thread safe, but Java's isn't.
       val calc = ImprovedSkyCalc(place)

--- a/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
@@ -14,7 +14,6 @@ import lucuma.core.math.Offset
 import lucuma.core.math.Offset.Component
 import lucuma.core.math.arb.*
 import lucuma.core.math.syntax.int.*
-import lucuma.core.tests.ScalaCheckFlaky
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.*
 import org.scalacheck.Prop.*
@@ -67,7 +66,7 @@ class ShapeExpressionSuite extends munit.DisciplineSuite {
     }
   }
 
-  test("(a ∪ b).area = (a.area + b.area) - (a ∩ b).area".tag(ScalaCheckFlaky)) {
+  test("(a ∪ b).area = (a.area + b.area) - (a ∩ b).area".flaky) {
     forAll(genTwoCenteredShapes) { tcs =>
       val rhs = (tcs.shape0 ∪ tcs.shape1).µasSquared
       val lhs = (tcs.shape0.µasSquared + tcs.shape1.µasSquared) -
@@ -79,7 +78,7 @@ class ShapeExpressionSuite extends munit.DisciplineSuite {
     }
   }
 
-  test("(a ∩ b).area = (a ∪ b).area - ((a - b).area + (b - a).area)".tag(ScalaCheckFlaky)) {
+  test("(a ∩ b).area = (a ∪ b).area - ((a - b).area + (b - a).area)".flaky) {
     forAll(genTwoCenteredShapes) { tcs =>
       val rhs = (tcs.shape0 ∩ tcs.shape1).µasSquared
       val lhs = (tcs.shape0 ∪ tcs.shape1).µasSquared - (

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/BoundedIntervalSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/BoundedIntervalSuite.scala
@@ -10,7 +10,6 @@ import lucuma.core.math.arb.ArbInterval
 import lucuma.core.optics.laws.discipline.ValidSplitEpiTests
 import lucuma.core.optics.laws.discipline.WedgeTests
 import lucuma.core.syntax.time.*
-import lucuma.core.tests.ScalaCheckFlaky
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Prop.*
@@ -128,7 +127,7 @@ class BoundedIntervalSuite  extends munit.DisciplineSuite with IntervalGens {
     }
   }
 
-  test("ToFullDays".tag(ScalaCheckFlaky)) {
+  test("ToFullDays".flaky) {
     forAll { (i: BoundedInterval[Instant], z: ZoneId, t: LocalTime) =>
       val allDay = i.toFullDays(z, t)
       assert(i.isSubsetOf(allDay))

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/CoordinatesSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/CoordinatesSuite.scala
@@ -12,7 +12,6 @@ import cats.syntax.all.*
 import lucuma.core.math.Coordinates.centerOf
 import lucuma.core.math.arb.*
 import lucuma.core.optics.laws.discipline.*
-import lucuma.core.tests.ScalaCheckFlaky
 import monocle.law.discipline.*
 import org.scalacheck.Prop.*
 
@@ -124,8 +123,7 @@ final class CoordinatesSuite extends munit.DisciplineSuite {
   }
 
   test(
-    "interpolate should be consistent with fractional angular separation, to within 20 µas"
-      .tag(ScalaCheckFlaky)
+    "interpolate should be consistent with fractional angular separation, to within 20 µas".flaky
   ) {
     val µas180 = Angle.Angle180.toMicroarcseconds
     val µas360 = µas180 * 2L

--- a/modules/tests/shared/src/test/scala/lucuma/core/tests/ScalaCheckFlaky.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/tests/ScalaCheckFlaky.scala
@@ -1,8 +1,0 @@
-// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
-// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
-
-package lucuma.core.tests
-
-// munit's regular .flaky tag doesn't catch `AssertionError`s thrown by scalacheck,
-// so we define a custom tag to skip these tests when flaky tests are OK.
-object ScalaCheckFlaky extends munit.Tag("ScalaCheckFlaky")


### PR DESCRIPTION
Avoiding test suite failure on flaky tests depends on `munitFlakyOK` being set in the suite.

MUnit has a `munitFlakyOK` implementation that turns the flag on depending on the env variable `MUNIT_FLAKY_OK`. However, in Scala.js, there's no env variables and this mechanism always fails, resulting in failed flaky tests ruining the test run.

Previously, we had a custom tag (`ScalaCheckFlaky`). Tests with this tags were outright excluded in CI runs.

This PR seeks to provide a way that always honors flaky test declaration without the need for us to remember to use a custom tag.

Now, there's no need for a custom tag and the behaviour is:
- JVM: flaky tests are run but tolerated (as intended).
- JS: they are excluded.

The alternative, to run and tolerate JS tests, is to define our own base suite trait but then we have to remember to implement all tests suites extending that particular trait, which as a general mechanism sounds... well... flaky.