### PR TITLE
Unify telescope offsets across instruments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.219"
+ThisBuild / tlBaseVersion                         := "0.220"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/SlitOffsetPreset.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/SlitOffsetPreset.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Display
+import lucuma.core.util.Enumerated
+
+/**
+ * Common interface for an instrument's slit offset presets.
+ * Each instrument defines its own enum of presets
+ */
+sealed trait SlitOffsetPreset:
+  def tag: String
+  def description: String
+
+/**
+ * Enumerated type for the Flamingos2 slit offset presets.
+ */
+enum Flamingos2SlitOffsetPreset(
+  val tag:         String,
+  val description: String
+) extends SlitOffsetPreset derives Enumerated, Display:
+  case Telluric     extends Flamingos2SlitOffsetPreset("telluric",       "Telluric")
+  case NodAlongSlit extends Flamingos2SlitOffsetPreset("nod_along_slit", "Nod along slit")
+  case NodToSky     extends Flamingos2SlitOffsetPreset("nod_to_sky",     "Nod to sky")
+
+/**
+ * Enumerated type for the GNIRS slit offset presets.
+ */
+enum GnirsSlitOffsetPreset(
+  val tag:         String,
+  val description: String
+) extends SlitOffsetPreset derives Enumerated, Display:
+  case NodAlongSlit extends GnirsSlitOffsetPreset("nod_along_slit", "Nod along slit")
+  case NodToSky     extends GnirsSlitOffsetPreset("nod_to_sky",     "Nod to sky")
+
+/**
+ * Enumerated type for the IGRINS2 slit offset presets.
+ */
+enum Igrins2SlitOffsetPreset(
+  val tag:         String,
+  val description: String
+) extends SlitOffsetPreset derives Enumerated, Display:
+  case NodAlongSlit extends Igrins2SlitOffsetPreset("nod_along_slit", "Nod along slit")
+  case NodToSky     extends Igrins2SlitOffsetPreset("nod_to_sky",     "Nod to sky")

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/flamingos2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/flamingos2/package.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.flamingos2
+
+import cats.data.NonEmptyList
+import lucuma.core.enums.Flamingos2SlitOffsetPreset
+import lucuma.core.enums.StepGuideState
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.bigDecimal.*
+import lucuma.core.model.SlitTelescopeConfigs
+import lucuma.core.model.sequence.TelescopeConfig
+import lucuma.core.model.sequence.TelescopeConfigAlongSlit
+
+val TelluricDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
+  NonEmptyList.of(
+    TelescopeConfigAlongSlit( 15.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-15.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-15.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit( 15.qArcsec, StepGuideState.Enabled),
+  )
+
+val NodAlongSlitDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
+  NonEmptyList.of(
+    TelescopeConfigAlongSlit( 10.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-10.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-10.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit( 10.qArcsec, StepGuideState.Enabled),
+  )
+
+val NodToSkyDefaultTelescopeConfigs: NonEmptyList[TelescopeConfig] =
+  NonEmptyList.of(
+    TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
+    TelescopeConfig(Offset(0.pArcsec, 300.qArcsec), StepGuideState.Disabled),
+    TelescopeConfig(Offset(0.pArcsec, 310.qArcsec), StepGuideState.Disabled),
+    TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
+  )
+
+def defaultSlitTelescopeConfigs(preset: Flamingos2SlitOffsetPreset): SlitTelescopeConfigs =
+  preset match
+    case Flamingos2SlitOffsetPreset.Telluric     => SlitTelescopeConfigs.AlongSlit(TelluricDefaultTelescopeConfigs)
+    case Flamingos2SlitOffsetPreset.NodAlongSlit => SlitTelescopeConfigs.AlongSlit(NodAlongSlitDefaultTelescopeConfigs)
+    case Flamingos2SlitOffsetPreset.NodToSky     => SlitTelescopeConfigs.ToSky(NodToSkyDefaultTelescopeConfigs)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/package.scala
@@ -8,7 +8,7 @@ import cats.syntax.order.*
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFpuIfu
 import lucuma.core.enums.GnirsPrism
-import lucuma.core.enums.SlitOffsetMode
+import lucuma.core.enums.GnirsSlitOffsetPreset
 import lucuma.core.enums.StepGuideState
 import lucuma.core.math.Offset
 import lucuma.core.math.Wavelength
@@ -41,12 +41,12 @@ val OnSkyDefaultTelescopeConfigs: NonEmptyList[TelescopeConfig] =
     TelescopeConfig(Offset.Zero, StepGuideState.Enabled)
   )
 
-def defaultSlitTelescopeConfigs(mode: SlitOffsetMode, prism: GnirsPrism, camera: GnirsCamera, wavelength: GnirsGratingWavelength): SlitTelescopeConfigs =
-  mode match
-    case SlitOffsetMode.NodAlongSlit => SlitTelescopeConfigs.AlongSlit(alongSlitDefaultTelescopeConfigs(prism, camera, wavelength))
-    case SlitOffsetMode.NodToSky     => SlitTelescopeConfigs.ToSky(OnSkyDefaultTelescopeConfigs)
+def defaultSlitTelescopeConfigs(preset: GnirsSlitOffsetPreset, prism: GnirsPrism, camera: GnirsCamera, wavelength: GnirsGratingWavelength): SlitTelescopeConfigs =
+  preset match
+    case GnirsSlitOffsetPreset.NodAlongSlit => SlitTelescopeConfigs.AlongSlit(alongSlitDefaultTelescopeConfigs(prism, camera, wavelength))
+    case GnirsSlitOffsetPreset.NodToSky     => SlitTelescopeConfigs.ToSky(OnSkyDefaultTelescopeConfigs)
 
-// GNIRS IFU telescope-config presets. Unlike the long-slit defaults these are not 
+// GNIRS IFU telescope-config presets. Unlike the long-slit defaults these are not
 // derived from the optical config; they are fixed templates.
 // The head of each list is the default value, used to initialize observing modes at creation.
 private val LowResolutionIfuPresets: NonEmptyList[(String, NonEmptyList[TelescopeConfig])] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/igrins2/Igrins2StaticConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/igrins2/Igrins2StaticConfig.scala
@@ -5,13 +5,13 @@ package lucuma.core.model.sequence.igrins2
 
 import cats.Eq
 import cats.derived.*
-import lucuma.core.enums.SlitOffsetMode
+import lucuma.core.enums.Igrins2SlitOffsetPreset
 import monocle.Focus
 import monocle.Lens
 
 case class Igrins2StaticConfig(
   saveSVCImages: Igrins2SVCImages,
-  offsetMode:    SlitOffsetMode
+  offsetMode:    Igrins2SlitOffsetPreset
 ) derives Eq
 
 object Igrins2StaticConfig:
@@ -20,5 +20,5 @@ object Igrins2StaticConfig:
     Focus[Igrins2StaticConfig](_.saveSVCImages)
 
   /** @group Optics */
-  val offsetMode: Lens[Igrins2StaticConfig, SlitOffsetMode] =
+  val offsetMode: Lens[Igrins2StaticConfig, Igrins2SlitOffsetPreset] =
     Focus[Igrins2StaticConfig](_.offsetMode)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/igrins2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/igrins2/package.scala
@@ -5,7 +5,7 @@ package lucuma.core.model.sequence.igrins2
 
 import cats.data.NonEmptyList
 import lucuma.core.enums.Igrins2FowlerSamples
-import lucuma.core.enums.SlitOffsetMode
+import lucuma.core.enums.Igrins2SlitOffsetPreset
 import lucuma.core.enums.StepGuideState
 import lucuma.core.math.Offset
 import lucuma.core.math.Wavelength
@@ -59,7 +59,7 @@ val NodToSkyDefaultTelescopeConfigs: NonEmptyList[TelescopeConfig] =
     TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
   )
 
-def defaultSlitTelescopeConfigs(mode: SlitOffsetMode): SlitTelescopeConfigs =
-  mode match
-    case SlitOffsetMode.NodAlongSlit => SlitTelescopeConfigs.AlongSlit(NodAlongSlitDefaultTelescopeConfigs)
-    case SlitOffsetMode.NodToSky     => SlitTelescopeConfigs.ToSky(NodToSkyDefaultTelescopeConfigs)
+def defaultSlitTelescopeConfigs(preset: Igrins2SlitOffsetPreset): SlitTelescopeConfigs =
+  preset match
+    case Igrins2SlitOffsetPreset.NodAlongSlit => SlitTelescopeConfigs.AlongSlit(NodAlongSlitDefaultTelescopeConfigs)
+    case Igrins2SlitOffsetPreset.NodToSky     => SlitTelescopeConfigs.ToSky(NodToSkyDefaultTelescopeConfigs)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/igrins2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/igrins2/package.scala
@@ -3,11 +3,16 @@
 
 package lucuma.core.model.sequence.igrins2
 
+import cats.data.NonEmptyList
 import lucuma.core.enums.Igrins2FowlerSamples
 import lucuma.core.enums.SlitOffsetMode
+import lucuma.core.enums.StepGuideState
 import lucuma.core.math.Offset
 import lucuma.core.math.Wavelength
 import lucuma.core.math.syntax.bigDecimal.*
+import lucuma.core.model.SlitTelescopeConfigs
+import lucuma.core.model.sequence.TelescopeConfig
+import lucuma.core.model.sequence.TelescopeConfigAlongSlit
 import lucuma.core.syntax.timespan.*
 import lucuma.core.util.NewBoolean
 import lucuma.core.util.TimeSpan
@@ -39,24 +44,22 @@ def fowlerSamplesForExposureTime(exposure: TimeSpan): Igrins2FowlerSamples =
     .find(fs => nFowler >= (1 << fs.ordinal))
     .getOrElse(Igrins2FowlerSamples.One)
 
-val NodAlongSlitDefaultOffsets: List[Offset] =
-  List(
-    Offset.Zero.copy(q = -1.25.qArcsec),
-    Offset.Zero.copy(q =  1.25.qArcsec),
-    Offset.Zero.copy(q =  1.25.qArcsec),
-    Offset.Zero.copy(q = -1.25.qArcsec),
+val NodAlongSlitDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
+  NonEmptyList.of(
+    TelescopeConfigAlongSlit(-1.25.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit( 1.25.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit( 1.25.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-1.25.qArcsec, StepGuideState.Enabled),
   )
 
-val DefaultSpatialOffsets: List[Offset] = NodAlongSlitDefaultOffsets
-
-val NodToSkyDefaultOffsets: List[Offset] =
-  List(
-    Offset.Zero,
-    Offset(10.pArcsec, 10.qArcsec),
-    Offset.Zero,
+val NodToSkyDefaultTelescopeConfigs: NonEmptyList[TelescopeConfig] =
+  NonEmptyList.of(
+    TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
+    TelescopeConfig(Offset(10.pArcsec, 10.qArcsec), StepGuideState.Disabled),
+    TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
   )
 
-def defaultOffsetsFor(mode: SlitOffsetMode): List[Offset] =
+def defaultSlitTelescopeConfigs(mode: SlitOffsetMode): SlitTelescopeConfigs =
   mode match
-    case SlitOffsetMode.NodAlongSlit => NodAlongSlitDefaultOffsets
-    case SlitOffsetMode.NodToSky     => NodToSkyDefaultOffsets
+    case SlitOffsetMode.NodAlongSlit => SlitTelescopeConfigs.AlongSlit(NodAlongSlitDefaultTelescopeConfigs)
+    case SlitOffsetMode.NodToSky     => SlitTelescopeConfigs.ToSky(NodToSkyDefaultTelescopeConfigs)

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/igrins2/arb/ArbIgrins2DynamicConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/igrins2/arb/ArbIgrins2DynamicConfig.scala
@@ -3,7 +3,7 @@
 
 package lucuma.core.model.sequence.igrins2.arb
 
-import lucuma.core.enums.SlitOffsetMode
+import lucuma.core.enums.Igrins2SlitOffsetPreset
 import lucuma.core.model.sequence.igrins2.Igrins2DynamicConfig
 import lucuma.core.model.sequence.igrins2.Igrins2SVCImages
 import lucuma.core.model.sequence.igrins2.Igrins2StaticConfig
@@ -31,11 +31,11 @@ trait ArbIgrins2StaticConfig:
     Arbitrary:
       for {
         svc <- arbitrary[Igrins2SVCImages]
-        off <- arbitrary[SlitOffsetMode]
+        off <- arbitrary[Igrins2SlitOffsetPreset]
       } yield Igrins2StaticConfig(svc, off)
 
   given Cogen[Igrins2StaticConfig] =
-    Cogen[(Igrins2SVCImages, SlitOffsetMode)]
+    Cogen[(Igrins2SVCImages, Igrins2SlitOffsetPreset)]
       .contramap(c => (c.saveSVCImages, c.offsetMode))
 
 object ArbIgrins2StaticConfig extends ArbIgrins2StaticConfig

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/flamingos2/Flamingos2ConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/flamingos2/Flamingos2ConfigSuite.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.flamingos2
+
+import cats.data.NonEmptyList
+import lucuma.core.enums.Flamingos2SlitOffsetPreset
+import lucuma.core.enums.SlitOffsetMode
+import lucuma.core.enums.StepGuideState
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.bigDecimal.*
+import lucuma.core.model.sequence.TelescopeConfig
+import munit.*
+
+class Flamingos2ConfigSuite extends FunSuite:
+
+  private def alongSlit(guiding: StepGuideState, qs: BigDecimal*): NonEmptyList[TelescopeConfig] =
+    NonEmptyList.fromListUnsafe(
+      qs.toList.map(q => TelescopeConfig(Offset(0.pArcsec, q.qArcsec), guiding))
+    )
+
+  test("Telluric: along-slit ±15 arcsec, all guided"):
+    val cfg = defaultSlitTelescopeConfigs(Flamingos2SlitOffsetPreset.Telluric)
+    assertEquals(cfg.offsetsType, SlitOffsetMode.NodAlongSlit)
+    assertEquals(cfg.telescopeConfigs, alongSlit(StepGuideState.Enabled, 15, -15, -15, 15))
+
+  test("NodAlongSlit: along-slit ±10 arcsec, all guided"):
+    val cfg = defaultSlitTelescopeConfigs(Flamingos2SlitOffsetPreset.NodAlongSlit)
+    assertEquals(cfg.offsetsType, SlitOffsetMode.NodAlongSlit)
+    assertEquals(cfg.telescopeConfigs, alongSlit(StepGuideState.Enabled, 10, -10, -10, 10))
+
+  test("NodToSky: (0,0),(0,300),(0,310),(0,0), guide off on the sky offsets"):
+    val cfg = defaultSlitTelescopeConfigs(Flamingos2SlitOffsetPreset.NodToSky)
+    assertEquals(cfg.offsetsType, SlitOffsetMode.NodToSky)
+    assertEquals(
+      cfg.telescopeConfigs,
+      NonEmptyList.of(
+        TelescopeConfig(Offset(0.pArcsec,   0.qArcsec), StepGuideState.Enabled),
+        TelescopeConfig(Offset(0.pArcsec, 300.qArcsec), StepGuideState.Disabled),
+        TelescopeConfig(Offset(0.pArcsec, 310.qArcsec), StepGuideState.Disabled),
+        TelescopeConfig(Offset(0.pArcsec,   0.qArcsec), StepGuideState.Enabled)
+      )
+    )

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/igrins2/Igrins2ConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/igrins2/Igrins2ConfigSuite.scala
@@ -3,11 +3,15 @@
 
 package lucuma.core.model.sequence.igrins2
 
+import cats.data.NonEmptyList
 import cats.kernel.laws.discipline.*
 import lucuma.core.enums.Igrins2FowlerSamples
+import lucuma.core.enums.Igrins2SlitOffsetPreset
 import lucuma.core.enums.SlitOffsetMode
 import lucuma.core.enums.StepGuideState
-import lucuma.core.model.SlitTelescopeConfigs
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.bigDecimal.*
+import lucuma.core.model.sequence.TelescopeConfig
 import lucuma.core.model.sequence.igrins2.arb.ArbIgrins2DynamicConfig.given
 import lucuma.core.model.sequence.igrins2.arb.ArbIgrins2StaticConfig.given
 import lucuma.core.syntax.timespan.*
@@ -16,6 +20,11 @@ import munit.*
 class Igrins2ConfigSuite extends DisciplineSuite:
   checkAll("Eq[Igrins2DynamicConfig]", EqTests[Igrins2DynamicConfig].eqv)
   checkAll("Eq[Igrins2StaticConfig]", EqTests[Igrins2StaticConfig].eqv)
+
+  private def alongSlit(guiding: StepGuideState, qs: BigDecimal*): NonEmptyList[TelescopeConfig] =
+    NonEmptyList.fromListUnsafe(
+      qs.toList.map(q => TelescopeConfig(Offset(0.pArcsec, q.qArcsec), guiding))
+    )
 
   test("fowlerSamples from exposure time"):
     assertEquals(Igrins2DynamicConfig(1000.msTimeSpan).fowlerSamples, Igrins2FowlerSamples.One)
@@ -26,17 +35,18 @@ class Igrins2ConfigSuite extends DisciplineSuite:
     assertEquals(Igrins2DynamicConfig(120.secTimeSpan).fowlerSamples, Igrins2FowlerSamples.Sixteen)
 
   test("defaultSlitTelescopeConfigs for NodAlongSlit"):
-    assertEquals(
-      defaultSlitTelescopeConfigs(SlitOffsetMode.NodAlongSlit),
-      SlitTelescopeConfigs.AlongSlit(NodAlongSlitDefaultTelescopeConfigs)
-    )
-    assert(NodAlongSlitDefaultTelescopeConfigs.forall(_.guiding == StepGuideState.Enabled))
+    val cfg = defaultSlitTelescopeConfigs(Igrins2SlitOffsetPreset.NodAlongSlit)
+    assertEquals(cfg.offsetsType, SlitOffsetMode.NodAlongSlit)
+    assertEquals(cfg.telescopeConfigs, alongSlit(StepGuideState.Enabled, -1.25, 1.25, 1.25, -1.25))
 
   test("defaultSlitTelescopeConfigs for NodToSky"):
+    val cfg = defaultSlitTelescopeConfigs(Igrins2SlitOffsetPreset.NodToSky)
+    assertEquals(cfg.offsetsType, SlitOffsetMode.NodToSky)
     assertEquals(
-      defaultSlitTelescopeConfigs(SlitOffsetMode.NodToSky),
-      SlitTelescopeConfigs.ToSky(NodToSkyDefaultTelescopeConfigs)
-    )
-    assertEquals(NodToSkyDefaultTelescopeConfigs.toList.map(_.guiding),
-      List(StepGuideState.Enabled, StepGuideState.Disabled, StepGuideState.Enabled)
+      cfg.telescopeConfigs,
+      NonEmptyList.of(
+        TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
+        TelescopeConfig(Offset(10.pArcsec, 10.qArcsec), StepGuideState.Disabled),
+        TelescopeConfig(Offset.Zero, StepGuideState.Enabled)
+      )
     )

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/igrins2/Igrins2ConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/igrins2/Igrins2ConfigSuite.scala
@@ -5,6 +5,9 @@ package lucuma.core.model.sequence.igrins2
 
 import cats.kernel.laws.discipline.*
 import lucuma.core.enums.Igrins2FowlerSamples
+import lucuma.core.enums.SlitOffsetMode
+import lucuma.core.enums.StepGuideState
+import lucuma.core.model.SlitTelescopeConfigs
 import lucuma.core.model.sequence.igrins2.arb.ArbIgrins2DynamicConfig.given
 import lucuma.core.model.sequence.igrins2.arb.ArbIgrins2StaticConfig.given
 import lucuma.core.syntax.timespan.*
@@ -21,3 +24,19 @@ class Igrins2ConfigSuite extends DisciplineSuite:
     assertEquals(Igrins2DynamicConfig(15.secTimeSpan).fowlerSamples, Igrins2FowlerSamples.Eight)
     assertEquals(Igrins2DynamicConfig(30.secTimeSpan).fowlerSamples, Igrins2FowlerSamples.Sixteen)
     assertEquals(Igrins2DynamicConfig(120.secTimeSpan).fowlerSamples, Igrins2FowlerSamples.Sixteen)
+
+  test("defaultSlitTelescopeConfigs for NodAlongSlit"):
+    assertEquals(
+      defaultSlitTelescopeConfigs(SlitOffsetMode.NodAlongSlit),
+      SlitTelescopeConfigs.AlongSlit(NodAlongSlitDefaultTelescopeConfigs)
+    )
+    assert(NodAlongSlitDefaultTelescopeConfigs.forall(_.guiding == StepGuideState.Enabled))
+
+  test("defaultSlitTelescopeConfigs for NodToSky"):
+    assertEquals(
+      defaultSlitTelescopeConfigs(SlitOffsetMode.NodToSky),
+      SlitTelescopeConfigs.ToSky(NodToSkyDefaultTelescopeConfigs)
+    )
+    assertEquals(NodToSkyDefaultTelescopeConfigs.toList.map(_.guiding),
+      List(StepGuideState.Enabled, StepGuideState.Disabled, StepGuideState.Enabled)
+    )


### PR DESCRIPTION
Generalizes how longslit telescope-offset presets are modeled so instruments can declare different preset sets, and adds Flamingos2 longslit support. Also brings IGRINS2 onto the same SlitTelescopeConfigs architecture as GNIRS.