### PR TITLE
Gnirs imaging + IFU AGS and imaging geometry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.216"
+ThisBuild / tlBaseVersion                         := "0.217"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
@@ -13,6 +13,8 @@ import lucuma.core.enums.GmosFpuType
 import lucuma.core.enums.GmosNorthFpu
 import lucuma.core.enums.GmosSouthFpu
 import lucuma.core.enums.GnirsCamera
+import lucuma.core.enums.GnirsFilter
+import lucuma.core.enums.GnirsFpuIfu
 import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsPrism
 import lucuma.core.enums.GuideProbe
@@ -22,6 +24,7 @@ import lucuma.core.geom.Area
 import lucuma.core.geom.BoundingOffsets
 import lucuma.core.geom.Shape
 import lucuma.core.geom.ShapeExpression
+import lucuma.core.geom.gnirs
 import lucuma.core.geom.jts.interpreter.given
 import lucuma.core.geom.offsets.OffsetPosition
 import lucuma.core.geom.syntax.all.*
@@ -402,6 +405,64 @@ object AgsParams:
       port:   PortDisposition = PortDisposition.Bottom
     ): GnirsLongSlit =
       GnirsLongSlit(fpu, camera, prism, port, GuideProbe.PWFS2)
+
+    val GnirsScienceRadius = 20.arcseconds
+
+  case class GnirsImaging private (
+    camera: GnirsCamera,
+    filter: GnirsFilter,
+    port:   PortDisposition,
+    probe:  PWFSGuideProbe
+  ) extends AgsParams
+      with PwfsOnlyParams
+      with PwfsSupport[GnirsImaging] derives Eq:
+
+    protected def withPWFSProbe(probe: PWFSGuideProbe): GnirsImaging = copy(probe = probe)
+
+    override def scienceArea(posAngle: Angle, offset: Offset): ShapeExpression =
+      lucuma.core.geom.gnirs.scienceArea.imagingShapeAt(posAngle, offset, camera, filter)
+
+    override def scienceRadius: Angle = GnirsImaging.GnirsScienceRadius
+
+  object GnirsImaging:
+    def apply(
+      camera: GnirsCamera,
+      filter: GnirsFilter,
+      port:   PortDisposition = PortDisposition.Bottom
+    ): GnirsImaging =
+      GnirsImaging(camera, filter, port, GuideProbe.PWFS2)
+
+    // Representative filter for a multi-filter imaging observation: the keyhole
+    // (order-blocking / narrow-band / H-MK) field is larger than the round MK field,
+    // so a mixed set uses a keyhole filter when one is present.
+    def representativeFilter(filters: NonEmptyList[GnirsFilter]): GnirsFilter =
+      filters
+        .find(f => !gnirs.scienceArea.isRoundImagingFilter(f))
+        .getOrElse(filters.head)
+
+    val GnirsScienceRadius = 20.arcseconds
+
+  case class GnirsIfu private (
+    ifu:   GnirsFpuIfu,
+    port:  PortDisposition,
+    probe: PWFSGuideProbe
+  ) extends AgsParams
+      with PwfsOnlyParams
+      with PwfsSupport[GnirsIfu] derives Eq:
+
+    protected def withPWFSProbe(probe: PWFSGuideProbe): GnirsIfu = copy(probe = probe)
+
+    override def scienceArea(posAngle: Angle, offset: Offset): ShapeExpression =
+      lucuma.core.geom.gnirs.scienceArea.ifuShapeAt(posAngle, offset, ifu)
+
+    override def scienceRadius: Angle = GnirsIfu.GnirsScienceRadius
+
+  object GnirsIfu:
+    def apply(
+      ifu:  GnirsFpuIfu,
+      port: PortDisposition = PortDisposition.Bottom
+    ): GnirsIfu =
+      GnirsIfu(ifu, port, GuideProbe.PWFS2)
 
     val GnirsScienceRadius = 20.arcseconds
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GcalContinuum.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GcalContinuum.scala
@@ -12,5 +12,5 @@ import lucuma.core.util.Enumerated
 enum GcalContinuum(val tag: String, val shortName: String, val longName: String) derives Enumerated:
   /** @group Constructors */ case IrGreyBodyLow     extends GcalContinuum("IrGreyBodyLow", "IR Low", "IR grey body - low")
   /** @group Constructors */ case IrGreyBodyHigh    extends GcalContinuum("IrGreyBodyHigh", "IR High", "IR grey body - high")
-  /** @group Constructors */ case QuartzHalogen5W   extends GcalContinuum("QuartzHalogen5", "5W Quartz Halogen", "5W Quartz Halogen")
-  /** @group Constructors */ case QuartzHalogen100W extends GcalContinuum("QuartzHalogen100", "100W Quartz Halogen", "100W Quartz Halogen")
+  /** @group Constructors */ case QuartzHalogen5W   extends GcalContinuum("QuartzHalogen5", "5W QH", "5W Quartz Halogen")
+  /** @group Constructors */ case QuartzHalogen100W extends GcalContinuum("QuartzHalogen100", "100W QH", "100W Quartz Halogen")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GcalContinuum.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GcalContinuum.scala
@@ -10,7 +10,7 @@ import lucuma.core.util.Enumerated
  * @group Enumerations
  */
 enum GcalContinuum(val tag: String, val shortName: String, val longName: String) derives Enumerated:
-  /** @group Constructors */ case IrGreyBodyLow     extends GcalContinuum("IrGreyBodyLow", "IR grey body - low", "IR grey body - low")
-  /** @group Constructors */ case IrGreyBodyHigh    extends GcalContinuum("IrGreyBodyHigh", "IR grey body - high", "IR grey body - high")
+  /** @group Constructors */ case IrGreyBodyLow     extends GcalContinuum("IrGreyBodyLow", "IR Low", "IR grey body - low")
+  /** @group Constructors */ case IrGreyBodyHigh    extends GcalContinuum("IrGreyBodyHigh", "IR High", "IR grey body - high")
   /** @group Constructors */ case QuartzHalogen5W   extends GcalContinuum("QuartzHalogen5", "5W Quartz Halogen", "5W Quartz Halogen")
   /** @group Constructors */ case QuartzHalogen100W extends GcalContinuum("QuartzHalogen100", "100W Quartz Halogen", "100W Quartz Halogen")

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometry.scala
@@ -46,23 +46,22 @@ trait GnirsScienceAreaGeometry:
       case GnirsFilter.Y | GnirsFilter.J | GnirsFilter.K => true
       case _                                             => false
 
-  private def asec(a: Angle): Double = Angle.signedDecimalArcseconds.get(a).toDouble
-  private def arcsec(d: Double): Angle = Angle.fromDoubleArcseconds(d)
   private def offP(pArcsec: Double): Offset =
     Offset.signedMicroarcseconds.reverseGet(((pArcsec * 1e6).round, 0L))
 
   // A circular cap (segment) protruding toward +p from the +p edge of a bar of the
-  // given p-width (centered on the origin). `chord` is the cap's extent along q, and
-  // `sagitta` its protrusion along p; the radius is implied by the two. The long field
-  // axis runs along q (like the long slit), so the cap bumps out sideways.
+  // given p-width (centered on the origin). `capWidth` is the cap's extent along q, and
+  // `capHeight` its protrusion along p; the radius is implied by the two (the standard
+  // chord/sagitta relation for a circular segment). The long field axis runs along q
+  // (like the long slit), so the cap bumps out sideways.
   // See https://www.gemini.edu/sciops/instruments/nirs/filters/imaging_aps.jpg
-  private def cap(chord: Angle, sagitta: Angle, barWidth: Angle): ShapeExpression =
-    val c       = asec(chord)
-    val s       = asec(sagitta)
-    val baseP   = asec(barWidth) / 2                   // cap springs from the +p edge of the bar
-    val r       = (s * s + (c / 2) * (c / 2)) / (2 * s) // circle radius from chord & sagitta
-    val circle  = ShapeExpression.centeredEllipse(arcsec(2 * r), arcsec(2 * r)) ↗ offP(baseP - (r - s))
-    val clip    = ShapeExpression.centeredRectangle(arcsec(2 * s + 2), arcsec(c + 2)) ↗ offP(baseP + s + 1)
+  private def cap(capWidth: Angle, capHeight: Angle, barWidth: Angle): ShapeExpression =
+    val w       = capWidth.toSignedDoubleDecimalArcseconds
+    val h       = capHeight.toSignedDoubleDecimalArcseconds
+    val baseP   = barWidth.toSignedDoubleDecimalArcseconds / 2 // cap springs from the +p edge of the bar
+    val r       = (h * h + (w / 2) * (w / 2)) / (2 * h) // circle radius from chord (w) & sagitta (h)
+    val circle  = ShapeExpression.centeredEllipse((2 * r).toArcsecondsAngle, (2 * r).toArcsecondsAngle) ↗ offP(baseP - (r - h))
+    val clip    = ShapeExpression.centeredRectangle((2 * h + 2).toArcsecondsAngle, (w + 2).toArcsecondsAngle) ↗ offP(baseP + h + 1)
     circle ∩ clip
 
   // GNIRS imaging science area ("keyhole"): the 99"/49" no-XD field along q (camera-

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometry.scala
@@ -4,6 +4,7 @@
 package lucuma.core.geom.gnirs
 
 import lucuma.core.enums.GnirsCamera
+import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsFpuIfu
 import lucuma.core.enums.GnirsFpuOther
 import lucuma.core.enums.GnirsFpuSlit
@@ -37,6 +38,44 @@ trait GnirsScienceAreaGeometry:
     prism:  GnirsPrism
   ): ShapeExpression =
     ShapeExpression.centeredRectangle(slit.slitWidth, slitLength(camera, prism))
+
+  // Y-MK, J-MK and K-MK filters see the smaller, round unvignetted field; every other
+  // imaging filter (order-blocking, narrow-band, H-MK) sees the full keyhole.
+  def isRoundImagingFilter(filter: GnirsFilter): Boolean =
+    filter match
+      case GnirsFilter.Y | GnirsFilter.J | GnirsFilter.K => true
+      case _                                             => false
+
+  private def asec(a: Angle): Double = Angle.signedDecimalArcseconds.get(a).toDouble
+  private def arcsec(d: Double): Angle = Angle.fromDoubleArcseconds(d)
+  private def offP(pArcsec: Double): Offset =
+    Offset.signedMicroarcseconds.reverseGet(((pArcsec * 1e6).round, 0L))
+
+  // A circular cap (segment) protruding toward +p from the +p edge of a bar of the
+  // given p-width (centered on the origin). `chord` is the cap's extent along q, and
+  // `sagitta` its protrusion along p; the radius is implied by the two. The long field
+  // axis runs along q (like the long slit), so the cap bumps out sideways.
+  // See https://www.gemini.edu/sciops/instruments/nirs/filters/imaging_aps.jpg
+  private def cap(chord: Angle, sagitta: Angle, barWidth: Angle): ShapeExpression =
+    val c       = asec(chord)
+    val s       = asec(sagitta)
+    val baseP   = asec(barWidth) / 2                   // cap springs from the +p edge of the bar
+    val r       = (s * s + (c / 2) * (c / 2)) / (2 * s) // circle radius from chord & sagitta
+    val circle  = ShapeExpression.centeredEllipse(arcsec(2 * r), arcsec(2 * r)) ↗ offP(baseP - (r - s))
+    val clip    = ShapeExpression.centeredRectangle(arcsec(2 * s + 2), arcsec(c + 2)) ↗ offP(baseP + s + 1)
+    circle ∩ clip
+
+  // GNIRS imaging science area ("keyhole"): the 99"/49" no-XD field along q (camera-
+  // dependent, like the long slit) as a narrow bar, with a circular cap bumping out to
+  // one side; or, for the MK filters, the smaller round field. Widths below are the
+  // diagram's horizontal (mapped to q); heights are its vertical (the spatial cross-axis, p).
+  private def imagingFov(camera: GnirsCamera, filter: GnirsFilter): ShapeExpression =
+    if isRoundImagingFilter(filter) then
+      ShapeExpression.centeredRectangle(RoundFieldHeight, RoundFieldWidth) ∪
+        cap(RoundCapWidth, RoundCapHeight, RoundFieldHeight)
+    else
+      ShapeExpression.centeredRectangle(KeyholeBarHeight, slitLength(camera, GnirsPrism.Mirror)) ∪
+        cap(KeyholeCapWidth, KeyholeCapHeight, KeyholeBarHeight)
 
   // IFU science area: a rectangle of the IFU "slit width" by a fixed,
   // resolution-dependent height (derived from ocs InstGNIRS.getScienceArea).
@@ -78,5 +117,20 @@ trait GnirsScienceAreaGeometry:
     prism:     GnirsPrism
   ): ShapeExpression =
     longSlitFov(slit, camera, prism).shapeAt(offsetPos, posAngle)
+
+  def imagingShapeAt(
+    posAngle:  Angle,
+    offsetPos: Offset,
+    camera:    GnirsCamera,
+    filter:    GnirsFilter
+  ): ShapeExpression =
+    imagingFov(camera, filter).shapeAt(offsetPos, posAngle)
+
+  def ifuShapeAt(
+    posAngle:  Angle,
+    offsetPos: Offset,
+    ifu:       GnirsFpuIfu
+  ): ShapeExpression =
+    ifuFov(ifu).shapeAt(offsetPos, posAngle)
 
 object scienceArea extends GnirsScienceAreaGeometry

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/package.scala
@@ -22,4 +22,23 @@ val IfuHighResHeight: Angle = 1800.mas
 val Pinhole1Size: Angle = 100.mas
 val Pinhole3Size: Angle = 300.mas
 
+// GNIRS imaging science area (the "keyhole"): a rectangular bar with a circular cap
+// on top. The shape depends on the filter; the bar length also depends on the camera.
+//
+// Order-blocking, narrow-band and H-MK filters see the full keyhole:
+//   bar: no-cross-dispersion slit length (99" short cam / 49" long cam) by 10" tall
+//   cap: 28" wide, rising 10" above the bar (r ~ 15")
+val KeyholeBarHeight:  Angle = 10.arcsec
+val KeyholeCapWidth:   Angle = 28.arcsec
+val KeyholeCapHeight:  Angle = 10.arcsec
+//
+// Y-MK, J-MK and K-MK filters see the smaller, round unvignetted field
+// (camera-independent):
+//   bar: 24" wide by 9" tall
+//   cap: 24" wide, rising 7" above the bar (r ~ 12")
+val RoundFieldWidth:   Angle = 24.arcsec
+val RoundFieldHeight:  Angle = 9.arcsec
+val RoundCapWidth:     Angle = 24.arcsec
+val RoundCapHeight:    Angle = 7.arcsec
+
 object all extends GnirsScienceAreaGeometry

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/syntax/package.scala
@@ -49,3 +49,6 @@ object all extends shapeexpression:
     def toDoubleArcseconds: (BigDecimal, BigDecimal) =
       (Angle.signedDecimalArcseconds.get(o.p.toAngle), Angle.signedDecimalArcseconds.get(o.q.toAngle))
 
+  extension (arcsec: Double)
+    def toArcsecondsAngle: Angle =
+      Angle.fromDoubleArcseconds(arcsec)

--- a/modules/core/shared/src/main/scala/lucuma/core/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Angle.scala
@@ -257,6 +257,13 @@ object Angle extends AngleOptics {
       BigDecimal(toMicroarcseconds) / Angle.µasPerDegree
 
     /**
+    * This angle in decimal arcseconds. Approximate, non-invertible.
+    * @group Conversions
+    */
+    def toSignedDoubleDecimalArcseconds: Double =
+      Angle.signedDecimalArcseconds.get(angle).toDouble
+
+    /**
     * This angle in signed decimal degrees. Approximate, non-invertible
     * @group Conversions
     */

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsAcquisitionMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsAcquisitionMode.scala
@@ -27,10 +27,14 @@ enum GnirsAcquisitionMode(val acquisitionType: GnirsAcquisitionType) derives Eq:
 
 object GnirsAcquisitionMode:
   object Faint {
-    val DefaultSkyOffset: Offset = Offset(0.pArcsec, -2.qArcsec)
+    // The default Faint sky offset for long slit.
+    val DefaultSlitSkyOffset: Offset = Offset(0.pArcsec, -2.qArcsec)
+
+    // The default Faint sky offset for IFU: the sky is imaged 10" west of the target.
+    val DefaultIfuSkyOffset: Offset = Offset(-10.pArcsec, 0.qArcsec)
 
     val Default: GnirsAcquisitionMode.Faint =
-      GnirsAcquisitionMode.Faint(DefaultSkyOffset)
+      GnirsAcquisitionMode.Faint(DefaultSlitSkyOffset)
 
     val skyOffset: Iso[GnirsAcquisitionMode.Faint, Offset] = Focus[GnirsAcquisitionMode.Faint](_.skyOffset)
   }
@@ -51,7 +55,7 @@ object GnirsAcquisitionMode:
     acquisitionType match
       case GnirsAcquisitionType.VeryBright => VeryBright
       case GnirsAcquisitionType.Bright => Bright
-      case GnirsAcquisitionType.Faint => Faint(skyOffset.getOrElse(Faint.DefaultSkyOffset))
+      case GnirsAcquisitionType.Faint => Faint(skyOffset.getOrElse(Faint.DefaultSlitSkyOffset))
 
   // Default value depends on integration time (exposure time * coadds).
   def defaultFor(exposureTime: TimeSpan, coadds: PosInt): GnirsAcquisitionMode =

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -222,7 +222,7 @@ class JtsDemo extends Frame("JTS Demo") {
     50.arcsec
 
   // Pixel width and height
-  val canvasSize: Int = 800
+  val canvasSize: Int = 1000
 
   val hints: Map[RenderingHints.Key, Object] =
     Map(
@@ -508,6 +508,44 @@ trait GnirsShapes extends InstrumentShapes:
     ) ++ scienceArea.shapeAt(posAngle, offsetPos, fpu, camera, prism).toList
 
 object JtsGnirsDemo extends JtsDemo with GnirsShapes:
+  override val arcsecPerPixel: Double = 1.0
+
+trait GnirsImagingShapes extends InstrumentShapes:
+  import lucuma.core.geom.gnirs.*
+  import lucuma.core.geom.pwfs.{patrolField, probeArm}
+  import lucuma.core.enums.GnirsCamera
+  import lucuma.core.enums.GnirsFilter
+  import lucuma.core.enums.GuideProbe
+
+  val posAngle: Angle =
+    15.deg
+
+  val offsetPos: Offset =
+    Offset.Zero
+
+  val guideStarOffset: Offset =
+    Offset(270.arcsec.p, 224.arcsec.q)
+
+  val probe: GuideProbe = GuideProbe.PWFS2
+
+  val camera: GnirsCamera = GnirsCamera.ShortBlue
+
+  // Order4 (H) is a keyhole filter, so this shows the full keyhole science area.
+  // Switch to GnirsFilter.Y/J/K to see the smaller round field.
+  val filter: GnirsFilter = GnirsFilter.Order4
+
+  def shapes: List[ShapeExpression] =
+    List(
+      ShapeExpression.centeredRectangle(1.arcsec, 1.arcsec).translate(guideStarOffset),
+      scienceArea.imagingShapeAt(posAngle, offsetPos, camera, filter),
+      patrolField.patrolFieldAt(posAngle, offsetPos),
+      probeArm.mirrorAt(probe, guideStarOffset, offsetPos),
+      probeArm.mirrorVignettedAreaAt(probe, guideStarOffset, offsetPos),
+      probeArm.armVignettedAreaAt(probe, guideStarOffset, offsetPos),
+      probeArm.armAt(probe, guideStarOffset, offsetPos)
+    )
+
+object JtsGnirsImagingDemo extends JtsDemo with GnirsImagingShapes:
   override val arcsecPerPixel: Double = 1.0
 
 trait MaroonXShapes extends InstrumentShapes:

--- a/modules/tests/shared/src/test/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometrySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometrySuite.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.geom.gnirs
+
+import lucuma.core.enums.GnirsCamera
+import lucuma.core.enums.GnirsFilter
+import lucuma.core.enums.GnirsFpuIfu
+import lucuma.core.geom.jts.interpreter.given
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+
+class GnirsScienceAreaGeometrySuite extends munit.FunSuite:
+
+  private def sides(shape: lucuma.core.geom.ShapeExpression): (Angle, Angle) =
+    val b = shape.eval.boundingOffsets
+    (b.topLeft.p.toAngle.difference(b.bottomRight.p.toAngle),
+     b.topLeft.q.toAngle.difference(b.bottomRight.q.toAngle)
+    )
+
+  // Bounding-box side lengths (p, q) of the imaging science area at PA 0, no offset.
+  private def imagingSides(camera: GnirsCamera, filter: GnirsFilter): (Angle, Angle) =
+    sides(scienceArea.imagingShapeAt(Angle.Angle0, Offset.Zero, camera, filter))
+
+  private def ifuSides(ifu: GnirsFpuIfu): (Angle, Angle) =
+    sides(scienceArea.ifuShapeAt(Angle.Angle0, Offset.Zero, ifu))
+
+  private def assertCloseArcsec(actual: Angle, expectedArcsec: Double): Unit =
+    assertEqualsDouble(actual.toSignedDoubleDegrees * 3600.0, expectedArcsec, 0.01)
+
+  // Order4 (H) is a keyhole filter; the bar runs the full no-XD slit length along q, and
+  // the cap bumps out 10" along p, so the bounding box is (p = 10 + 10) x (q = slit length).
+  test("keyhole imaging bounding box is the full bar for the short camera (20\" x 99\")"):
+    List(GnirsCamera.ShortBlue, GnirsCamera.ShortRed).foreach: camera =>
+      val (p, q) = imagingSides(camera, GnirsFilter.Order4)
+      assertCloseArcsec(p, 20.0)
+      assertCloseArcsec(q, 99.0)
+
+  test("keyhole imaging bounding box is the full bar for the long camera (20\" x 49\")"):
+    List(GnirsCamera.LongBlue, GnirsCamera.LongRed).foreach: camera =>
+      val (p, q) = imagingSides(camera, GnirsFilter.Order4)
+      assertCloseArcsec(p, 20.0)
+      assertCloseArcsec(q, 49.0)
+
+  // Y/J/K-MK filters see the smaller round field: 9" (p) x 24" (q) rectangle plus a 7"
+  // cap along p, camera-independent.
+  test("round imaging bounding box is the MK field (16\" x 24\"), independent of camera"):
+    for
+      filter <- List(GnirsFilter.Y, GnirsFilter.J, GnirsFilter.K)
+      camera <- GnirsCamera.values.toList
+    do
+      val (p, q) = imagingSides(camera, filter)
+      assertCloseArcsec(p, 16.0)
+      assertCloseArcsec(q, 24.0)
+
+  test("LR-IFU science area is the IFU slit width by the low-res height (3.15\" x 4.8\")"):
+    val (w, h) = ifuSides(GnirsFpuIfu.LowResolution)
+    assertCloseArcsec(w, 3.15)
+    assertCloseArcsec(h, 4.8)
+
+  test("HR-IFU science area is the IFU slit width by the high-res height (1.25\" x 1.8\")"):
+    val (w, h) = ifuSides(GnirsFpuIfu.HighResolution)
+    assertCloseArcsec(w, 1.25)
+    assertCloseArcsec(h, 1.8)

--- a/modules/tests/shared/src/test/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometrySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometrySuite.scala
@@ -6,13 +6,14 @@ package lucuma.core.geom.gnirs
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsFpuIfu
+import lucuma.core.geom.ShapeExpression
 import lucuma.core.geom.jts.interpreter.given
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 
 class GnirsScienceAreaGeometrySuite extends munit.FunSuite:
 
-  private def sides(shape: lucuma.core.geom.ShapeExpression): (Angle, Angle) =
+  private def sides(shape: ShapeExpression): (Angle, Angle) =
     val b = shape.eval.boundingOffsets
     (b.topLeft.p.toAngle.difference(b.bottomRight.p.toAngle),
      b.topLeft.q.toAngle.difference(b.bottomRight.q.toAngle)


### PR DESCRIPTION
~For imaging the geometry width is 4.33 arcsecs, which in OCS is the default width for FPUs that don't define an explicit width. This is the case for the acquisition FPU, which is the one GNIRS uses for imaging.~

The actual keyhole geometry is implemented, see comment below.

