### PR TITLE
Support pending masks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.223"
+ThisBuild / tlBaseVersion                         := "0.224"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/MaskDefinition.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/MaskDefinition.scala
@@ -5,6 +5,9 @@ package lucuma.core.model
 
 import cats.Eq
 import cats.derived.*
+import monocle.Iso
+import monocle.Prism
+import monocle.macros.GenPrism
 
 /**
  * Observations with a mask to be defined are valid.
@@ -14,3 +17,14 @@ sealed trait MaskDefinition derives Eq
 
 case object ToBeDefined extends MaskDefinition derives Eq
 case class Defined(id: Attachment.Id) extends MaskDefinition derives Eq
+
+object Defined:
+  def id: Iso[Defined, Attachment.Id] =
+    Iso[Defined, Attachment.Id](_.id)(Defined(_))
+
+object MaskDefinition:
+  val toBeDefined: Prism[MaskDefinition, ToBeDefined.type] =
+    GenPrism[MaskDefinition, ToBeDefined.type]
+
+  val defined: Prism[MaskDefinition, Defined] =
+    GenPrism[MaskDefinition, Defined]

--- a/modules/core/shared/src/main/scala/lucuma/core/model/MaskDefinition.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/MaskDefinition.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Eq
+import cats.derived.*
+
+/**
+ * Observations with a mask to be defined are valid.
+ * We'll represent that state with the ADT below
+ */
+sealed trait MaskDefinition derives Eq
+
+case object ToBeDefined extends MaskDefinition derives Eq
+case class Defined(id: Attachment.Id) extends MaskDefinition derives Eq

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/flamingos2/Flamingos2FpuMask.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/flamingos2/Flamingos2FpuMask.scala
@@ -5,11 +5,10 @@ package lucuma.core.model.sequence.flamingos2
 
 import cats.Eq
 import cats.syntax.all.*
-import eu.timepit.refined.cats.*
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.Flamingos2CustomSlitWidth
 import lucuma.core.enums.Flamingos2Decker
 import lucuma.core.enums.Flamingos2Fpu
+import lucuma.core.model.MaskDefinition
 import monocle.Focus
 import monocle.Iso
 import monocle.Lens
@@ -41,8 +40,8 @@ sealed trait Flamingos2FpuMask:
   def custom: Option[Custom] =
     fold(none, _ => none, _.some)
 
-  def customFilename: Option[NonEmptyString] =
-    custom.map(_.filename)
+  def customMaskDefinition: Option[MaskDefinition] =
+    custom.map(_.mask)
 
   def customSlitWidth: Option[Flamingos2CustomSlitWidth] =
     custom.map(_.slitWidth)
@@ -72,14 +71,14 @@ object Flamingos2FpuMask:
     def value: Iso[Builtin, Flamingos2Fpu] =
       Iso[Builtin, Flamingos2Fpu](_.value)(Builtin.apply)
 
-  case class Custom(filename: NonEmptyString, slitWidth: Flamingos2CustomSlitWidth) extends Flamingos2FpuMask
+  case class Custom(mask: MaskDefinition, slitWidth: Flamingos2CustomSlitWidth) extends Flamingos2FpuMask
 
   object Custom:
-    given Eq[Custom] = Eq.by(x => (x.filename, x.slitWidth))
+    given Eq[Custom] = Eq.by(x => (x.mask, x.slitWidth))
 
     /** @group Optics */
-    val filename: Lens[Custom, NonEmptyString] =
-      Focus[Custom](_.filename)
+    val maskDefinition: Lens[Custom, MaskDefinition] =
+      Focus[Custom](_.mask)
 
     /** @group Optics */
     val customSlitWidth: Lens[Custom, Flamingos2CustomSlitWidth] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/GmosFpuMask.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/GmosFpuMask.scala
@@ -5,9 +5,8 @@ package lucuma.core.model.sequence.gmos
 
 import cats.Eq
 import cats.syntax.all.*
-import eu.timepit.refined.cats.*
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.GmosCustomSlitWidth
+import lucuma.core.model.MaskDefinition
 import monocle.Focus
 import monocle.Iso
 import monocle.Lens
@@ -37,8 +36,8 @@ sealed trait GmosFpuMask[+T] {
   def custom: Option[Custom] =
     fold(_ => none, _.some)
 
-  def customFilename: Option[NonEmptyString] =
-    custom.map(_.filename)
+  def customMaskDefinition: Option[MaskDefinition] =
+    custom.map(_.mask)
 
   def customSlitWidth: Option[GmosCustomSlitWidth] =
     custom.map(_.slitWidth)
@@ -58,14 +57,14 @@ object GmosFpuMask {
       Iso[Builtin[T], T](_.value)(Builtin.apply)
   }
 
-  final case class Custom(filename: NonEmptyString, slitWidth: GmosCustomSlitWidth) extends GmosFpuMask[Nothing]
+  final case class Custom(mask: MaskDefinition, slitWidth: GmosCustomSlitWidth) extends GmosFpuMask[Nothing]
 
   object Custom {
-    given Eq[Custom] = Eq.by(x => (x.filename, x.slitWidth))
+    given Eq[Custom] = Eq.by(x => (x.mask, x.slitWidth))
 
     /** @group Optics */
-    val filename: Lens[Custom, NonEmptyString] =
-      Focus[Custom](_.filename)
+    val maskDefinition: Lens[Custom, MaskDefinition] =
+      Focus[Custom](_.mask)
 
     /** @group Optics */
     val slitWidth: Lens[Custom, GmosCustomSlitWidth] =

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbMaskDefinition.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbMaskDefinition.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+package arb
+
+import cats.syntax.all.*
+import lucuma.core.util.arb.ArbGid
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbMaskDefinition {
+  import ArbGid.given
+
+  given Arbitrary[MaskDefinition] =
+    Arbitrary(
+      Gen.oneOf(
+        Gen.const(ToBeDefined),
+        arbitrary[Attachment.Id].map(Defined(_))
+      )
+    )
+
+  given Cogen[MaskDefinition] =
+    Cogen[Option[Attachment.Id]].contramap {
+      case ToBeDefined  => none
+      case Defined(id)  => id.some
+    }
+}
+
+object ArbMaskDefinition extends ArbMaskDefinition

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/f2/arb/ArbFlamingos2FpuMask.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/f2/arb/ArbFlamingos2FpuMask.scala
@@ -4,9 +4,9 @@
 package lucuma.core.model.sequence.flamingos2.arb
 
 import cats.syntax.all.*
-import eu.timepit.refined.scalacheck.string.given
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.*
+import lucuma.core.model.MaskDefinition
+import lucuma.core.model.arb.ArbMaskDefinition.given
 import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
 import lucuma.core.util.Enumerated
 import lucuma.core.util.arb.ArbEnumerated.given
@@ -23,18 +23,18 @@ trait ArbFlamingos2FpuMask:
         Flamingos2FpuMask.Imaging,
         Gen.oneOf(Enumerated[Flamingos2Fpu].all).map(Flamingos2FpuMask.Builtin(_)),
         for
-          f <- arbitrary[NonEmptyString]
+          m <- arbitrary[MaskDefinition]
           s <- arbitrary[Flamingos2CustomSlitWidth]
-        yield Flamingos2FpuMask.Custom(f, s)
+        yield Flamingos2FpuMask.Custom(m, s)
       )
     )
 
   given Cogen[Flamingos2FpuMask] =
-    Cogen[Option[Either[Flamingos2Fpu, (String, Flamingos2CustomSlitWidth)]]]
+    Cogen[Option[Either[Flamingos2Fpu, (MaskDefinition, Flamingos2CustomSlitWidth)]]]
       .contramap {
         case Flamingos2FpuMask.Imaging => none
         case Flamingos2FpuMask.Builtin(b) => b.asLeft.some
-        case Flamingos2FpuMask.Custom(f, s) => (f.value, s).asRight.some
+        case Flamingos2FpuMask.Custom(m, s) => (m, s).asRight.some
       }
 
 object ArbFlamingos2FpuMask extends ArbFlamingos2FpuMask

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/gmos/arb/ArbGmosFpuMask.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/gmos/arb/ArbGmosFpuMask.scala
@@ -5,17 +5,16 @@ package lucuma.core.model.sequence.gmos
 package arb
 
 import cats.syntax.all.*
-import eu.timepit.refined.scalacheck.string.*
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.GmosCustomSlitWidth
-import lucuma.core.math.arb.ArbRefined
+import lucuma.core.model.MaskDefinition
+import lucuma.core.model.arb.ArbMaskDefinition
 import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 
 trait ArbGmosFpuMask {
   import ArbEnumerated.given
-  import ArbRefined.given
+  import ArbMaskDefinition.given
 
   given arbGmosBuiltinFpuMask[T: Arbitrary]: Arbitrary[GmosFpuMask.Builtin[T]] =
     Arbitrary(arbitrary[T].map(GmosFpuMask.Builtin.apply))
@@ -23,9 +22,9 @@ trait ArbGmosFpuMask {
   given Arbitrary[GmosFpuMask.Custom] =
     Arbitrary(
       for {
-        filename  <- arbitrary[NonEmptyString]
+        mask      <- arbitrary[MaskDefinition]
         slitWidth <- arbitrary[GmosCustomSlitWidth]
-      } yield GmosFpuMask.Custom(filename, slitWidth)
+      } yield GmosFpuMask.Custom(mask, slitWidth)
     )
 
   given arbGmosFpuMask[T: Arbitrary]: Arbitrary[GmosFpuMask[T]] =
@@ -40,7 +39,7 @@ trait ArbGmosFpuMask {
     Cogen[T].contramap(_.value)
 
   given Cogen[GmosFpuMask.Custom] =
-    Cogen[(NonEmptyString, GmosCustomSlitWidth)].contramap(m => (m.filename, m.slitWidth))
+    Cogen[(MaskDefinition, GmosCustomSlitWidth)].contramap(m => (m.mask, m.slitWidth))
 
   given cogGmosFpuMask[T: Cogen]: Cogen[GmosFpuMask[T]] =
     Cogen[Either[GmosFpuMask.Builtin[T], GmosFpuMask.Custom]]

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/GmosFpuMaskSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/gmos/GmosFpuMaskSuite.scala
@@ -4,13 +4,11 @@
 package lucuma.core.model.sequence.gmos
 
 import cats.kernel.laws.discipline.*
-import eu.timepit.refined.cats.*
-import eu.timepit.refined.scalacheck.string.*
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.GmosCustomSlitWidth
 import lucuma.core.enums.GmosNorthGrating
 import lucuma.core.enums.GmosSouthGrating
-import lucuma.core.math.arb.*
+import lucuma.core.model.ToBeDefined
+import lucuma.core.model.arb.ArbMaskDefinition
 import lucuma.core.model.sequence.gmos.arb.*
 import lucuma.core.util.arb.*
 import monocle.law.discipline.*
@@ -19,7 +17,7 @@ import munit.*
 final class GmosFpuMaskSuite extends DisciplineSuite {
   import ArbEnumerated.given
   import ArbGmosFpuMask.given
-  import ArbRefined.given
+  import ArbMaskDefinition.given
 
   checkAll(
     "Eq[GmosFpuMask.Builtin[GmosNorthGrating]]",
@@ -39,7 +37,7 @@ final class GmosFpuMaskSuite extends DisciplineSuite {
   )
 
   checkAll("Eq[GmosFpuMask.Custom", EqTests[GmosFpuMask.Custom].eqv)
-  checkAll("GmosFpuMask.Custom.filename", LensTests(GmosFpuMask.Custom.filename))
+  checkAll("GmosFpuMask.Custom.maskDefinition", LensTests(GmosFpuMask.Custom.maskDefinition))
   checkAll("GmosFpuMask.Custom.slitWidth", LensTests(GmosFpuMask.Custom.slitWidth))
 
   checkAll("Eq[GmosFpuMask[GmosNorthGrating]]", EqTests[GmosFpuMask[GmosNorthGrating]].eqv)
@@ -57,7 +55,7 @@ final class GmosFpuMaskSuite extends DisciplineSuite {
     val b: GmosFpuMask[Int] = GmosFpuMask.Builtin(1)
     assertEquals(b.fold(_ => "builtin", _ => "custom"), "builtin")
 
-    val c: GmosFpuMask[Int] = GmosFpuMask.Custom(NonEmptyString.unsafeFrom("foo"), GmosCustomSlitWidth.CustomWidth_0_25)
+    val c: GmosFpuMask[Int] = GmosFpuMask.Custom(ToBeDefined, GmosCustomSlitWidth.CustomWidth_0_25)
     assertEquals(c.fold(_ => "builtin", _ => "custom"), "custom")
   }
 }


### PR DESCRIPTION
for MOS we may actually define the mask in phase2 but before that it is valid to have a MOS observation that doesn't have a fully defined mask id yet.

This PR models that adding an option for a `ToBeDefined `mask without a name