### PR TITLE
Revert the shortName changes from PR 1546

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
@@ -30,7 +30,7 @@ enum GnirsFilter(
   // (https://www.gemini.edu/instrumentation/gnirs/capability#Imaging)
   val imagingWidth: Option[BoundedInterval[Wavelength]],      // Imaging bandpass.
   val filterType: FilterType
-) derives Enumerated, Display:
+) derives Enumerated:
   // There are two J filters (ORDER5 and J-MK) and two K filters (ORDER3 and K-MK).  The "ORDER" filters are for spectroscopy and have wider
   // wavelength coverage, while the "MK" filters are for imaging and are matched to the bandpasses of the Maunakea photometric system.
   // The "ORDER" filters are physically large and cover the length of the slit, while the MK filters are small and only cover the inner circular region.
@@ -39,19 +39,19 @@ enum GnirsFilter(
   // Note that only the "ORDER" filters are valid for spectroscopy science. The other ones with spectroscopyRange defined (H2 and PAH)
   // can still be used for acquisition.
   case CrossDispersed extends GnirsFilter("CrossDispersed", "XD",        "Cross dispersed",     none,              none,                                none,                                FilterType.BroadBand)
-  case Order6 extends         GnirsFilter("Order6",         "X (spec)",         "Order 6 (X)",         1_100_000.pm.some, (1_030_000, 1_175_400).pmRange.some, (1_030_000, 1_170_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 1.03-1.17µm (Δλ = 140nm)
-  case Order5 extends         GnirsFilter("Order5",         "J (spec)",         "Order 5 (J)",         1_250_000.pm.some, (1_175_400, 1_370_000).pmRange.some, none,                                FilterType.Spectroscopic)
+  case Order6 extends         GnirsFilter("Order6",         "X",         "Order 6 (X)",         1_100_000.pm.some, (1_030_000, 1_175_400).pmRange.some, (1_030_000, 1_170_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 1.03-1.17µm (Δλ = 140nm)
+  case Order5 extends         GnirsFilter("Order5",         "J",         "Order 5 (J)",         1_250_000.pm.some, (1_175_400, 1_370_000).pmRange.some, none,                                FilterType.Spectroscopic)
   case Order4 extends         GnirsFilter("Order4",         "H",         "Order 4 (H: 1.65µm)", 1_650_000.pm.some, (1_490_000, 1_800_000).pmRange.some, (1_490_000, 1_800_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 1.49-1.80µm (Δλ = 310nm)
   case H2 extends             GnirsFilter("H2",             "H2",        "H2: 2.12µm",          2_120_000.pm.some, (2_105_000, 2_136_000).pmRange.some, none,                                FilterType.NarrowBand)
-  case Order3 extends         GnirsFilter("Order3",         "K (spec)",         "Order 3 (K)",         2_200_000.pm.some, (1_910_000, 2_490_000).pmRange.some, none,                                FilterType.Spectroscopic)
-  case Order2 extends         GnirsFilter("Order2",         "L (spec)",         "Order 2 (L)",         3_500_000.pm.some, (2_800_000, 4_200_000).pmRange.some, none,                                FilterType.BroadBand)
-  case Order1 extends         GnirsFilter("Order1",         "M (spec)",         "Order 1 (M)",         4_800_000.pm.some, (4_400_000, 6_000_000).pmRange.some, none,                                FilterType.BroadBand)
+  case Order3 extends         GnirsFilter("Order3",         "K",         "Order 3 (K)",         2_200_000.pm.some, (1_910_000, 2_490_000).pmRange.some, none,                                FilterType.Spectroscopic)
+  case Order2 extends         GnirsFilter("Order2",         "L",         "Order 2 (L)",         3_500_000.pm.some, (2_800_000, 4_200_000).pmRange.some, none,                                FilterType.BroadBand)
+  case Order1 extends         GnirsFilter("Order1",         "M",         "Order 1 (M)",         4_800_000.pm.some, (4_400_000, 6_000_000).pmRange.some, none,                                FilterType.BroadBand)
   case HNd100x extends        GnirsFilter("HNd100x",        "H+ND100X",  "H + ND100X",          1_650_000.pm.some, none,                                none,                                FilterType.BroadBand)
   case H2Nd100x extends       GnirsFilter("H2Nd100x",       "H2+ND100X", "H2 + ND100X",         2_120_000.pm.some, none,                                none,                                FilterType.NarrowBand)
   case PAH extends            GnirsFilter("PAH",            "PAH",       "PAH: 3.3µm",          3_300_000.pm.some, (3_266_000, 3_321_000).pmRange.some, none,                                FilterType.NarrowBand)
-  case Y extends              GnirsFilter("Y",              "Y (phot)",         "Y: 1.03µm",           1_030_000.pm.some, none,                                (970_000,   1_070_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 0.97-1.07µm (Δλ = 100nm)
-  case J extends              GnirsFilter("J",              "J (phot)",         "J: 1.25µm",           1_250_000.pm.some, none,                                (1_170_000, 1_340_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 1.17-1.34µm (Δλ = 170nm)
-  case K extends              GnirsFilter("K",              "K (phot)",         "K: 2.20µm",           2_200_000.pm.some, none,                                (2_030_000, 2_370_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 2.03-2.37µm (Δλ = 340nm)
+  case Y extends              GnirsFilter("Y",              "Y",         "Y: 1.03µm",           1_030_000.pm.some, none,                                (970_000,   1_070_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 0.97-1.07µm (Δλ = 100nm)
+  case J extends              GnirsFilter("J",              "J",         "J: 1.25µm",           1_250_000.pm.some, none,                                (1_170_000, 1_340_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 1.17-1.34µm (Δλ = 170nm)
+  case K extends              GnirsFilter("K",              "K",         "K: 2.20µm",           2_200_000.pm.some, none,                                (2_030_000, 2_370_000).pmRange.some, FilterType.BroadBand)     // Imaging bandpass: 2.03-2.37µm (Δλ = 340nm)
 
   def centralWavelength: Wavelength =
     // The only case the filter optimalWavelength is none is for XD, where we fix to 1.65um.
@@ -120,4 +120,12 @@ object GnirsFilter:
           BroadbandAutoAcquisitionFilters.reduceLeft: (a, b) =>
             if distance(b) < distance(a) then b else a
 
+  private def toShortDisplayName(f: GnirsFilter): String =
+    f match
+      case Order6 | Order5 | Order3 | Order2 | Order1 => s"${f.shortName} (spec)"
+      case Y | J | K => s"${f.shortName} (phot)"
+      case _ => f.shortName
 
+  // Andy has requested that the display names be unambiguous. However, shortName is used for parsing the 
+  // phase 0 tables in explore, so we don't want to change those.
+  given Display[GnirsFilter] = Display.by(toShortDisplayName, _.longName)


### PR DESCRIPTION
The shortNames are used to parse the phase 0 tables in the odb. Create a manual Display instance, instead.