### PR TITLE
Always find a GNIRS acquisition filter, and acquire on the blue camera

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.231"
+ThisBuild / tlBaseVersion                         := "0.232"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsCamera.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsCamera.scala
@@ -21,3 +21,18 @@ enum GnirsCamera(
   case LongRed extends GnirsCamera("LongRed", "LR", "Long Red", GnirsPixelScale.PixelScale_0_05)
   case ShortBlue extends GnirsCamera("ShortBlue", "SB", "Short Blue", GnirsPixelScale.PixelScale_0_15)
   case ShortRed extends GnirsCamera("ShortRed", "SR", "Short Red", GnirsPixelScale.PixelScale_0_15)
+
+  // The blue and red cameras come in pairs sharing a pixel scale, and short and long are
+  // never mixed within an observation, so changing colour always keeps the pixel scale.
+
+  /** The blue camera with this camera's pixel scale; itself, when already blue. */
+  def blue: GnirsCamera =
+    pixelScale match
+      case GnirsPixelScale.PixelScale_0_05 => GnirsCamera.LongBlue
+      case GnirsPixelScale.PixelScale_0_15 => GnirsCamera.ShortBlue
+
+  /** The red camera with this camera's pixel scale; itself, when already red. */
+  def red: GnirsCamera =
+    pixelScale match
+      case GnirsPixelScale.PixelScale_0_05 => GnirsCamera.LongRed
+      case GnirsPixelScale.PixelScale_0_15 => GnirsCamera.ShortRed

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
@@ -61,18 +61,63 @@ object GnirsFilter:
   val SpectroscopyScienceFilters: NonEmptyList[GnirsFilter] =
     NonEmptyList.of(Order6, Order5, Order4, Order3, Order2, Order1)
 
+  /** Every filter that may be used for a spectroscopic acquisition, explicitly or automatically. */
   // Declaration order matters for range match. Since H2 is completely contained in Order3, it needs to come before or it will never be selected.
   val AcquisitionFilters: NonEmptyList[GnirsFilter] =
     NonEmptyList.of(Order6, Order5, Order4, H2, Order3, PAH)
 
-  private def forWavelength(lookupList: NonEmptyList[GnirsFilter])(wavelength: Wavelength): Either[String, GnirsFilter] =
-    lookupList.find(_.spectroscopyRange.exists(_.contains(wavelength)))
-      .toRight(s"No Gnirs spectroscopy filter available for wavelength: $wavelength")
+  /**
+   * The filters that automatic acquisition selection may produce by wavelength coverage.
+   * PAH is excluded: thermal-IR science is acquired on the blue camera, where a 3.3µm filter
+   * does not belong, and above `ThermalAcquisitionCutoff` `ThermalAcquisitionFilter` is used
+   * instead of a coverage match.  It remains available as an explicit choice.
+   */
+  // Declaration order matters here too (see AcquisitionFilters).
+  val AutoAcquisitionFilters: NonEmptyList[GnirsFilter] =
+    NonEmptyList.of(Order6, Order5, Order4, H2, Order3)
+
+  /** The broadband subset of the automatic filters, used when no range contains the wavelength. */
+  private val BroadbandAutoAcquisitionFilters: NonEmptyList[GnirsFilter] =
+    NonEmptyList.of(Order6, Order5, Order4, Order3)
+
+  /** The blue/red boundary: science above this wavelength is a thermal-IR observation. */
+  val ThermalAcquisitionCutoff: Wavelength =
+    Wavelength.unsafeFromIntPicometers(2_500_000)
+
+  /**
+   * The automatic acquisition filter for thermal-IR science (L and M), where no acquisition
+   * filter covers the science wavelength.  The broad L and M filters cannot be used: they
+   * saturate on the sky background.
+   *
+   * Per the GNIRS instrument scientists, red-camera science is acquired with the blue camera
+   * (`GnirsCamera.blue`) in H, or in H2 when the target is very bright — and that second case
+   * is just the ordinary brightness rule, so only the Bright/Faint choice is fixed here.  The
+   * legacy OCS did the same: its templates imaged the slit in H and the field in H or H2 in
+   * every band.
+   */
+  val ThermalAcquisitionFilter: GnirsFilter =
+    Order4
 
   def fromSpectroscopyScienceWavelength(wavelength: Wavelength): Either[String, GnirsFilter] =
-    forWavelength(SpectroscopyScienceFilters)(wavelength)
+    SpectroscopyScienceFilters.find(_.spectroscopyRange.exists(_.contains(wavelength)))
+      .toRight(s"No Gnirs spectroscopy science filter available for wavelength: $wavelength")
 
-  def fromAcquisitionWavelength(wavelength: Wavelength): Either[String, GnirsFilter] =
-    forWavelength(AcquisitionFilters)(wavelength)
+  /**
+   * The automatic acquisition filter for science at the given wavelength: the filter whose
+   * range contains it, else `ThermalAcquisitionFilter` for thermal-IR science, else the
+   * nearest broadband filter (which covers the gaps between the order filter bandpasses).
+   * Total: acquisition must always be possible for an observable wavelength.
+   */
+  def fromAcquisitionWavelength(wavelength: Wavelength): GnirsFilter =
+    AutoAcquisitionFilters
+      .find(_.spectroscopyRange.exists(_.contains(wavelength)))
+      .getOrElse:
+        if wavelength >= ThermalAcquisitionCutoff then ThermalAcquisitionFilter
+        else
+          // Ties keep the earlier (shorter) filter, hence the strict comparison.
+          def distance(f: GnirsFilter): Int =
+            (wavelength.toPicometers.value.value - f.centralWavelength.toPicometers.value.value).abs
+          BroadbandAutoAcquisitionFilters.reduceLeft: (a, b) =>
+            if distance(b) < distance(a) then b else a
 
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/enums/GnirsCameraSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enums/GnirsCameraSuite.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+import munit.DisciplineSuite
+
+final class GnirsCameraSuite extends DisciplineSuite {
+
+  test("blue and red keep the pixel scale") {
+    Enumerated[GnirsCamera].all.foreach: c =>
+      assertEquals(c.blue.pixelScale, c.pixelScale, s"${c.tag}.blue changed the pixel scale")
+      assertEquals(c.red.pixelScale, c.pixelScale, s"${c.tag}.red changed the pixel scale")
+  }
+
+  test("blue and red are idempotent and mutually inverse") {
+    Enumerated[GnirsCamera].all.foreach: c =>
+      assertEquals(c.blue.blue, c.blue)
+      assertEquals(c.red.red, c.red)
+      assertEquals(c.blue.red, c.red)
+      assertEquals(c.red.blue, c.blue)
+  }
+
+  test("the pairs") {
+    assertEquals(GnirsCamera.ShortRed.blue, GnirsCamera.ShortBlue)
+    assertEquals(GnirsCamera.LongRed.blue, GnirsCamera.LongBlue)
+    assertEquals(GnirsCamera.ShortBlue.blue, GnirsCamera.ShortBlue)
+    assertEquals(GnirsCamera.LongBlue.red, GnirsCamera.LongRed)
+  }
+
+}

--- a/modules/tests/shared/src/test/scala/lucuma/core/enums/GnirsFilterSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enums/GnirsFilterSuite.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.math.Wavelength
+import munit.DisciplineSuite
+
+final class GnirsFilterSuite extends DisciplineSuite {
+
+  private def acq(pm: Int): GnirsFilter =
+    GnirsFilter.fromAcquisitionWavelength(Wavelength.unsafeFromIntPicometers(pm))
+
+  private def checkAcq(pm: Int, expected: GnirsFilter): Unit =
+    assertEquals(acq(pm), expected, s"acquisition filter at ${pm}pm")
+
+  test("acquisition filter, wavelength within a filter's range") {
+    checkAcq(1_030_000, GnirsFilter.Order6) // X, lower bound
+    checkAcq(1_100_000, GnirsFilter.Order6)
+    checkAcq(1_250_000, GnirsFilter.Order5) // J
+    checkAcq(1_650_000, GnirsFilter.Order4) // H
+    checkAcq(2_200_000, GnirsFilter.Order3) // K
+  }
+
+  test("acquisition filter, H2 wins over the Order3 range that contains it") {
+    checkAcq(2_105_000, GnirsFilter.H2)
+    checkAcq(2_120_000, GnirsFilter.H2)
+    checkAcq(2_135_999, GnirsFilter.H2)
+    checkAcq(2_136_000, GnirsFilter.Order3) // ranges are open above
+  }
+
+  test("acquisition filter, gaps between the order filters use the nearest broadband filter") {
+    checkAcq(1_000_000, GnirsFilter.Order6) // below X
+    checkAcq(1_400_000, GnirsFilter.Order5) // J/H gap, nearer J
+    checkAcq(1_480_000, GnirsFilter.Order4) // J/H gap, nearer H
+    checkAcq(1_800_000, GnirsFilter.Order4) // H upper bound is exclusive
+    checkAcq(1_850_000, GnirsFilter.Order4) // H/K gap: the LC SXD optimal wavelength
+    checkAcq(2_490_000, GnirsFilter.Order3) // K upper bound is exclusive
+  }
+
+  test("acquisition filter, thermal-IR science") {
+    checkAcq(2_500_000, GnirsFilter.ThermalAcquisitionFilter) // the cutoff itself
+    checkAcq(2_800_000, GnirsFilter.ThermalAcquisitionFilter) // L, lower bound
+    checkAcq(3_300_000, GnirsFilter.ThermalAcquisitionFilter) // the PAH band
+    checkAcq(3_500_000, GnirsFilter.ThermalAcquisitionFilter) // L, optimal
+    checkAcq(4_300_000, GnirsFilter.ThermalAcquisitionFilter) // L/M gap
+    checkAcq(4_800_000, GnirsFilter.ThermalAcquisitionFilter) // M, optimal
+    checkAcq(5_000_000, GnirsFilter.ThermalAcquisitionFilter) // the reported failure
+    checkAcq(6_000_000, GnirsFilter.ThermalAcquisitionFilter) // M upper bound is exclusive
+  }
+
+  test("acquisition filter selection is total over (and beyond) the GNIRS range") {
+    (500_000 to 7_000_000 by 1_000).foreach: pm =>
+      assert(GnirsFilter.AutoAcquisitionFilters.toList.contains(acq(pm)), s"no acquisition filter at ${pm}pm")
+  }
+
+  test("automatic acquisition selection never produces PAH") {
+    assert(!GnirsFilter.AutoAcquisitionFilters.toList.contains(GnirsFilter.PAH))
+    assert(GnirsFilter.AcquisitionFilters.toList.contains(GnirsFilter.PAH))
+  }
+
+  test("science filter") {
+    assertEquals(
+      GnirsFilter.fromSpectroscopyScienceWavelength(Wavelength.unsafeFromIntPicometers(5_000_000)),
+      Right(GnirsFilter.Order1)
+    )
+    assert(
+      GnirsFilter.fromSpectroscopyScienceWavelength(Wavelength.unsafeFromIntPicometers(2_600_000)).isLeft
+    )
+  }
+
+}


### PR DESCRIPTION
A GNIRS observation at 5µm could not generate a sequence: it failed with "No Gnirs spectroscopy filter available for wavelength: 5000000". The acquisition filters cover 1.030-2.490µm plus PAH's 3.266-3.321µm, and fromAcquisitionWavelength required strict containment, so every M-band config and every L-band config outside the PAH band had no acquisition filter at all. Gaps at 1.370-1.490 and 1.800-1.910µm failed the same way — the latter reachable from a cross-dispersed config, whose LC SXD optimal wavelength is 1.85µm.

fromAcquisitionWavelength is now total: containment first, then ThermalAcquisitionFilter above the 2.5µm blue/red boundary, then the nearest broadband order filter for the remaining gaps. Acquisition must always be possible for a wavelength the instrument can observe.

Per the GNIRS instrument scientists, thermal-IR science is acquired with the blue camera at the same pixel scale (short and long are never mixed) in H, or in H2 when the target is very bright, which the existing brightness rule already handles. GnirsCamera gains blue and red accessors for that; red is not used yet but is what a manual override to acquire on the red camera will want. PAH drops out of automatic selection, since a 3.3µm filter has no place on the blue camera; it remains available as an explicit choice, and Explore's dropdown is unaffected because it uses AcquisitionFilters.

Returning a filter rather than an Either is binary incompatible, hence the tlBaseVersion bump.