### PR TITLE
ProgramTypes and ProgramReferences for Keck and Subaru

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.218"
+ThisBuild / tlBaseVersion                         := "0.219"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ProgramType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ProgramType.scala
@@ -15,10 +15,20 @@ enum ProgramType(val tag: String, val abbreviation: String) derives Enumerated:
   case Commissioning extends ProgramType("commissioning", "COM")
   case Engineering   extends ProgramType("engineering",   "ENG")
   case Example       extends ProgramType("example",       "XPL")
+  case Keck          extends ProgramType("keck",          "KCK")
   case Library       extends ProgramType("library",       "LIB")
   case Monitoring    extends ProgramType("monitoring",    "MON")
   case Science       extends ProgramType("science",       "SCI")
+  case Subaru        extends ProgramType("subaru",        "SUB")
   case System        extends ProgramType("system",        "SYS")
+
+  /**
+   * True for program types that carry a proposal: Gemini science and the Keck
+   * and Subaru time-exchange types.
+   */
+  def hasProposal: Boolean = this match
+    case Science | Keck | Subaru => true
+    case _                       => false
 
 object ProgramType {
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SubaruCallForProposalsType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SubaruCallForProposalsType.scala
@@ -5,6 +5,6 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-enum SubaruCallForProposalsType(val tag: String) derives Enumerated:
-  case Normal    extends SubaruCallForProposalsType("normal")
-  case Intensive extends SubaruCallForProposalsType("intensive")
+enum SubaruCallForProposalsType(val tag: String, val letter: Char) derives Enumerated:
+  case Normal    extends SubaruCallForProposalsType("normal",    'U')
+  case Intensive extends SubaruCallForProposalsType("intensive", 'I')

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/parser/EnumParsers.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/parser/EnumParsers.scala
@@ -31,6 +31,10 @@ trait EnumParsers {
   val scienceSubtype: Parser[ScienceSubtype] =
     enumBy[ScienceSubtype](_.letter.toString)
 
+  /** Parser for `SubaruCallForProposalsType` based on the single reference letter (U/I). */
+  val subaruCallForProposalsType: Parser[SubaruCallForProposalsType] =
+    enumBy[SubaruCallForProposalsType](_.letter.toString)
+
   /** Parser for `Site` based on `shortName` like `GS`. */
   val site: Parser[Site] =
     enumBy[Site](_.shortName).withContext("Site")

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ProgramReference.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ProgramReference.scala
@@ -17,6 +17,7 @@ import io.circe.syntax.*
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ProgramType
 import lucuma.core.enums.ScienceSubtype
+import lucuma.core.enums.SubaruCallForProposalsType
 import lucuma.core.optics.Format
 import monocle.Prism
 
@@ -176,6 +177,42 @@ object ProgramReference {
       Format(s => parse.program.parseAll(s).toOption, _.label)
   }
 
+  case class Keck(proposal: ProposalReference) extends SemesterlyProgramReference {
+    override def programType: ProgramType = ProgramType.Keck
+
+    override def semester: Semester = proposal.semester
+
+    override def label: String =
+      s"${proposal.label}-K"
+  }
+
+  object Keck {
+
+    given Order[Keck] =
+      Order.by(_.proposal)
+
+    val fromString: Format[String, Keck] =
+      Format(s => parse.keck.parseAll(s).toOption, _.label)
+  }
+
+  case class Subaru(proposal: ProposalReference, subaruType: SubaruCallForProposalsType) extends SemesterlyProgramReference {
+    override def programType: ProgramType = ProgramType.Subaru
+
+    override def semester: Semester = proposal.semester
+
+    override def label: String =
+      s"${proposal.label}-${subaruType.letter}"
+  }
+
+  object Subaru {
+
+    given Order[Subaru] =
+      Order.by { a => (a.proposal, a.subaruType) }
+
+    val fromString: Format[String, Subaru] =
+      Format(s => parse.subaru.parseAll(s).toOption, _.label)
+  }
+
   case class System(description: Description) extends ProgramReference {
     override def programType: ProgramType = ProgramType.System
 
@@ -196,6 +233,7 @@ object ProgramReference {
   object parse {
 
     import lucuma.core.enums.parser.EnumParsers.scienceSubtype
+    import lucuma.core.enums.parser.EnumParsers.subaruCallForProposalsType
     import parser.ReferenceParsers.*
     import Semester.parse.semester
 
@@ -233,12 +271,22 @@ object ProgramReference {
         Science(proposal, scienceSubtype)
       }
 
+    val keck: Parser[Keck] =
+      (ProposalReference.parse.proposal <* dash <* char('K')).map(Keck(_))
+
+    val subaru: Parser[Subaru] =
+      ((ProposalReference.parse.proposal <* dash) ~ subaruCallForProposalsType).map { case (proposal, subaruType) =>
+        Subaru(proposal, subaruType)
+      }
+
     val system: Parser[System] =
       (string(s"SYS-") *> description).map { description => System(description) }
 
     val programReference: Parser[ProgramReference] =
       oneOf(
         parse.program.backtrack       ::
+        parse.keck.backtrack          ::
+        parse.subaru.backtrack        ::
         parse.calibration.backtrack   ::
         parse.commissioning.backtrack ::
         parse.engineering.backtrack   ::
@@ -269,9 +317,11 @@ object ProgramReference {
       case (a @ Commissioning(_, _, _), b @ Commissioning(_, _, _)) => Order.compare(a, b)
       case (a @ Engineering(_, _, _),   b @ Engineering(_, _, _))   => Order.compare(a, b)
       case (a @ Example(_),             b @ Example(_))             => Order.compare(a, b)
+      case (a @ Keck(_),                b @ Keck(_))                => Order.compare(a, b)
       case (a @ Library(_, _),          b @ Library(_, _))          => Order.compare(a, b)
       case (a @ Monitoring(_, _, _),    b @ Monitoring(_, _, _))    => Order.compare(a, b)
       case (a @ Science(_, _),          b @ Science(_, _))          => Order.compare(a, b)
+      case (a @ Subaru(_, _),           b @ Subaru(_, _))           => Order.compare(a, b)
       case (a @ System(_),              b @ System(_))              => Order.compare(a, b)
       case (a, b)                                                   => Order.compare(a.programType, b.programType)
     }

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbProgramReference.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbProgramReference.scala
@@ -7,6 +7,7 @@ package arb
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ScienceSubtype
+import lucuma.core.enums.SubaruCallForProposalsType
 import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
@@ -136,6 +137,32 @@ trait ArbProgramReference extends ArbReference {
   val scienceStrings: Gen[String] =
     referenceStrings[Science](_.label)
 
+  given Arbitrary[Keck] =
+    Arbitrary(arbitrary[ProposalReference].map(Keck(_)))
+
+  given Cogen[Keck] =
+    Cogen[ProposalReference].contramap(_.proposal)
+
+  val keckStrings: Gen[String] =
+    referenceStrings[Keck](_.label)
+
+  given Arbitrary[Subaru] =
+    Arbitrary {
+      for {
+        p <- arbitrary[ProposalReference]
+        t <- arbitrary[SubaruCallForProposalsType]
+      } yield Subaru(p, t)
+    }
+
+  given Cogen[Subaru] =
+    Cogen[(ProposalReference, SubaruCallForProposalsType)].contramap { a => (
+      a.proposal,
+      a.subaruType
+    )}
+
+  val subaruStrings: Gen[String] =
+    referenceStrings[Subaru](_.label)
+
   given Arbitrary[ProgramReference] =
     Arbitrary {
       Gen.oneOf[ProgramReference](
@@ -143,9 +170,11 @@ trait ArbProgramReference extends ArbReference {
         arbitrary[Commissioning],
         arbitrary[Engineering],
         arbitrary[Example],
+        arbitrary[Keck],
         arbitrary[Library],
         arbitrary[Monitoring],
         arbitrary[Science],
+        arbitrary[Subaru],
         arbitrary[System]
       )
     }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/ProgramReferenceSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/ProgramReferenceSuite.scala
@@ -19,8 +19,10 @@ final class ProgramReferenceSuite extends munit.DisciplineSuite {
   checkAll("Calibration.fromString", FormatTests(Calibration.fromString).formatWith(calibrationStrings))
   checkAll("Engineering.fromString", FormatTests(Engineering.fromString).formatWith(engineeringStrings))
   checkAll("Example.fromString",     PrismTests(Example.fromString))
+  checkAll("Keck.fromString",        FormatTests(Keck.fromString).formatWith(keckStrings))
   checkAll("Library.fromString",     PrismTests(Library.fromString))
   checkAll("Science.fromString",     FormatTests(Science.fromString).formatWith(scienceStrings))
+  checkAll("Subaru.fromString",      FormatTests(Subaru.fromString).formatWith(subaruStrings))
   checkAll("System.fromString",      PrismTests(System.fromString))
 
   checkAll("ProgramReference",       FormatTests(ProgramReference.fromString).formatWith(programReferenceStrings))


### PR DESCRIPTION
Due to a desire to reserve existing ProgramTypes and ProgramReferences for gemini programs, new instances of each were added for Keck and Subaru.