### PR TITLE
Shortcut 8952: add exchange partners + enums

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.212"
+ThisBuild / tlBaseVersion                         := "0.213"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ExchangePartner.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ExchangePartner.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum ExchangePartner(val tag: String) derives Enumerated:
+  case Keck   extends ExchangePartner("keck")
+  case Subaru extends ExchangePartner("subaru")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GeminiCallForProposalsType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GeminiCallForProposalsType.scala
@@ -6,14 +6,14 @@ package lucuma.core.enums
 import cats.data.NonEmptyList
 import lucuma.core.util.Enumerated
 
-enum CallForProposalsType(val tag: String, val title: String) derives Enumerated:
-  case DemoScience        extends CallForProposalsType("demo_science", "Demo Science")
-  case DirectorsTime      extends CallForProposalsType("directors_time", "Director's Time")
-  case FastTurnaround     extends CallForProposalsType("fast_turnaround", "Fast Turnaround")
-  case LargeProgram       extends CallForProposalsType("large_program", "Large Program")
-  case PoorWeather        extends CallForProposalsType("poor_weather", "Poor Weather")
-  case RegularSemester    extends CallForProposalsType("regular_semester", "Regular Semester")
-  case SystemVerification extends CallForProposalsType("system_verification", "System Verification")
+enum GeminiCallForProposalsType(val tag: String, val title: String) derives Enumerated:
+  case DemoScience        extends GeminiCallForProposalsType("demo_science", "Demo Science")
+  case DirectorsTime      extends GeminiCallForProposalsType("directors_time", "Director's Time")
+  case FastTurnaround     extends GeminiCallForProposalsType("fast_turnaround", "Fast Turnaround")
+  case LargeProgram       extends GeminiCallForProposalsType("large_program", "Large Program")
+  case PoorWeather        extends GeminiCallForProposalsType("poor_weather", "Poor Weather")
+  case RegularSemester    extends GeminiCallForProposalsType("regular_semester", "Regular Semester")
+  case SystemVerification extends GeminiCallForProposalsType("system_verification", "System Verification")
 
   def subTypes: NonEmptyList[ScienceSubtype] =
       this match

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/KeckInstrument.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/KeckInstrument.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum KeckInstrument(val tag: String) derives Enumerated:
+  case Hires extends KeckInstrument("hires")
+  case Other extends KeckInstrument("other")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/Observatory.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/Observatory.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum Observatory(val tag: String) derives Enumerated:
+  case Gemini extends Observatory("gemini")
+  case Keck   extends Observatory("keck")
+  case Subaru extends Observatory("subaru")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/PartnerLinkType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/PartnerLinkType.scala
@@ -6,9 +6,7 @@ package lucuma.core.enums
 import lucuma.core.util.Enumerated
 
 enum PartnerLinkType(val tag: String) derives Enumerated:
-
-  case HasPartner            extends PartnerLinkType("has_partner")
+  case HasGeminiPartner      extends PartnerLinkType("has_gemini_partner")
+  case HasExchangePartner    extends PartnerLinkType("has_exchange_partner")
   case HasNonPartner         extends PartnerLinkType("has_non_partner")
   case HasUnspecifiedPartner extends PartnerLinkType("has_unspecified_partner")
-
-end PartnerLinkType

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SubaruCallForProposalsType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SubaruCallForProposalsType.scala
@@ -5,6 +5,6 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-enum SubaruProposalType(val tag: String) derives Enumerated:
-  case Normal    extends SubaruProposalType("normal")
-  case Intensive extends SubaruProposalType("intensive")
+enum SubaruCallForProposalsType(val tag: String) derives Enumerated:
+  case Normal    extends SubaruCallForProposalsType("normal")
+  case Intensive extends SubaruCallForProposalsType("intensive")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SubaruInstrument.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SubaruInstrument.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum SubaruInstrument(val tag: String) derives Enumerated:
+  case Focas   extends SubaruInstrument("focas")
+  case Hds     extends SubaruInstrument("hds")
+  case Hsc     extends SubaruInstrument("hsc")
+  case Ircs    extends SubaruInstrument("ircs")
+  case Moircs  extends SubaruInstrument("moircs")
+  case Pfs     extends SubaruInstrument("pfs")
+  case Visitor extends SubaruInstrument("visitor")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SubaruProposalType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SubaruProposalType.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+enum SubaruProposalType(val tag: String) derives Enumerated:
+  case Normal    extends SubaruProposalType("normal")
+  case Intensive extends SubaruProposalType("intensive")

--- a/modules/core/shared/src/main/scala/lucuma/core/model/PartnerLink.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/PartnerLink.scala
@@ -3,21 +3,20 @@
 
 package lucuma.core.model
 
-
-
 import cats.Eq
 import cats.syntax.either.*
+import cats.syntax.option.*
+import lucuma.core.enums.ExchangePartner
 import lucuma.core.enums.Partner
 import lucuma.core.enums.PartnerLinkType
-import monocle.Iso
-
 
 /**
  * Embodies the association between a user and a partner, if any.  There are
- * three possible values: `HasPartner` (meaning the user is tied to a particular
- * `Partner`), `HasNonPartner` (the user is explicitly not associated with any
- * `Partner`) and `HasUnspecifiedPartner` (the relationship is not yet
- * determined).
+ * four possible values: `HasGeminiPartner` (the user is tied to a particular
+ * Gemini `Partner`), `HasExchangePartner` (the user is tied to a particular
+ * `ExchangePartner` community), `HasNonPartner` (the user is explicitly not
+ * associated with any partner) and `HasUnspecifiedPartner` (the relationship
+ * is not yet determined).
  */
 sealed trait PartnerLink extends Product with Serializable:
 
@@ -25,78 +24,72 @@ sealed trait PartnerLink extends Product with Serializable:
     fold(
       PartnerLinkType.HasUnspecifiedPartner,
       PartnerLinkType.HasNonPartner,
-      _ => PartnerLinkType.HasPartner
+      _ => PartnerLinkType.HasGeminiPartner,
+      _ => PartnerLinkType.HasExchangePartner
     )
 
   /**
-   * Converts to an either where Left(true) is `HasNonPartner`, Left(false) is
-   * `HasUnspecifiedPartner` and Right(partner) is `HasPartner`.
+   * Creates an Option[Partner] which is Some when this link is
+   * `HasGeminiPartner`.
    */
-  def toEither: Either[Boolean, Partner] =
-    fold(false.asLeft, true.asLeft, _.asRight)
+  def geminiPartnerOption: Option[Partner] =
+    fold(none, none, _.some, _ => none)
 
   /**
-   * Creates an Option[Partner] which is Some when this link is `HasPartner`.
+   * Creates an Option[ExchangePartner] which is Some when this link is
+   * `HasExchangePartner`.
    */
-  def partnerOption: Option[Partner] =
-    toEither.toOption
+  def exchangePartnerOption: Option[ExchangePartner] =
+    fold(none, none, _ => none, _.some)
+
+  /**
+   * True only if HasUnspecifiedPartner.  Same as `!hasPartner`.
+   */
+  def isUnspecifiedPartner: Boolean =
+    !isSet
 
   /**
    * True only if HasNonPartner.
    */
   def isNonPartner: Boolean =
-    fold(false, true, _ => false)
+    fold(false, true, _ => false, _ => false)
 
   /**
-   * True if HasPartner or HasNonPartner.
+   * True if associated with a partner, an exchange partner, or explicitly no
+   * partner.
    */
   def isSet: Boolean =
-    fold(false, true, _ => true)
+    fold(false, true, _ => true, _ => true)
 
-  /**
-   * True only if HasUnspecifiedPartner.  Same as `!isSet`.
-   */
-  def isUnspecified: Boolean =
-    !isSet
-
-  def fold[A](unspecified: => A, hasNonPartner: => A, hasPartner: Partner => A): A =
-    this match {
+  def fold[A](
+    unspecified:        => A,
+    hasNonPartner:      => A,
+    hasGeminiPartner:   Partner => A,
+    hasExchangePartner: ExchangePartner => A
+  ): A =
+    this match
       case PartnerLink.HasUnspecifiedPartner => unspecified
       case PartnerLink.HasNonPartner         => hasNonPartner
-      case PartnerLink.HasPartner(p)         => hasPartner(p)
-    }
-end PartnerLink
+      case PartnerLink.HasGeminiPartner(p)   => hasGeminiPartner(p)
+      case PartnerLink.HasExchangePartner(p) => hasExchangePartner(p)
 
 object PartnerLink:
 
-  case class HasPartner(partner: Partner) extends PartnerLink
-  case object HasNonPartner               extends PartnerLink
-  case object HasUnspecifiedPartner       extends PartnerLink
+  case class  HasGeminiPartner(partner: Partner)           extends PartnerLink
+  case class  HasExchangePartner(partner: ExchangePartner) extends PartnerLink
+  case object HasNonPartner                                extends PartnerLink
+  case object HasUnspecifiedPartner                        extends PartnerLink
 
   given Eq[PartnerLink] =
-    Eq.by(_.toEither)
+    Eq.by(pl => (pl.linkType, pl.geminiPartnerOption, pl.exchangePartnerOption))
 
-  private def fromEither(e: Either[Boolean, Partner]): PartnerLink =
-    e.fold(b => if (b) HasNonPartner else HasUnspecifiedPartner, HasPartner.apply)
-
-  /**
-   * Iso for an Either where Left(true) is HasNoPartner and Left(false) is
-   * HasUnspecifiedPartner.
-   */
-  val either: Iso[PartnerLink, Either[Boolean, Partner]] =
-    Iso[PartnerLink, Either[Boolean, Partner]](_.toEither)(fromEither)
-
-  /**
-   * Creates a `PartnerLink` where a None value for `Partner` is interpreted as
-   * `HasNonPartner`.
-   */
-  def asNonPartner(p: Option[Partner]): PartnerLink =
-    p.fold(HasNonPartner)(HasPartner.apply)
-
-  def fromLinkType(linkType: PartnerLinkType, partner: Option[Partner] = None): Either[String, PartnerLink] =
+  def fromLinkType(
+    linkType:        PartnerLinkType,
+    geminiPartner:   Option[Partner]         = None,
+    exchangePartner: Option[ExchangePartner] = None
+  ): Either[String, PartnerLink] =
     linkType match
-      case PartnerLinkType.HasPartner            => partner.map(HasPartner.apply).toRight("HasPartner instance missing partner")
+      case PartnerLinkType.HasGeminiPartner      => geminiPartner.map(HasGeminiPartner.apply).toRight("HasGeminiPartner instance missing gemini partner")
+      case PartnerLinkType.HasExchangePartner    => exchangePartner.map(HasExchangePartner.apply).toRight("HasExchangePartner instance missing exchange partner")
       case PartnerLinkType.HasNonPartner         => HasNonPartner.asRight
       case PartnerLinkType.HasUnspecifiedPartner => HasUnspecifiedPartner.asRight
-
-end PartnerLink

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbPartnerLink.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbPartnerLink.scala
@@ -4,6 +4,7 @@
 package lucuma.core.model
 package arb
 
+import lucuma.core.enums.ExchangePartner
 import lucuma.core.enums.Partner
 import lucuma.core.enums.PartnerLinkType
 import lucuma.core.util.arb.ArbEnumerated
@@ -12,33 +13,38 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen.const
 
 
-trait ArbPartnerLink {
+trait ArbPartnerLink:
 
   import ArbEnumerated.given
 
-  given Arbitrary[PartnerLink.HasPartner] =
-    Arbitrary {
-      arbitrary[Partner].map(PartnerLink.HasPartner.apply)
-    }
+  given Arbitrary[PartnerLink.HasGeminiPartner] =
+    Arbitrary:
+      arbitrary[Partner].map(PartnerLink.HasGeminiPartner.apply)
 
-  given Cogen[PartnerLink.HasPartner] =
+  given Cogen[PartnerLink.HasGeminiPartner] =
     Cogen[Partner].contramap(_.partner)
 
+  given Arbitrary[PartnerLink.HasExchangePartner] =
+    Arbitrary:
+      arbitrary[ExchangePartner].map(PartnerLink.HasExchangePartner.apply)
+
+  given Cogen[PartnerLink.HasExchangePartner] =
+    Cogen[ExchangePartner].contramap(_.partner)
+
   given Arbitrary[PartnerLink] =
-    Arbitrary {
+    Arbitrary:
       Gen.oneOf(
-        arbitrary[PartnerLink.HasPartner],
+        arbitrary[PartnerLink.HasGeminiPartner],
+        arbitrary[PartnerLink.HasExchangePartner],
         const(PartnerLink.HasNonPartner),
         const(PartnerLink.HasUnspecifiedPartner)
       )
-    }
 
   given Cogen[PartnerLink] =
-    Cogen[(PartnerLinkType, Option[Partner])].contramap { a => (
+    Cogen[(PartnerLinkType, Option[Partner], Option[ExchangePartner])].contramap { a => (
       a.linkType,
-      a.partnerOption
+      a.geminiPartnerOption,
+      a.exchangePartnerOption
     )}
-
-}
 
 object ArbPartnerLink extends ArbPartnerLink


### PR DESCRIPTION
This PR contains some proposed updates for [the exchange partner work](https://app.shortcut.com/lucuma/epic/8907?group_by=none&hide_subtasks=false&vc_group_by=day&ct_workflow=all&cf_workflow=500000071).

* Add `ExchangePartner`.  This is needed to distinguish which exchange partner is associated with a Gemini proposal made by a Keck or Subaru PI.
* Rename `CallForProposalsType` -> `GeminiCallForProposalsType`.  Not all CfPs are Gemini CfPs and the existing `CallForProposalsType`s only apply to Gemini.
* Add `SubaruCallForProposalsType` (which parallels the `GeminiCallForProposalsType`) to distinguish between normal and intensive Subaru calls.
* Add `Observatory` as a discriminator.
* Add `KeckInstrument` and `SubaruInstrument` to allow the available instruments for external proposals to be limited in the same way that Gemini CfPs are sometimes limited to specific instruments.
* Refactor `PartnerLink` to add a new `HasExchangePartner` option.  This allows Keck and Subaru PIs to be associated with a partner like Gemini PIs.