### PR TITLE
GnirsFpu enum, DaytimePinhole calibration role

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.211"
+ThisBuild / tlBaseVersion                         := "0.212"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/CalibrationRole.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/CalibrationRole.scala
@@ -10,3 +10,4 @@ enum CalibrationRole(val tag: String) derives Enumerated:
   case Photometric        extends CalibrationRole("photometric")
   case SpectroPhotometric extends CalibrationRole("spectrophotometric")
   case Telluric           extends CalibrationRole("telluric")
+  case DaytimePinhole     extends CalibrationRole("daytime_pinhole")

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometry.scala
@@ -12,6 +12,7 @@ import lucuma.core.geom.ShapeExpression
 import lucuma.core.geom.syntax.all.*
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 
 /**
  * GNIRS science area geometry
@@ -48,7 +49,7 @@ trait GnirsScienceAreaGeometry:
   def shapeAt(
     posAngle:  Angle,
     offsetPos: Offset,
-    fpu:       Either[GnirsFpuSlit, GnirsFpuOther],
+    fpu:       GnirsFpu,
     camera:    GnirsCamera,
     prism:     GnirsPrism
   ): Option[ShapeExpression] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsDynamicConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsDynamicConfig.scala
@@ -10,8 +10,6 @@ import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsDecker
 import lucuma.core.enums.GnirsFilter
-import lucuma.core.enums.GnirsFpuOther
-import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsReadMode
 import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
@@ -23,7 +21,7 @@ final case class GnirsDynamicConfig(
   coadds:            PosInt,
   filter:            GnirsFilter,
   decker:            GnirsDecker,
-  fpu:               Either[GnirsFpuSlit, GnirsFpuOther],
+  fpu:               GnirsFpu,
   acquisitionMirror: GnirsAcquisitionMirrorMode,
   camera:            GnirsCamera,
   focus:             GnirsFocus,
@@ -47,7 +45,7 @@ object GnirsDynamicConfig:
   val decker: Lens[GnirsDynamicConfig, GnirsDecker] =
     Focus[GnirsDynamicConfig](_.decker)
 
-  val fpu: Lens[GnirsDynamicConfig, Either[GnirsFpuSlit, GnirsFpuOther]] =
+  val fpu: Lens[GnirsDynamicConfig, GnirsFpu] =
     Focus[GnirsDynamicConfig](_.fpu)
 
   val acquisitionMirror: Lens[GnirsDynamicConfig, GnirsAcquisitionMirrorMode] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsFpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsFpu.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.gnirs
+
+import cats.Eq
+import cats.derived.*
+import lucuma.core.enums.GnirsFpuOther
+import lucuma.core.enums.GnirsFpuSlit
+import monocle.Iso
+import monocle.Prism
+import monocle.macros.GenPrism
+
+/**
+ * The GNIRS focal plane unit, which is either a long-slit aperture
+ * (`GnirsFpuSlit`) or one of the other apertures such as the acquisition mirror,
+ * pupil viewer or pinholes (`GnirsFpuOther`).
+ */
+enum GnirsFpu derives Eq:
+  case Slit(value: GnirsFpuSlit)
+  case Other(value: GnirsFpuOther)
+
+  def fold[A](fs: GnirsFpuSlit => A, fo: GnirsFpuOther => A): A =
+    this match
+      case Slit(v)  => fs(v)
+      case Other(v) => fo(v)
+
+object GnirsFpu:
+  val slit: Prism[GnirsFpu, GnirsFpuSlit] =
+    GenPrism[GnirsFpu, Slit].andThen(Iso[Slit, GnirsFpuSlit](_.value)(Slit(_)))
+
+  val other: Prism[GnirsFpu, GnirsFpuOther] =
+    GenPrism[GnirsFpu, Other].andThen(Iso[Other, GnirsFpuOther](_.value)(Other(_)))

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/gnirs/arb/ArbGnirsDynamicConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/gnirs/arb/ArbGnirsDynamicConfig.scala
@@ -3,6 +3,7 @@
 
 package lucuma.core.model.sequence.gnirs.arb
 
+import cats.syntax.either.*
 import coulomb.Quantity
 import coulomb.testkit.given
 import eu.timepit.refined.scalacheck.numeric.given
@@ -14,6 +15,7 @@ import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
 import lucuma.core.model.sequence.gnirs.GnirsFocus
 import lucuma.core.model.sequence.gnirs.GnirsFocusMotorStep
 import lucuma.core.model.sequence.gnirs.GnirsFocusMotorStepsValue
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.arb.ArbEnumerated.given
 import lucuma.core.util.arb.ArbNewType.given
@@ -25,6 +27,17 @@ import org.scalacheck.Gen
 
 trait ArbGnirsDynamicConfig:
   import ArbGnirsAcquisitionMirrorMode.given
+
+  given Arbitrary[GnirsFpu] = Arbitrary:
+    Gen.oneOf(
+      arbitrary[GnirsFpuSlit].map(GnirsFpu.Slit(_)),
+      arbitrary[GnirsFpuOther].map(GnirsFpu.Other(_))
+    )
+
+  given Cogen[GnirsFpu] =
+    Cogen[Either[GnirsFpuSlit, GnirsFpuOther]].contramap:
+      case GnirsFpu.Slit(slit) => slit.asLeft
+      case GnirsFpu.Other(other) => other.asRight
 
   given Arbitrary[GnirsFocus] = Arbitrary:
     Gen.oneOf(
@@ -45,7 +58,7 @@ trait ArbGnirsDynamicConfig:
       coadds            <- arbitrary[PosInt]
       filter            <- arbitrary[GnirsFilter]
       decker            <- arbitrary[GnirsDecker]
-      fpu               <- arbitrary[Either[GnirsFpuSlit, GnirsFpuOther]]
+      fpu               <- arbitrary[GnirsFpu]
       acquisitionMirror <- arbitrary[GnirsAcquisitionMirrorMode]
       camera            <- arbitrary[GnirsCamera]
       focus             <- arbitrary[GnirsFocus]
@@ -69,7 +82,7 @@ trait ArbGnirsDynamicConfig:
         PosInt,
         GnirsFilter,
         GnirsDecker,
-        Either[GnirsFpuSlit, GnirsFpuOther],
+        GnirsFpu,
         GnirsAcquisitionMirrorMode,
         GnirsCamera,
         GnirsFocus,

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -4,7 +4,6 @@
 package lucuma.core.geom.jts
 package demo
 
-import cats.syntax.either.*
 import lucuma.core.enums.Flamingos2Fpu
 import lucuma.core.enums.Flamingos2LyotWheel
 import lucuma.core.enums.GmosNorthFpu
@@ -465,6 +464,7 @@ trait GnirsShapes extends InstrumentShapes:
   import lucuma.core.enums.GnirsFpuSlit
   import lucuma.core.enums.GnirsPrism
   import lucuma.core.enums.GuideProbe
+  import lucuma.core.model.sequence.gnirs.GnirsFpu
 
   val posAngle: Angle =
     15.deg
@@ -477,11 +477,11 @@ trait GnirsShapes extends InstrumentShapes:
 
   val probe: GuideProbe = GuideProbe.PWFS2
 
-  val longSlitFpu: Either[GnirsFpuSlit, GnirsFpuOther] =
-    GnirsFpuSlit.LongSlit_1_00.asLeft
+  val longSlitFpu: GnirsFpu =
+    GnirsFpu.Slit(GnirsFpuSlit.LongSlit_1_00)
 
-  val pinholeFpu: Either[GnirsFpuSlit, GnirsFpuOther] =
-    GnirsFpuOther.Pinhole3.asRight
+  val pinholeFpu: GnirsFpu =
+    GnirsFpu.Other(GnirsFpuOther.Pinhole3)
 
   val fpu = longSlitFpu
 


### PR DESCRIPTION
Having an `enum GnirsFpu` makes downstream code much easier to understand than an `Either`. This is a breaking change and PRs for ODB and apps are lined up and will be sent right after this one.

Also, add `DaytimePinhole` calibration role.