### PR TITLE
SC-10025 break validation errors and warnings into distinct enums

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.242"
+ThisBuild / tlBaseVersion                         := "0.243"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationValidationCode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObservationValidationCode.scala
@@ -5,84 +5,129 @@ package lucuma.core.enums
 
 import lucuma.core.util.Enumerated
 
-import ObservationValidationCode.*
+/**
+ * Enumeration identifying classes of validation problems. The top-level enumeration `ObservationValidationCode` is
+ * also available as a pair of sub-enumerations `ObservationValidationCode.Error` and 
+ * `ObservationValidationCode.Warning` for code that needs to distinguish these at the type level.
+ */
 
-enum ObservationValidationCode(
-  val tag: String,
-  val name: String,
-  val description: String,
-) derives Enumerated:
-  def severity: Severity
-  case ConfigurationError extends ObservationValidationCode("configuration_error", "Configuration Error", "The observation is not configured correctly and cannot be executed") with Fatal
-  case CallForProposalsError extends ObservationValidationCode("cfp_error", "Call for Proposals Error", "Not valid for the selected Call for Proposals") with Fatal
-  case ItcError extends ObservationValidationCode("itc_error", "ITC Error", "Integration time is unavailable.") with Fatal
-  case ConfigurationRequestUnavailable 
-    extends ObservationValidationCode(
-      "config_request_unavailable", 
-      "Unknown Approval Status", 
-      ObservationValidationCode.ConfigurationRequestMsg.Unavailable, 
-    ) with Fatal
-  case ConfigurationRequestNotRequested
-    extends ObservationValidationCode(
-      "config_request_not_requested", 
-      "Needs Approval", 
-      ObservationValidationCode.ConfigurationRequestMsg.NotRequested, 
-    ) with Fatal
-  case ConfigurationRequestDenied
-    extends ObservationValidationCode(
-      "config_request_denied", 
-      "Denied", 
-      ObservationValidationCode.ConfigurationRequestMsg.Denied, 
-    ) with Fatal
-  case ConfigurationRequestPending
-    extends ObservationValidationCode(
-      "config_request_pending",
-      "Approval Pending",
-      ObservationValidationCode.ConfigurationRequestMsg.Pending,
-    ) with Fatal
-  case TooActivationUnapproved
-    extends ObservationValidationCode(
-      "too_activation_unapproved",
-      "ToO Activation Unapproved",
-      ObservationValidationCode.TooActivationMsg.ExceedsCeiling,
-    ) with Fatal
-  @deprecated("Use a fine-grained code.")
-  case GenericWarning
-    extends ObservationValidationCode(
-      "generic_warning",
-      "Warning",
-      "A warning was issued.",
-    ) with Nonfatal
-  case ConditionsUnlikely
-    extends ObservationValidationCode(
-      "conditions_unlikely",
-      "Observing Conditions Unlikely",
-      "Likelihood of observing conditions is below recommended percentage.",
-    ) with Nonfatal
-  case LowTotalSignalToNoise
-    extends ObservationValidationCode(
-      "low_total_signal_to_noise",
-      "Low Total Signal to Noise",
-      "Total signal to noise is below recommended threshold.",
-    ) with Nonfatal
+sealed trait ObservationValidationCode:
+  import ObservationValidationCode.*
 
+  def tag: String // we must ensure th
+  def name: String
+  def description: String
+  
+  def fold[A](f: Error => A, g: Warning => A): A =
+    this match
+      case e: Error   => f(e)
+      case w: Warning => g(w)
+
+  def isError: Boolean = fold(_ => true, _ => false)
+  def asError: Option[Error] = fold(Some(_), _ => None)
+
+  def isWarning: Boolean = fold(_ => false, _ => true)
+  def asWarning: Option[Warning] = fold(_ => None, Some(_))
+
+  @deprecated("Use fold or a variant.")
+  def severity: Severity = fold(_ => Severity.Fatal, _ => Severity.Nonfatal)
+ 
 object ObservationValidationCode:
+  export Error.*
+  export Warning.*
 
-  // Marker traits, so you can have a catch-all match case for wanings without
-  // losing exhaustiveness checks for fatal. This is important in the workflow
-  // calculation in the ODB.
-  trait Fatal:
-    def severity = Severity.Fatal
-  trait Nonfatal:
-    def severity = Severity.Nonfatal
-
+  // TODO: remove
   enum Severity:
     case Fatal, Nonfatal
-  object TooActivationMsg:
-    val ExceedsCeiling = "Target of Opportunity activation exceeds what the accepted proposal allows."
 
-  object ConfigurationRequestMsg:
-    val Unavailable  = "Configuration approval status could not be determined."
-    val NotRequested = "Configuration is unapproved (approval has not been requested)."
-    val Denied       = "Configuration is unapproved (request was denied)."
-    val Pending      = "Configuration is unapproved (request is pending)."
+  @deprecated("Use `Error`")
+  type Fatal = Error
+
+  @deprecated("Use `Warning`")
+  type Nonfatal = Warning
+
+  given Enumerated[ObservationValidationCode] with
+    assert:   // ensure that the tag sets are disjoint
+      val te = Enumerated[Error].all.map(_.tag).toSet
+      val tw = Enumerated[Warning].all.map(_.tag).toSet
+      te.intersect(tw).isEmpty
+    def all: List[ObservationValidationCode] = Enumerated[Error].all ++ Enumerated[Warning].all
+    def tag(a: ObservationValidationCode): String = a.tag
+
+  enum Error(
+    val tag: String,
+    val name: String,
+    val description: String,
+  ) extends ObservationValidationCode derives Enumerated:
+
+    case ConfigurationError extends Error("configuration_error", "Configuration Error", "The observation is not configured correctly and cannot be executed") 
+    case CallForProposalsError extends Error("cfp_error", "Call for Proposals Error", "Not valid for the selected Call for Proposals") 
+    case ItcError extends Error("itc_error", "ITC Error", "Integration time is unavailable.") 
+    case ConfigurationRequestUnavailable 
+      extends Error(
+        "config_request_unavailable", 
+        "Unknown Approval Status", 
+        Error.ConfigurationRequestMsg.Unavailable, 
+      ) 
+    case ConfigurationRequestNotRequested
+      extends Error(
+        "config_request_not_requested", 
+        "Needs Approval", 
+        Error.ConfigurationRequestMsg.NotRequested, 
+      ) 
+    case ConfigurationRequestDenied
+      extends Error(
+        "config_request_denied", 
+        "Denied", 
+        Error.ConfigurationRequestMsg.Denied, 
+      ) 
+    case ConfigurationRequestPending
+      extends Error(
+        "config_request_pending",
+        "Approval Pending",
+        Error.ConfigurationRequestMsg.Pending,
+      ) 
+    case TooActivationUnapproved
+      extends Error(
+        "too_activation_unapproved",
+        "ToO Activation Unapproved",
+        Error.TooActivationMsg.ExceedsCeiling,
+      ) 
+
+  object Error:
+    object TooActivationMsg:
+      val ExceedsCeiling = "Target of Opportunity activation exceeds what the accepted proposal allows."
+
+    object ConfigurationRequestMsg:
+      val Unavailable  = "Configuration approval status could not be determined."
+      val NotRequested = "Configuration is unapproved (approval has not been requested)."
+      val Denied       = "Configuration is unapproved (request was denied)."
+      val Pending      = "Configuration is unapproved (request is pending)."
+
+  enum Warning(
+    val tag: String,
+    val name: String,
+    val description: String,
+  ) extends ObservationValidationCode derives Enumerated:
+
+    @deprecated("Use a fine-grained code.")
+    case GenericWarning
+      extends Warning(
+        "generic_warning",
+        "Warning",
+        "A warning was issued.",
+      ) 
+    case ConditionsUnlikely
+      extends Warning(
+        "conditions_unlikely",
+        "Observing Conditions Unlikely",
+        "Likelihood of observing conditions is below recommended percentage.",
+      ) 
+    case LowTotalSignalToNoise
+      extends Warning(
+        "low_total_signal_to_noise",
+        "Low Total Signal to Noise",
+        "Total signal to noise is below recommended threshold.",
+      ) 
+
+


### PR DESCRIPTION
This is a mostly mechanical change. `ObservationValidationCode` exists as before and is source-compatible, but there are now also sub-enums `ObservationValidationCode.Error` and `ObservationValidationCode.Warning` for code that needs to distinguish them.