### PR TITLE
Add outline for the GMOS masks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.217"
+ThisBuild / tlBaseVersion                         := "0.218"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometry.scala
@@ -26,8 +26,45 @@ trait GmosScienceAreaGeometry {
   val imaging: ShapeExpression =
     imagingFov(330340.mas, 33840.mas)
 
+  // TODO: This may not be the correct shape, verify
   val mos: ShapeExpression =
     imagingFov(314240.mas, 17750.mas)
+
+  // GMMPS "slit placement area" for GMOS MOS masks
+  // It is a a polygon whose vertices come from the GMMPS Hamamatsu FoV definitions 
+  // in arcsec relative to the pointing center.
+  private val mosVerticesNorth: List[(Int, Int)] =
+    List(
+      (-128, -164), (-163, -131), (-163, 131), (-130, 164),
+      (130, 164),   (164, 129),   (164, 48),    (155, 48),
+      (155, -65),   (164, -65),   (164, -106),  (114, -164)
+    )
+
+  private val mosVerticesSouth: List[(Int, Int)] =
+    List(
+      (-130, -159), (-163, -125), (-163, 136), (-133, 166),
+      (136, 166),   (165, 136),   (165, 50),   (150, 50),
+      (150, -50),   (165, -50),   (165, -105), (115, -159)
+    )
+
+  private def mosOutlineFromVertices(vertices: List[(Int, Int)]): ShapeExpression =
+    ShapeExpression.polygonAt(
+      vertices.map((x, y) => ((-x).arcsec.p, y.arcsec.q))*
+    )
+
+  val mosOutlineNorth: ShapeExpression =
+    mosOutlineFromVertices(mosVerticesNorth)
+
+  val mosOutlineSouth: ShapeExpression =
+    mosOutlineFromVertices(mosVerticesSouth)
+
+  object mosModeNorth:
+    def shapeAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
+      mosOutlineNorth.shapeAt(offsetPos, posAngle)
+
+  object mosModeSouth:
+    def shapeAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
+      mosOutlineSouth.shapeAt(offsetPos, posAngle)
 
   object imagingMode:
     def shapeAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -96,6 +96,28 @@ trait GmosImagingShapes extends InstrumentShapes:
       candidatesArea.candidatesAreaAt(posAngle, offsetPos)
     )
 
+trait GmosMosShapes extends InstrumentShapes:
+  import lucuma.core.geom.gmos.{scienceArea, candidatesArea}
+  import lucuma.core.geom.gmos.oiwfs.{probeArm, patrolField}
+
+  val posAngle: Angle         = 0.deg
+  val offsetPos: Offset       = Offset(-60.arcsec.p, 60.arcsec.q)
+  val guideStarOffset: Offset = Offset(-140.arcsec.p, 160.arcsec.q)
+  val port: PortDisposition   = PortDisposition.Side
+
+  override def coloredShapes: List[ColoredShape] =
+    List(
+      ColoredShape(scienceArea.imagingMode.shapeAt(posAngle, offsetPos),   new Color(144, 238, 144)),
+      ColoredShape(scienceArea.mosModeSouth.shapeAt(posAngle, offsetPos), Color.cyan, Some(new BasicStroke(2f)))
+    )
+
+  def shapes: List[ShapeExpression] =
+    List(
+      probeArm.imaging.shapeAt(posAngle, guideStarOffset, offsetPos, port),
+      patrolField.imagingMode.patrolFieldAt(posAngle, offsetPos, port),
+      candidatesArea.candidatesAreaAt(posAngle, offsetPos)
+    )
+
 trait Flamingos2LSShapes extends InstrumentShapes:
   import lucuma.core.geom.flamingos2.*
   import lucuma.core.geom.flamingos2.oiwfs.{probeArm, patrolField}
@@ -379,6 +401,8 @@ object JtsFlamingos2LSDemo extends JtsDemo with Flamingos2LSShapes
 object JtsFlamingos2ImagingDemo extends JtsDemo with Flamingos2ImagingShapes
 
 object JtsGmosImagingDemo extends JtsDemo with GmosImagingShapes
+
+object JtsGmosMosDemo extends JtsDemo with GmosMosShapes
 
 object JtsPwfsDemo extends JtsDemo with PwfsShapes:
   override val arcsecPerPixel: Double = 0.5


### PR DESCRIPTION
We can get the outline of the MOS masks for gmos from gmmps (barcode included). Note the outline is slightly different at GN and GS

<img width="1824" height="1824" alt="image" src="https://github.com/user-attachments/assets/d144556c-e984-4d49-bc1d-937e3f69ef48" />
