### PR TITLE
Use js.Object instead of @JSExport for exported types

### DIFF
--- a/modules/npm/src/main/scala/lucuma/core/AngleJS.scala
+++ b/modules/npm/src/main/scala/lucuma/core/AngleJS.scala
@@ -7,27 +7,26 @@ import lucuma.core.math.Angle
 import lucuma.core.math.HourAngle
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSExport
 
-final case class AngleJS(a: Angle):
+final class AngleJS(a: Angle) extends js.Object:
 
-  val ha  = Angle.hourAngle.get(a)
-  val µas = a.toMicroarcseconds
-  val µs  = ha.toMicroseconds
+  private val ha  = Angle.hourAngle.get(a)
+  private val µas = a.toMicroarcseconds
+  private val µs  = ha.toMicroseconds
 
-  def divMicro(micro:    Long, denom: Int) = (BigDecimal(micro, 6) / denom).doubleValue
-  def divArcseconds(div: Int)              = divMicro(µas, div)
-  def divSeconds(div:    Int)              = divMicro(µs, div)
+  private def divMicro(micro:    Long, denom: Int) = (BigDecimal(micro, 6) / denom).doubleValue
+  private def divArcseconds(div: Int)              = divMicro(µas, div)
+  private def divSeconds(div:    Int)              = divMicro(µs, div)
 
-  @JSExport val arcminutes: Double         = divArcseconds(60)
-  @JSExport val arcseconds: Double         = BigDecimal(µas, 6).doubleValue
-  @JSExport val degrees: Double            = divArcseconds(3_600)
-  @JSExport val dms: String                = Angle.dms.get(a).format.dropRight(3)
-  @JSExport val hms: String                = HourAngle.HMS(ha).format.dropRight(3)
-  @JSExport val hours: Double              = divSeconds(3_600)
-  @JSExport val microarcseconds: js.BigInt = js.BigInt(µas.toString())
-  @JSExport val microseconds: Double       = µs.toDouble
-  @JSExport val milliarcseconds: Double    = BigDecimal(µas, 3).doubleValue
-  @JSExport val milliseconds: Double       = BigDecimal(µs, 3).doubleValue
-  @JSExport val minutes: Double            = divSeconds(60)
-  @JSExport val seconds: Double            = BigDecimal(µs, 6).doubleValue
+  val arcminutes: Double         = divArcseconds(60)
+  val arcseconds: Double         = BigDecimal(µas, 6).doubleValue
+  val degrees: Double            = divArcseconds(3_600)
+  val dms: String                = Angle.dms.get(a).format.dropRight(3)
+  val hms: String                = HourAngle.HMS(ha).format.dropRight(3)
+  val hours: Double              = divSeconds(3_600)
+  val microarcseconds: js.BigInt = js.BigInt(µas.toString())
+  val microseconds: Double       = µs.toDouble
+  val milliarcseconds: Double    = BigDecimal(µas, 3).doubleValue
+  val milliseconds: Double       = BigDecimal(µs, 3).doubleValue
+  val minutes: Double            = divSeconds(60)
+  val seconds: Double            = BigDecimal(µs, 6).doubleValue

--- a/modules/npm/src/main/scala/lucuma/core/DeclinationJS.scala
+++ b/modules/npm/src/main/scala/lucuma/core/DeclinationJS.scala
@@ -6,9 +6,8 @@ package lucuma.core
 import lucuma.core.math.Declination
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSExport
 
-final class DeclinationJS(dec: Declination):
-  @JSExport val dms: String                = Declination.fromStringSignedDMS.reverseGet(dec).dropRight(3)
-  @JSExport val degrees: Double            = dec.toAngle.toSignedDoubleDegrees
-  @JSExport val microarcseconds: js.BigInt = js.BigInt(dec.toAngle.toMicroarcseconds.toString())
+final class DeclinationJS(dec: Declination) extends js.Object:
+  val dms: String                = Declination.fromStringSignedDMS.reverseGet(dec).dropRight(3)
+  val degrees: Double            = dec.toAngle.toSignedDoubleDegrees
+  val microarcseconds: js.BigInt = js.BigInt(dec.toAngle.toMicroarcseconds.toString())

--- a/modules/npm/src/main/scala/lucuma/core/ProperMotionJS.scala
+++ b/modules/npm/src/main/scala/lucuma/core/ProperMotionJS.scala
@@ -6,22 +6,19 @@ package lucuma.core
 import lucuma.core.math.ProperMotion
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSExport
 
-final class ProperMotionJS(_ra: ProperMotion.RA, _dec: ProperMotion.Dec):
-  @JSExport
+final class ProperMotionJS(_ra: ProperMotion.RA, _dec: ProperMotion.Dec) extends js.Object:
   val dec: ProperMotionDeclinationJS = ProperMotionDeclinationJS(_dec)
-  @JSExport
   val ra: ProperMotionRAJS           = ProperMotionRAJS(_ra)
 
-final class ProperMotionDeclinationJS(dec: ProperMotion.Dec):
-  @JSExport val microarcsecondsPerYear: js.BigInt =
+final class ProperMotionDeclinationJS(dec: ProperMotion.Dec) extends js.Object:
+  val microarcsecondsPerYear: js.BigInt =
     js.BigInt(ProperMotion.Dec.microarcsecondsPerYear.reverseGet(dec).toString)
-  @JSExport val milliarcsecondsPerYear: Double    =
+  val milliarcsecondsPerYear: Double    =
     ProperMotion.Dec.milliarcsecondsPerYear.get(dec).doubleValue
 
-final class ProperMotionRAJS(ra: ProperMotion.RA):
-  @JSExport val microarcsecondsPerYear: js.BigInt =
+final class ProperMotionRAJS(ra: ProperMotion.RA) extends js.Object:
+  val microarcsecondsPerYear: js.BigInt =
     js.BigInt(ProperMotion.RA.microarcsecondsPerYear.reverseGet(ra).toString)
-  @JSExport val milliarcsecondsPerYear: Double    =
+  val milliarcsecondsPerYear: Double    =
     ProperMotion.RA.milliarcsecondsPerYear.get(ra).doubleValue

--- a/modules/npm/src/main/scala/lucuma/core/RightAscensionJS.scala
+++ b/modules/npm/src/main/scala/lucuma/core/RightAscensionJS.scala
@@ -7,17 +7,16 @@ import lucuma.core.math.RightAscension
 import lucuma.core.math.validation.MathValidators
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSExport
 
-final case class RightAscensionJS(ra: RightAscension):
+final class RightAscensionJS(ra: RightAscension) extends js.Object:
 
-  val ha  = ra.toHourAngle
-  val µas = ra.toAngle.toMicroarcseconds
-  val µs  = ha.toMicroseconds
+  private val ha  = ra.toHourAngle
+  private val µas = ra.toAngle.toMicroarcseconds
+  private val µs  = ha.toMicroseconds
 
-  def divMicro(micro: Long, denom: Int) = BigDecimal(micro, 6) / denom
+  private def divMicro(micro: Long, denom: Int) = BigDecimal(micro, 6) / denom
 
-  @JSExport val hms: String             = MathValidators.truncatedRA.reverseGet(ra)
-  @JSExport val hours: Double           = divMicro(µs, 3_600).floatValue
-  @JSExport val degrees: Double         = divMicro(µas, 3_600).floatValue
-  @JSExport val microseconds: js.BigInt = js.BigInt(µs.toString())
+  val hms: String             = MathValidators.truncatedRA.reverseGet(ra)
+  val hours: Double           = divMicro(µs, 3_600).floatValue
+  val degrees: Double         = divMicro(µas, 3_600).floatValue
+  val microseconds: js.BigInt = js.BigInt(µs.toString())


### PR DESCRIPTION
Works much nicer in JS land:

```sh
> const pkg = require('./main.js')
undefined
> pkg.toDeclination(0)
$b_Llucuma_core_DeclinationJS {
  dms: '+00:00:00.000',
  degrees: 0,
  microarcseconds: 0n
}
> {...pkg.toDeclination(0)}
{ dms: '+00:00:00.000', degrees: 0, microarcseconds: 0n }
```

Instead of:

```sh
> pkg.toDeclination(0)
$c_Llucuma_core_DeclinationJS { Os: '+00:00:00.000', Or: 0, Ot: 0n }
> {...pkg.toDeclination(0)}
{ Os: '+00:00:00.000', Or: 0, Ot: 0n }
> pkg.toDeclination(0).dms
'+00:00:00.000'
```