### PR TITLE
sc-10025 remove `for_review` workflow state

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.239"
+ThisBuild / tlBaseVersion                         := "0.240"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationWorkflowState.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationWorkflowState.scala
@@ -11,7 +11,6 @@ enum ObservationWorkflowState(val tag: String, val name: String) derives Enumera
   case Undefined  extends ObservationWorkflowState("undefined", "Undefined")
   case Unapproved extends ObservationWorkflowState("unapproved", "Unapproved")
   case Defined    extends ObservationWorkflowState("defined", "Defined")
-  case ForReview  extends ObservationWorkflowState("for_review", "For Review")
   case Ready      extends ObservationWorkflowState("ready", "Ready")
   case Ongoing    extends ObservationWorkflowState("ongoing", "Ongoing")
   case Completed  extends ObservationWorkflowState("completed", "Completed")


### PR DESCRIPTION
We decided to get rid of `for_review` in favor of just blocking the transition to `ready` when warnings exist, and giving staff a way to dismiss classes of warnings on a per-program basis. This is step 1 of this change.

After this change the transition set will be accurate (no "secret" transition available to staff users) so that special case goes away in the UI.