### PR TITLE
Swap Gmos IFU sky positions

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometry.scala
@@ -93,14 +93,17 @@ trait GmosScienceAreaGeometry {
   /**
    * Where the sky field lands once the target field is centred on the base. The two fields are a
    * fixed [[IfuFieldSeparation]] apart, so re-centring shifts the sky field by the difference of the
-   * two half-widths on top of that. South mirrors it about the base, North does not, which is the
-   * `OT-10` flip in OCS `GmosScienceAreaGeometry.ifuFOV`.
+   * two half-widths on top of that.
+   *
+   * North puts it East of the base and South mirrors it West, the `OT-10` flip in OCS
+   * `GmosScienceAreaGeometry.ifuFOV`. Beware the frame: OCS states those rectangles in the shape
+   * frame, where `x = -p`, so the negative x it uses for North is a positive `p` here.
    */
   def ifuSkyOffset(fieldWidth: Angle, site: Site): Offset =
     val p = IfuFieldSeparation + fieldWidth.bisect - ifuSkyFieldWidth(fieldWidth).bisect
     (site match
-      case Site.GN => -p
-      case Site.GS => p
+      case Site.GN => p
+      case Site.GS => -p
     ).offsetInP
 
   object ifuMode:

--- a/modules/tests/shared/src/test/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometrySuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometrySuite.scala
@@ -48,11 +48,13 @@ class GmosScienceAreaGeometrySuite extends ScienceAreaGeometrySuite:
     assertCloseArcsec(q1, 5.0)
 
   // OCS GmosScienceAreaGeometry.ifuFOV, OT-10: South mirrors the sky bundle about the base.
-  // Getting this backwards would put an observer's sky bundle on the wrong patch of sky.
-  test("sky field sits ~62\" away, on opposite sides in North and South"):
-    assertEqualsDouble(skyCentreArcsecP(GmosNorthIfuFpu.TwoSlits.fieldWidth, Site.GN), -61.75, 0.01)
-    assertEqualsDouble(skyCentreArcsecP(GmosSouthIfuFpu.TwoSlits.fieldWidth, Site.GS), 61.75, 0.01)
+  // OCS states those rectangles in the shape frame, where x = -p, so its negative x for North is
+  // East, a positive p here. Getting this backwards, as we did, points an observer's sky bundle at
+  // the wrong patch of sky.
+  test("sky field sits ~62\" away, East in North and West in South"):
+    assertEqualsDouble(skyCentreArcsecP(GmosNorthIfuFpu.TwoSlits.fieldWidth, Site.GN), 61.75, 0.01)
+    assertEqualsDouble(skyCentreArcsecP(GmosSouthIfuFpu.TwoSlits.fieldWidth, Site.GS), -61.75, 0.01)
 
   test("one-slit sky field shifts in with the narrower fields"):
-    assertEqualsDouble(skyCentreArcsecP(GmosNorthIfuFpu.OneSlitRed.fieldWidth, Site.GN), -60.875, 0.01)
-    assertEqualsDouble(skyCentreArcsecP(GmosSouthIfuFpu.OneSlitRed.fieldWidth, Site.GS), 60.875, 0.01)
+    assertEqualsDouble(skyCentreArcsecP(GmosNorthIfuFpu.OneSlitRed.fieldWidth, Site.GN), 60.875, 0.01)
+    assertEqualsDouble(skyCentreArcsecP(GmosSouthIfuFpu.OneSlitRed.fieldWidth, Site.GS), -60.875, 0.01)


### PR DESCRIPTION
Fix the sky field positions. See https://app.shortcut.com/lucuma/story/10048/gmos-ifu-aladin-overlay#activity-10236