### PR TITLE
Derive Display for ObservationWorkflowState & ConfigurationRequestStatus

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.236"
+ThisBuild / tlBaseVersion                         := "0.237"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ConfigurationRequestStatus.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ConfigurationRequestStatus.scala
@@ -3,11 +3,12 @@
 
 package lucuma.core.enums
 
+import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
 
-enum ConfigurationRequestStatus(val tag: String) derives Enumerated:
-  case Requested extends ConfigurationRequestStatus("requested")
-  case Approved  extends ConfigurationRequestStatus("approved")
-  case Denied    extends ConfigurationRequestStatus("denied")
-  case Withdrawn extends ConfigurationRequestStatus("withdrawn")
+enum ConfigurationRequestStatus(val tag: String, val name: String) derives Enumerated, Display:
+  case Requested extends ConfigurationRequestStatus("requested", "Requested")
+  case Approved  extends ConfigurationRequestStatus("approved", "Approved")
+  case Denied    extends ConfigurationRequestStatus("denied", "Denied")
+  case Withdrawn extends ConfigurationRequestStatus("withdrawn", "Withdrawn")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationWorkflowState.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationWorkflowState.scala
@@ -3,17 +3,18 @@
 
 package lucuma.core.enums
 
+import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
-enum ObservationWorkflowState(val tag: String) derives Enumerated:
-  case Inactive   extends ObservationWorkflowState("inactive")
-  case Undefined  extends ObservationWorkflowState("undefined")
-  case Unapproved extends ObservationWorkflowState("unapproved")
-  case Defined    extends ObservationWorkflowState("defined")
-  case ForReview  extends ObservationWorkflowState("for_review")
-  case Ready      extends ObservationWorkflowState("ready")
-  case Ongoing    extends ObservationWorkflowState("ongoing")
-  case Completed  extends ObservationWorkflowState("completed")
+enum ObservationWorkflowState(val tag: String, val name: String) derives Enumerated, Display:
+  case Inactive   extends ObservationWorkflowState("inactive", "Inactive")
+  case Undefined  extends ObservationWorkflowState("undefined", "Undefined")
+  case Unapproved extends ObservationWorkflowState("unapproved", "Unapproved")
+  case Defined    extends ObservationWorkflowState("defined", "Defined")
+  case ForReview  extends ObservationWorkflowState("for_review", "For Review")
+  case Ready      extends ObservationWorkflowState("ready", "Ready")
+  case Ongoing    extends ObservationWorkflowState("ongoing", "Ongoing")
+  case Completed  extends ObservationWorkflowState("completed", "Completed")
 
 
 


### PR DESCRIPTION
Explore was taking the easy way out and just capitalizing the tag. `for_review` broke that, so this seems like a better idea.