### PR TITLE
Flip the orientation of gnirs imaging cap to match ocs

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gnirs/GnirsScienceAreaGeometry.scala
@@ -49,7 +49,7 @@ trait GnirsScienceAreaGeometry:
   private def offP(pArcsec: Double): Offset =
     Offset.signedMicroarcseconds.reverseGet(((pArcsec * 1e6).round, 0L))
 
-  // A circular cap (segment) protruding toward +p from the +p edge of a bar of the
+  // A circular cap (segment) protruding toward -p from the -p edge of a bar of the
   // given p-width (centered on the origin). `capWidth` is the cap's extent along q, and
   // `capHeight` its protrusion along p; the radius is implied by the two (the standard
   // chord/sagitta relation for a circular segment). The long field axis runs along q
@@ -58,10 +58,10 @@ trait GnirsScienceAreaGeometry:
   private def cap(capWidth: Angle, capHeight: Angle, barWidth: Angle): ShapeExpression =
     val w       = capWidth.toSignedDoubleDecimalArcseconds
     val h       = capHeight.toSignedDoubleDecimalArcseconds
-    val baseP   = barWidth.toSignedDoubleDecimalArcseconds / 2 // cap springs from the +p edge of the bar
+    val baseP   = barWidth.toSignedDoubleDecimalArcseconds / 2 // cap springs from the -p edge of the bar
     val r       = (h * h + (w / 2) * (w / 2)) / (2 * h) // circle radius from chord (w) & sagitta (h)
-    val circle  = ShapeExpression.centeredEllipse((2 * r).toArcsecondsAngle, (2 * r).toArcsecondsAngle) ↗ offP(baseP - (r - h))
-    val clip    = ShapeExpression.centeredRectangle((2 * h + 2).toArcsecondsAngle, (w + 2).toArcsecondsAngle) ↗ offP(baseP + h + 1)
+    val circle  = ShapeExpression.centeredEllipse((2 * r).toArcsecondsAngle, (2 * r).toArcsecondsAngle) ↗ offP(-(baseP - (r - h)))
+    val clip    = ShapeExpression.centeredRectangle((2 * h + 2).toArcsecondsAngle, (w + 2).toArcsecondsAngle) ↗ offP(-(baseP + h + 1))
     circle ∩ clip
 
   // GNIRS imaging science area ("keyhole"): the 99"/49" no-XD field along q (camera-


### PR DESCRIPTION
<img width="2224" height="2224" alt="image" src="https://github.com/user-attachments/assets/c56da6fe-eb8c-43ce-b977-3db8fcd34bcc" />
