### PR TITLE
Shortcut 9121: exchange observations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.214"
+ThisBuild / tlBaseVersion                         := "0.215"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/data/Metadata.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/data/Metadata.scala
@@ -40,4 +40,4 @@ object Metadata:
           case Instrument.Gsaoi        => Availability.always(Site.GS)
           case Instrument.Scorpio      => Availability.always(Site.GS)
           case Instrument.VisitorSouth => Availability.always(Site.GS)        
-          case Instrument.Zorro        => Availability.always(Site.GS)        
+          case Instrument.Zorro        => Availability.always(Site.GS)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/Instrument.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/Instrument.scala
@@ -15,24 +15,32 @@ import lucuma.core.util.Enumerated
  *
  * @group Enumerations
  */
-enum Instrument(val tag: String, val shortName: String, val longName: String, val referenceName: NonEmptyString, val obsolete: Boolean) derives Enumerated:
-  /** @group Constructors */ case AcqCamNorth  extends Instrument("AcqCamNorth", "AcqCam (North)", "Acquisition Camera (North)", "ACQCAMN".refined[NonEmpty], false)
-  /** @group Constructors */ case AcqCamSouth  extends Instrument("AcqCamSouth", "AcqCam (South)", "Acquisition Camera (South)", "ACQCAMS".refined[NonEmpty], false)
-  /** @group Constructors */ case Alopeke      extends Instrument("Alopeke", "ALOPEKE", "Alopeke", "ALOPEKE".refined[NonEmpty], false)
-  /** @group Constructors */ case Flamingos2   extends Instrument("Flamingos2", "Flamingos2", "Flamingos 2", "F2".refined[NonEmpty], false)
-  /** @group Constructors */ case Ghost        extends Instrument("Ghost", "GHOST", "GHOST", "GHOST".refined[NonEmpty], false)
-  /** @group Constructors */ case GmosNorth    extends Instrument("GmosNorth", "GMOS-N", "GMOS North", "GMOSN".refined[NonEmpty], false)
-  /** @group Constructors */ case GmosSouth    extends Instrument("GmosSouth", "GMOS-S", "GMOS South", "GMOSS".refined[NonEmpty], false)
-  /** @group Constructors */ case Gnirs        extends Instrument("Gnirs", "GNIRS", "GNIRS", "GNIRS".refined[NonEmpty], false)
-  /** @group Constructors */ case Gpi          extends Instrument("Gpi", "GPI", "GPI", "GPI".refined[NonEmpty], false)
-  /** @group Constructors */ case Gsaoi        extends Instrument("Gsaoi", "GSAOI", "GSAOI", "GSAOI".refined[NonEmpty], false)
-  /** @group Constructors */ case Igrins2      extends Instrument("Igrins2", "IGRINS-2", "IGRINS-2", "IGRINS2".refined[NonEmpty], false)
-  /** @group Constructors */ case MaroonX      extends Instrument("MaroonX", "MAROON-X", "MAROON-X", "MAROONX".refined[NonEmpty], false)
-  /** @group Constructors */ case Niri         extends Instrument("Niri", "NIRI", "NIRI", "NIRI".refined[NonEmpty], false)
-  /** @group Constructors */ case Scorpio      extends Instrument("Scorpio", "SCORPIO", "Scorpio", "SCORPIO".refined[NonEmpty], false)
-  /** @group Constructors */ case VisitorNorth extends Instrument("VisitorNorth", "Visitor (North)", "Visitor Instrument (North)", "VISITORN".refined[NonEmpty], false)
-  /** @group Constructors */ case VisitorSouth extends Instrument("VisitorSouth", "Visitor (South)", "Visitor Instrument (South)", "VISITORS".refined[NonEmpty], false)
-  /** @group Constructors */ case Zorro        extends Instrument("Zorro", "ZORRO", "Zorro", "ZORRO".refined[NonEmpty], false)
+enum Instrument(val tag: String, val shortName: String, val longName: String, val referenceName: NonEmptyString, val isVisitor: Boolean = false) derives Enumerated:
+  /** @group Constructors */ case AcqCamNorth  extends Instrument("AcqCamNorth", "AcqCam (North)", "Acquisition Camera (North)", "ACQCAMN".refined[NonEmpty])
+  /** @group Constructors */ case AcqCamSouth  extends Instrument("AcqCamSouth", "AcqCam (South)", "Acquisition Camera (South)", "ACQCAMS".refined[NonEmpty])
+  /** @group Constructors */ case Alopeke      extends Instrument("Alopeke", "ALOPEKE", "Alopeke", "ALOPEKE".refined[NonEmpty], isVisitor = true)
+  /** @group Constructors */ case Flamingos2   extends Instrument("Flamingos2", "Flamingos2", "Flamingos 2", "F2".refined[NonEmpty])
+  /** @group Constructors */ case Ghost        extends Instrument("Ghost", "GHOST", "GHOST", "GHOST".refined[NonEmpty])
+  /** @group Constructors */ case GmosNorth    extends Instrument("GmosNorth", "GMOS-N", "GMOS North", "GMOSN".refined[NonEmpty])
+  /** @group Constructors */ case GmosSouth    extends Instrument("GmosSouth", "GMOS-S", "GMOS South", "GMOSS".refined[NonEmpty])
+  /** @group Constructors */ case Gnirs        extends Instrument("Gnirs", "GNIRS", "GNIRS", "GNIRS".refined[NonEmpty])
+  /** @group Constructors */ case Gpi          extends Instrument("Gpi", "GPI", "GPI", "GPI".refined[NonEmpty])
+  /** @group Constructors */ case Gsaoi        extends Instrument("Gsaoi", "GSAOI", "GSAOI", "GSAOI".refined[NonEmpty])
+  /** @group Constructors */ case Igrins2      extends Instrument("Igrins2", "IGRINS-2", "IGRINS-2", "IGRINS2".refined[NonEmpty])
+  /** @group Constructors */ case MaroonX      extends Instrument("MaroonX", "MAROON-X", "MAROON-X", "MAROONX".refined[NonEmpty], isVisitor = true)
+  /** @group Constructors */ case Niri         extends Instrument("Niri", "NIRI", "NIRI", "NIRI".refined[NonEmpty])
+  /** @group Constructors */ case Scorpio      extends Instrument("Scorpio", "SCORPIO", "Scorpio", "SCORPIO".refined[NonEmpty])
+  /** @group Constructors */ case VisitorNorth extends Instrument("VisitorNorth", "Visitor (North)", "Visitor Instrument (North)", "VISITORN".refined[NonEmpty], isVisitor = true)
+  /** @group Constructors */ case VisitorSouth extends Instrument("VisitorSouth", "Visitor (South)", "Visitor Instrument (South)", "VISITORS".refined[NonEmpty], isVisitor = true)
+  /** @group Constructors */ case Zorro        extends Instrument("Zorro", "ZORRO", "Zorro", "ZORRO".refined[NonEmpty], isVisitor = true)
 
   def availability(using md: Metadata): Availability =
     md.availability(this)
+
+object Instrument:
+
+  def facilityInstruments: Set[Instrument] =
+    values.filterNot(_.isVisitor).toSet
+
+  def visitorInstruments: Set[Instrument] =
+    values.filter(_.isVisitor).toSet

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObservingModeType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObservingModeType.scala
@@ -6,22 +6,67 @@ package lucuma.core.enums
 import lucuma.core.math.Angle
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.util.Enumerated
+import monocle.Prism
+import monocle.macros.GenPrism
 
 sealed trait ObservingModeType derives Enumerated:
   def tag: String
-  def instrument: Instrument
   def defaultPosAngleConstraint: PosAngleConstraint
+  def observatory: Observatory
+
+  def fold[A](
+    fe: ExchangeObservingModeType => A,
+    ff: FacilityObservingModeType => A,
+    fv: VisitorObservingModeType  => A
+  ): A =
+    this match
+      case m: ExchangeObservingModeType => fe(m)
+      case m: FacilityObservingModeType => ff(m)
+      case m: VisitorObservingModeType  => fv(m)
+
+  def isExchange: Boolean =
+    fold(_ => true, _ => false, _ => false)
+
+  def isFacility: Boolean =
+    fold(_ => false, _ => true, _ => false)
+
+  def isVisitor: Boolean =
+    fold(_ => false, _ => false, _ => true)
 
 object ObservingModeType:
   export FacilityObservingModeType.{ values => _, * }
   export VisitorObservingModeType.{ values => _, * }
-  val values = FacilityObservingModeType.values ++ VisitorObservingModeType.values
+  export ExchangeObservingModeType.{ values => _, * }
+  val values = FacilityObservingModeType.values ++ VisitorObservingModeType.values ++ ExchangeObservingModeType.values
+
+  val toExchange: Prism[ObservingModeType, ExchangeObservingModeType] =
+    GenPrism[ObservingModeType, ExchangeObservingModeType]
+
+  val toFacility: Prism[ObservingModeType, FacilityObservingModeType] =
+    GenPrism[ObservingModeType, FacilityObservingModeType]
+
+  val toVisitor: Prism[ObservingModeType, VisitorObservingModeType] =
+    GenPrism[ObservingModeType, VisitorObservingModeType]
+
+// Exchange observing modes: a Gemini PI requesting time at another observatory
+// (Keck or Subaru) via an exchange.  The mode tag encodes the observatory; the
+// specific exchange instrument is carried alongside in the observation's config.
+// These are not Gemini instruments and are not supported by ITC or AGS, so they
+// have no `Instrument`.
+enum ExchangeObservingModeType(
+  val tag: String,
+  val observatory: Observatory
+) extends ObservingModeType derives Enumerated:
+  val defaultPosAngleConstraint = PosAngleConstraint.Fixed(Angle.Angle0) // for all exchanges
+  case ExchangeKeck   extends ExchangeObservingModeType("exchange_keck",   Observatory.Keck)
+  case ExchangeSubaru extends ExchangeObservingModeType("exchange_subaru", Observatory.Subaru)
 
 enum FacilityObservingModeType(
   val tag: String,
   val instrument: Instrument,
   val defaultPosAngleConstraint: PosAngleConstraint
 ) extends ObservingModeType derives Enumerated:
+  case Flamingos2Imaging  extends FacilityObservingModeType("flamingos_2_imaging",   Instrument.Flamingos2, PosAngleConstraint.Unbounded)
   case Flamingos2LongSlit extends FacilityObservingModeType("flamingos_2_long_slit", Instrument.Flamingos2, PosAngleConstraint.AverageParallactic)
   case GhostIfu           extends FacilityObservingModeType("ghost_ifu",             Instrument.Ghost,      PosAngleConstraint.Fixed(Angle.Angle0))
   case GmosNorthImaging   extends FacilityObservingModeType("gmos_north_imaging",    Instrument.GmosNorth,  PosAngleConstraint.Unbounded)
@@ -31,7 +76,9 @@ enum FacilityObservingModeType(
   case GnirsLongSlit      extends FacilityObservingModeType("gnirs_long_slit",       Instrument.Gnirs,      PosAngleConstraint.AverageParallactic)
   case GnirsIfu           extends FacilityObservingModeType("gnirs_ifu",             Instrument.Gnirs,      PosAngleConstraint.AverageParallactic)
   case Igrins2LongSlit    extends FacilityObservingModeType("igrins_2_long_slit",    Instrument.Igrins2,    PosAngleConstraint.AverageParallactic)
-  case Flamingos2Imaging  extends FacilityObservingModeType("flamingos_2_imaging",   Instrument.Flamingos2, PosAngleConstraint.Unbounded)
+
+  override def observatory: Observatory =
+    Observatory.Gemini
 
 enum VisitorObservingModeType(
   val tag: String,
@@ -46,3 +93,5 @@ enum VisitorObservingModeType(
   case ZorroSpeckle       extends VisitorObservingModeType("zorro_speckle",          Instrument.Zorro)
   case ZorroWideField     extends VisitorObservingModeType("zorro_wide_field",       Instrument.Zorro)
 
+  override def observatory: Observatory =
+    Observatory.Gemini

--- a/modules/core/shared/src/main/scala/lucuma/core/model/probes.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/probes.scala
@@ -4,6 +4,7 @@
 package lucuma.core.model
 
 import cats.syntax.all.*
+import lucuma.core.enums.ExchangeObservingModeType
 import lucuma.core.enums.GuideProbe
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.TrackType
@@ -12,6 +13,9 @@ import lucuma.core.enums.VisitorObservingModeType
 trait probes:
   def guideProbe(observingMode: ObservingModeType, trackType: TrackType): Option[GuideProbe] =
     (observingMode, trackType) match
+      // Exchange observations are not supported by AGS; there is no guide probe.
+      case (_: ExchangeObservingModeType, _) =>
+        none
       case (ObservingModeType.Flamingos2LongSlit | ObservingModeType.Flamingos2Imaging, TrackType.Nonsidereal) =>
         GuideProbe.PWFS2.some
       case (ObservingModeType.Flamingos2LongSlit | ObservingModeType.Flamingos2Imaging, TrackType.Sidereal) =>

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/InstrumentExecutionConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/InstrumentExecutionConfig.scala
@@ -35,10 +35,6 @@ sealed trait InstrumentExecutionConfig:
 
 object InstrumentExecutionConfig:
 
-  case class Visitor(visitorInstrument: Instrument) extends InstrumentExecutionConfig derives Eq:
-    override def instrument: Option[Instrument] = visitorInstrument.some
-    val isComplete = true
-
   /**
    * Exchange observations (Keck/Subaru) have no Gemini instrument and no
    * generated sequence.
@@ -46,6 +42,9 @@ object InstrumentExecutionConfig:
   case object Exchange extends InstrumentExecutionConfig:
     override def instrument: Option[Instrument] = none
     override def isComplete: Boolean            = true
+
+  val exchange: Prism[InstrumentExecutionConfig, Exchange.type] =
+    GenPrism[InstrumentExecutionConfig, Exchange.type]
 
   case class Flamingos2(
     executionConfig: ExecutionConfig[f2.Flamingos2StaticConfig, f2.Flamingos2DynamicConfig]
@@ -142,6 +141,13 @@ object InstrumentExecutionConfig:
 
   val igrins2: Prism[InstrumentExecutionConfig, Igrins2] =
     GenPrism[InstrumentExecutionConfig, Igrins2]
+
+  case class Visitor(visitorInstrument: Instrument) extends InstrumentExecutionConfig derives Eq:
+    override def instrument: Option[Instrument] = visitorInstrument.some
+    val isComplete = true
+
+  val visitor: Prism[InstrumentExecutionConfig, Visitor] =
+    GenPrism[InstrumentExecutionConfig, Visitor]
 
   given Eq[InstrumentExecutionConfig] =
     Eq.instance:

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/InstrumentExecutionConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/InstrumentExecutionConfig.scala
@@ -6,6 +6,7 @@ package lucuma.core.model.sequence
 import cats.Eq
 import cats.derived.*
 import cats.syntax.eq.*
+import cats.syntax.option.*
 import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.flamingos2 as f2
 import lucuma.core.model.sequence.ghost.GhostDynamicConfig
@@ -23,21 +24,33 @@ import monocle.macros.GenPrism
  */
 sealed trait InstrumentExecutionConfig:
 
-  /** Returns the instrument discriminator associated with this execution config. */
-  def instrument: Instrument
+  /**
+   * Returns the instrument discriminator associated with this execution config,
+   * if any.  Exchange observations are not Gemini instruments and have none.
+   */
+  def instrument: Option[Instrument]
 
   /** Returns `true` if there are no science steps to execute. */
   def isComplete: Boolean
 
 object InstrumentExecutionConfig:
 
-  case class Visitor(instrument: Instrument) extends InstrumentExecutionConfig:
+  case class Visitor(visitorInstrument: Instrument) extends InstrumentExecutionConfig derives Eq:
+    override def instrument: Option[Instrument] = visitorInstrument.some
     val isComplete = true
+
+  /**
+   * Exchange observations (Keck/Subaru) have no Gemini instrument and no
+   * generated sequence.
+   */
+  case object Exchange extends InstrumentExecutionConfig:
+    override def instrument: Option[Instrument] = none
+    override def isComplete: Boolean            = true
 
   case class Flamingos2(
     executionConfig: ExecutionConfig[f2.Flamingos2StaticConfig, f2.Flamingos2DynamicConfig]
   ) extends InstrumentExecutionConfig:
-    override def instrument: Instrument = Instrument.Flamingos2
+    override def instrument: Option[Instrument] = Instrument.Flamingos2.some
     override def isComplete: Boolean    = executionConfig.isComplete
 
   object Flamingos2:
@@ -54,7 +67,7 @@ object InstrumentExecutionConfig:
   case class Ghost(
     executionConfig: ExecutionConfig[GhostStaticConfig, GhostDynamicConfig]
   ) extends InstrumentExecutionConfig derives Eq:
-    override def instrument: Instrument = Instrument.Ghost
+    override def instrument: Option[Instrument] = Instrument.Ghost.some
     override def isComplete: Boolean    = executionConfig.isComplete
 
   object Ghost:
@@ -67,7 +80,7 @@ object InstrumentExecutionConfig:
   case class GmosNorth(
     executionConfig: ExecutionConfig[gmos.StaticConfig.GmosNorth, gmos.DynamicConfig.GmosNorth]
   ) extends InstrumentExecutionConfig:
-    override def instrument: Instrument = Instrument.GmosNorth
+    override def instrument: Option[Instrument] = Instrument.GmosNorth.some
     override def isComplete: Boolean    = executionConfig.isComplete
 
   object GmosNorth:
@@ -85,7 +98,7 @@ object InstrumentExecutionConfig:
   case class GmosSouth(
     executionConfig: ExecutionConfig[gmos.StaticConfig.GmosSouth, gmos.DynamicConfig.GmosSouth]
   ) extends InstrumentExecutionConfig:
-    override def instrument: Instrument = Instrument.GmosSouth
+    override def instrument: Option[Instrument] = Instrument.GmosSouth.some
     override def isComplete: Boolean    = executionConfig.isComplete
 
   object GmosSouth:
@@ -103,7 +116,7 @@ object InstrumentExecutionConfig:
   case class Gnirs(
     executionConfig: ExecutionConfig[GnirsStaticConfig, GnirsDynamicConfig]
   ) extends InstrumentExecutionConfig:
-    override def instrument: Instrument = Instrument.Gnirs
+    override def instrument: Option[Instrument] = Instrument.Gnirs.some
     override def isComplete: Boolean    = executionConfig.isComplete
 
   object Gnirs:
@@ -120,7 +133,7 @@ object InstrumentExecutionConfig:
   case class Igrins2(
     executionConfig: ExecutionConfig[ig2.Igrins2StaticConfig, ig2.Igrins2DynamicConfig]
   ) extends InstrumentExecutionConfig derives Eq:
-    override def instrument: Instrument = Instrument.Igrins2
+    override def instrument: Option[Instrument] = Instrument.Igrins2.some
     override def isComplete: Boolean    = executionConfig.isComplete
 
   object Igrins2:
@@ -132,10 +145,12 @@ object InstrumentExecutionConfig:
 
   given Eq[InstrumentExecutionConfig] =
     Eq.instance:
+      case (Exchange, Exchange)                   => true
       case (a @ Flamingos2(_), b @ Flamingos2(_)) => a === b
-      case (a @ Ghost(_), b @ Ghost(_))           => a === b
-      case (a @ GmosNorth(_), b @ GmosNorth(_))   => a === b
-      case (a @ GmosSouth(_), b @ GmosSouth(_))   => a === b
-      case (a @ Gnirs(_), b @ Gnirs(_))           => a === b
-      case (a @ Igrins2(_), b @ Igrins2(_))       => a === b
+      case (a @ Ghost(_),      b @ Ghost(_))      => a === b
+      case (a @ GmosNorth(_),  b @ GmosNorth(_))  => a === b
+      case (a @ GmosSouth(_),  b @ GmosSouth(_))  => a === b
+      case (a @ Gnirs(_),      b @ Gnirs(_))      => a === b
+      case (a @ Igrins2(_),    b @ Igrins2(_))    => a === b
+      case (a @ Visitor(_),    b @ Visitor(_))    => a === b
       case _                                      => false

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbInstrumentExecutionConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/arb/ArbInstrumentExecutionConfig.scala
@@ -4,6 +4,7 @@
 package lucuma.core.model.sequence
 package arb
 
+import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig
 import lucuma.core.model.sequence.flamingos2.Flamingos2StaticConfig
 import lucuma.core.model.sequence.flamingos2.arb.ArbFlamingos2DynamicConfig
@@ -16,10 +17,15 @@ import lucuma.core.model.sequence.gmos.DynamicConfig
 import lucuma.core.model.sequence.gmos.StaticConfig
 import lucuma.core.model.sequence.gmos.arb.ArbDynamicConfig
 import lucuma.core.model.sequence.gmos.arb.ArbStaticConfig
+import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
+import lucuma.core.model.sequence.gnirs.GnirsStaticConfig
+import lucuma.core.model.sequence.gnirs.arb.ArbGnirsDynamicConfig
+import lucuma.core.model.sequence.gnirs.arb.ArbGnirsStaticConfig
 import lucuma.core.model.sequence.igrins2.Igrins2DynamicConfig
 import lucuma.core.model.sequence.igrins2.Igrins2StaticConfig
 import lucuma.core.model.sequence.igrins2.arb.ArbIgrins2DynamicConfig
 import lucuma.core.model.sequence.igrins2.arb.ArbIgrins2StaticConfig
+import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen
@@ -28,14 +34,21 @@ import org.scalacheck.Gen
 trait ArbInstrumentExecutionConfig:
 
   import ArbDynamicConfig.given
+  import ArbEnumerated.given
   import ArbExecutionConfig.given
   import ArbFlamingos2DynamicConfig.given
   import ArbFlamingos2StaticConfig.given
   import ArbGhostDynamicConfig.given
   import ArbGhostStaticConfig.given
+  import ArbGnirsDynamicConfig.given
+  import ArbGnirsStaticConfig.given
   import ArbIgrins2DynamicConfig.given
   import ArbIgrins2StaticConfig.given
   import ArbStaticConfig.given
+
+  given Arbitrary[InstrumentExecutionConfig.Exchange.type] =
+    Arbitrary:
+      Gen.const(InstrumentExecutionConfig.Exchange)
 
   given Arbitrary[InstrumentExecutionConfig.Flamingos2] =
     Arbitrary:
@@ -53,19 +66,35 @@ trait ArbInstrumentExecutionConfig:
     Arbitrary:
       arbitrary[ExecutionConfig[StaticConfig.GmosSouth, DynamicConfig.GmosSouth]].map(InstrumentExecutionConfig.GmosSouth(_))
 
+  given Arbitrary[InstrumentExecutionConfig.Gnirs] =
+    Arbitrary:
+      arbitrary[ExecutionConfig[GnirsStaticConfig, GnirsDynamicConfig]].map(InstrumentExecutionConfig.Gnirs(_))
+
   given Arbitrary[InstrumentExecutionConfig.Igrins2] =
     Arbitrary:
       arbitrary[ExecutionConfig[Igrins2StaticConfig, Igrins2DynamicConfig]].map(InstrumentExecutionConfig.Igrins2(_))
 
+  given Arbitrary[InstrumentExecutionConfig.Visitor] =
+    Arbitrary:
+      Gen
+        .oneOf(Instrument.visitorInstruments)
+        .map(InstrumentExecutionConfig.Visitor(_))
+
   given Arbitrary[InstrumentExecutionConfig] =
     Arbitrary:
       Gen.oneOf(
+        arbitrary[InstrumentExecutionConfig.Exchange.type],
         arbitrary[InstrumentExecutionConfig.Flamingos2],
         arbitrary[InstrumentExecutionConfig.Ghost],
         arbitrary[InstrumentExecutionConfig.GmosNorth],
         arbitrary[InstrumentExecutionConfig.GmosSouth],
-        arbitrary[InstrumentExecutionConfig.Igrins2]
+        arbitrary[InstrumentExecutionConfig.Gnirs],
+        arbitrary[InstrumentExecutionConfig.Igrins2],
+        arbitrary[InstrumentExecutionConfig.Visitor]
       )
+
+  given Cogen[InstrumentExecutionConfig.Exchange.type] =
+    Cogen[Unit].contramap(_ => ())
 
   given Cogen[InstrumentExecutionConfig.Flamingos2] =
     Cogen[ExecutionConfig[Flamingos2StaticConfig, Flamingos2DynamicConfig]].contramap(_.executionConfig)
@@ -79,22 +108,36 @@ trait ArbInstrumentExecutionConfig:
   given Cogen[InstrumentExecutionConfig.GmosSouth] =
     Cogen[ExecutionConfig[StaticConfig.GmosSouth, DynamicConfig.GmosSouth]].contramap(_.executionConfig)
 
+  given Cogen[InstrumentExecutionConfig.Gnirs] =
+    Cogen[ExecutionConfig[GnirsStaticConfig, GnirsDynamicConfig]].contramap(_.executionConfig)
+
   given Cogen[InstrumentExecutionConfig.Igrins2] =
     Cogen[ExecutionConfig[Igrins2StaticConfig, Igrins2DynamicConfig]].contramap(_.executionConfig)
 
+  given Cogen[InstrumentExecutionConfig.Visitor] =
+    Cogen[Instrument]
+      .contramap: v =>
+        v.visitorInstrument
+
   given Cogen[InstrumentExecutionConfig] =
     Cogen[(
+      Option[InstrumentExecutionConfig.Exchange.type],
       Option[InstrumentExecutionConfig.Flamingos2],
       Option[InstrumentExecutionConfig.Ghost],
       Option[InstrumentExecutionConfig.GmosNorth],
       Option[InstrumentExecutionConfig.GmosSouth],
-      Option[InstrumentExecutionConfig.Igrins2]
+      Option[InstrumentExecutionConfig.Gnirs],
+      Option[InstrumentExecutionConfig.Igrins2],
+      Option[InstrumentExecutionConfig.Visitor]
     )].contramap { a => (
+      InstrumentExecutionConfig.exchange.getOption(a),
       InstrumentExecutionConfig.flamingos2.getOption(a),
       InstrumentExecutionConfig.ghost.getOption(a),
       InstrumentExecutionConfig.gmosNorth.getOption(a),
       InstrumentExecutionConfig.gmosSouth.getOption(a),
-      InstrumentExecutionConfig.igrins2.getOption(a)
+      InstrumentExecutionConfig.gnirs.getOption(a),
+      InstrumentExecutionConfig.igrins2.getOption(a),
+      InstrumentExecutionConfig.visitor.getOption(a)
     )}
 
 object ArbInstrumentExecutionConfig extends ArbInstrumentExecutionConfig


### PR DESCRIPTION
Adds an `ExchangeObservingModeType` for observations destined for Keck and Subaru.  Not only are these observations not given an execution sequence, they don't participate in AGS or configuration requests.  The new `ExchangeObservingModeType` is patterned after the `VisitorObservingModeType` but I needed to make the `Instrument` optional since there is no Gemini instrument for these.