### PR TITLE
Make GnirsDisperserOrder constructible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.229"
+ThisBuild / tlBaseVersion                         := "0.230"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsDisperserOrder.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsDisperserOrder.scala
@@ -5,12 +5,23 @@ package lucuma
 package core
 package enums
 import lucuma.core.math.Wavelength
+import lucuma.core.math.WavelengthDelta
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
 
 /**
  * Enumerated type for GNIRS Disperser Order.
+ *
+ * `deltaWavelength` is the wavelength covered by one pixel with the 32 l/mm disperser at
+ * the 0.15"/pix pixel scale; the other combinations are derived from it (111 l/mm divides
+ * by 3.49, 10 l/mm multiplies by 3, and the 0.05"/pix scale divides by 3).  It is `None`
+ * for the two orders where it is undefined, which are also the two that cannot be
+ * cross-dispersed.
+ *
+ * Note that order 4 appears twice: `FourXD` is the cross-dispersed variant, and both have
+ * a `count` of 4.
+ *
  * @group Enumerations
  */
 enum GnirsDisperserOrder(
@@ -21,17 +32,16 @@ enum GnirsDisperserOrder(
   val defaultWavelength: Wavelength,
   val minWavelength:     Wavelength,
   val maxWavelength:     Wavelength,
-  val deltaWavelength:   Wavelength,
+  val deltaWavelength:   Option[WavelengthDelta],
   val band:              Option[Band],
   val crossDispersed:    Boolean
 ) derives Enumerated, Display:
-  case One extends GnirsDisperserOrder("One", "1", "One", 1, Wavelength.unsafeFromIntPicometers(4850000), Wavelength.unsafeFromIntPicometers(4300000), Wavelength.unsafeFromIntPicometers(6000000), Wavelength.unsafeFromIntPicometers(0), Some(Band.M), false)
-  case Two extends GnirsDisperserOrder("Two", "2", "Two", 2, Wavelength.unsafeFromIntPicometers(3400000), Wavelength.unsafeFromIntPicometers(2700000), Wavelength.unsafeFromIntPicometers(4300000), Wavelength.unsafeFromIntPicometers(0), Some(Band.L), false)
-  case Three extends GnirsDisperserOrder("Three", "3", "Three", 3, Wavelength.unsafeFromIntPicometers(2220000), Wavelength.unsafeFromIntPicometers(1860000), Wavelength.unsafeFromIntPicometers(2700000), Wavelength.unsafeFromIntPicometers(647), Some(Band.K), true)
-  case FourXD extends GnirsDisperserOrder("FourXD", "4XD", "FourXD", 4, Wavelength.unsafeFromIntPicometers(1650000), Wavelength.unsafeFromIntPicometers(1420000), Wavelength.unsafeFromIntPicometers(1860000), Wavelength.unsafeFromIntPicometers(482), Some(Band.H), true)
-  case Four extends GnirsDisperserOrder("Four", "4", "Four", 4, Wavelength.unsafeFromIntPicometers(1630000), Wavelength.unsafeFromIntPicometers(1420000), Wavelength.unsafeFromIntPicometers(1860000), Wavelength.unsafeFromIntPicometers(485), Some(Band.H), true)
-  case Five extends GnirsDisperserOrder("Five", "5", "Five", 5, Wavelength.unsafeFromIntPicometers(1250000), Wavelength.unsafeFromIntPicometers(1170000), Wavelength.unsafeFromIntPicometers(1420000), Wavelength.unsafeFromIntPicometers(388), Some(Band.J), true)
-  case Six extends GnirsDisperserOrder("Six", "6", "Six", 6, Wavelength.unsafeFromIntPicometers(1100000), Wavelength.unsafeFromIntPicometers(1030000), Wavelength.unsafeFromIntPicometers(1170000), Wavelength.unsafeFromIntPicometers(323), None, true)
-  case Seven extends GnirsDisperserOrder("Seven", "7", "Seven", 7, Wavelength.unsafeFromIntPicometers(951000), Wavelength.unsafeFromIntPicometers(880000), Wavelength.unsafeFromIntPicometers(1030000), Wavelength.unsafeFromIntPicometers(276), None, true)
-  case Eight extends GnirsDisperserOrder("Eight", "8", "Eight", 8, Wavelength.unsafeFromIntPicometers(832000), Wavelength.unsafeFromIntPicometers(780000), Wavelength.unsafeFromIntPicometers(880000), Wavelength.unsafeFromIntPicometers(241), None, true)
-  
+  case One extends GnirsDisperserOrder("One", "1", "One", 1, Wavelength.unsafeFromIntPicometers(4850000), Wavelength.unsafeFromIntPicometers(4300000), Wavelength.unsafeFromIntPicometers(6000000), None, Some(Band.M), false)
+  case Two extends GnirsDisperserOrder("Two", "2", "Two", 2, Wavelength.unsafeFromIntPicometers(3400000), Wavelength.unsafeFromIntPicometers(2700000), Wavelength.unsafeFromIntPicometers(4300000), None, Some(Band.L), false)
+  case Three extends GnirsDisperserOrder("Three", "3", "Three", 3, Wavelength.unsafeFromIntPicometers(2220000), Wavelength.unsafeFromIntPicometers(1860000), Wavelength.unsafeFromIntPicometers(2700000), Some(WavelengthDelta.unsafeFromIntPicometers(647)), Some(Band.K), true)
+  case FourXD extends GnirsDisperserOrder("FourXD", "4XD", "FourXD", 4, Wavelength.unsafeFromIntPicometers(1650000), Wavelength.unsafeFromIntPicometers(1420000), Wavelength.unsafeFromIntPicometers(1860000), Some(WavelengthDelta.unsafeFromIntPicometers(482)), Some(Band.H), true)
+  case Four extends GnirsDisperserOrder("Four", "4", "Four", 4, Wavelength.unsafeFromIntPicometers(1630000), Wavelength.unsafeFromIntPicometers(1420000), Wavelength.unsafeFromIntPicometers(1860000), Some(WavelengthDelta.unsafeFromIntPicometers(485)), Some(Band.H), true)
+  case Five extends GnirsDisperserOrder("Five", "5", "Five", 5, Wavelength.unsafeFromIntPicometers(1250000), Wavelength.unsafeFromIntPicometers(1170000), Wavelength.unsafeFromIntPicometers(1420000), Some(WavelengthDelta.unsafeFromIntPicometers(388)), Some(Band.J), true)
+  case Six extends GnirsDisperserOrder("Six", "6", "Six", 6, Wavelength.unsafeFromIntPicometers(1100000), Wavelength.unsafeFromIntPicometers(1030000), Wavelength.unsafeFromIntPicometers(1170000), Some(WavelengthDelta.unsafeFromIntPicometers(323)), None, true)
+  case Seven extends GnirsDisperserOrder("Seven", "7", "Seven", 7, Wavelength.unsafeFromIntPicometers(951000), Wavelength.unsafeFromIntPicometers(880000), Wavelength.unsafeFromIntPicometers(1030000), Some(WavelengthDelta.unsafeFromIntPicometers(276)), None, true)
+  case Eight extends GnirsDisperserOrder("Eight", "8", "Eight", 8, Wavelength.unsafeFromIntPicometers(832000), Wavelength.unsafeFromIntPicometers(780000), Wavelength.unsafeFromIntPicometers(880000), Some(WavelengthDelta.unsafeFromIntPicometers(241)), None, true)

--- a/modules/tests/shared/src/test/scala/lucuma/core/enums/GnirsDisperserOrderSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enums/GnirsDisperserOrderSuite.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import cats.syntax.all.*
+import lucuma.core.util.Enumerated
+import munit.DisciplineSuite
+
+final class GnirsDisperserOrderSuite extends DisciplineSuite {
+
+  // Every value used to throw on construction: orders One and Two built a Wavelength from
+  // zero for their (undefined) delta wavelength, so merely touching the enum failed.
+  test("every value is constructible") {
+    assertEquals(Enumerated[GnirsDisperserOrder].all.size, 9)
+    Enumerated[GnirsDisperserOrder].all.foreach: o =>
+      assert(o.count >= 1 && o.count <= 8, s"unexpected order count for ${o.tag}")
+      assert(o.minWavelength < o.maxWavelength, s"empty range for ${o.tag}")
+  }
+
+  test("the delta wavelength is defined exactly for the cross-dispersed orders") {
+    Enumerated[GnirsDisperserOrder].all.foreach: o =>
+      assertEquals(o.deltaWavelength.isDefined, o.crossDispersed, s"delta/XD mismatch for ${o.tag}")
+    assertEquals(GnirsDisperserOrder.One.deltaWavelength, None)
+    assertEquals(GnirsDisperserOrder.Two.deltaWavelength, None)
+    assertEquals(
+      GnirsDisperserOrder.Three.deltaWavelength.map(_.toPicometers.value.value),
+      Some(647)
+    )
+  }
+
+  test("order 4 appears twice, cross-dispersed and not") {
+    val fours = Enumerated[GnirsDisperserOrder].all.filter(_.count == 4)
+    assertEquals(fours.map(_.tag), List("FourXD", "Four"))
+  }
+
+}


### PR DESCRIPTION
Orders One and Two passed zero as their delta wavelength, and Wavelength
requires a positive value, so every value of the enum threw on construction:
even touching one failed with "Cannot build a Wavelength with value 0". That
is why the enum had no callers.

The delta wavelength is a per-pixel span, so it is now an
Option[WavelengthDelta], None for the two orders where it is undefined —
which are also the two that cannot be cross-dispersed.

Note that this Enum was unused. It will be used in explore in an upcoming PR.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>