### PR TITLE
Fixes the warnings for unary conversions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,20 @@ jobs:
         if: matrix.project == 'rootJS'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' bundleMon
 
-      - name: Aggregate coverage reports
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' coverageReport coverageAggregate
+      - name: Make target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/topic/scala3')
+        run: mkdir -p modules/ags/.jvm/target modules/catalog-testkit/js/target modules/catalog/jvm/target modules/testkit/.js/target modules/ags/.js/target modules/core/js/target modules/catalog/js/target modules/horizons/.js/target modules/horizons/.jvm/target modules/catalog-testkit/jvm/target modules/core/jvm/target modules/itac/target modules/testkit/.jvm/target project/target
 
-      - name: Upload code coverage data
-        uses: codecov/codecov-action@v6
+      - name: Compress target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/topic/scala3')
+        run: tar cf targets.tar modules/ags/.jvm/target modules/catalog-testkit/js/target modules/catalog/jvm/target modules/testkit/.js/target modules/ags/.js/target modules/core/js/target modules/catalog/js/target modules/horizons/.js/target modules/horizons/.jvm/target modules/catalog-testkit/jvm/target modules/core/jvm/target modules/itac/target modules/testkit/.jvm/target project/target
+
+      - name: Upload target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/topic/scala3')
+        uses: actions/upload-artifact@v5
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
+          path: targets.tar
 
   publish:
     name: Publish Artifacts
@@ -136,6 +145,26 @@ jobs:
       - name: sbt update
         if: matrix.java == 'temurin@25' && steps.setup-java-temurin-25.outputs.cache-hit == 'false'
         run: sbt +update
+
+      - name: Download target directories (3, rootJS)
+        uses: actions/download-artifact@v6
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootJS
+
+      - name: Inflate target directories (3, rootJS)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3, rootJVM)
+        uses: actions/download-artifact@v6
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootJVM
+
+      - name: Inflate target directories (3, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Import signing key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ ThisBuild / tlCiReleaseBranches += "topic/scala3"
 Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)
 
 ThisBuild / crossScalaVersions := Seq("3.9.0")
+ThisBuild / lucumaCoverage := false
 ThisBuild / scalacOptions += "-language:implicitConversions" // TODO
 // Derivation for wide sums (Configuration.ObservingMode) exceeds the default budget of 32.
 ThisBuild / scalacOptions += "-Xmax-inlines:64"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.243"
+ThisBuild / tlBaseVersion                         := "0.244"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ ThisBuild / tlCiReleaseBranches += "topic/scala3"
 
 Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)
 
-ThisBuild / crossScalaVersions := Seq("3.8.4")
+ThisBuild / crossScalaVersions := Seq("3.9.0")
 ThisBuild / scalacOptions += "-language:implicitConversions" // TODO
 // Derivation for wide sums (Configuration.ObservingMode) exceeds the default budget of 32.
 ThisBuild / scalacOptions += "-Xmax-inlines:64"

--- a/modules/catalog-tests/jvm/src/test/scala/lucuma/catalog/clients/GaiaClientSuite.scala
+++ b/modules/catalog-tests/jvm/src/test/scala/lucuma/catalog/clients/GaiaClientSuite.scala
@@ -121,7 +121,7 @@ class GaiaClientSuite extends CatsEffectSuite with VoTableSamples:
           // parallax: 0.16641381 mas -> 166 μas as long
           assertEquals(tracking.parallax.map(_.μas.value.value), 166L.some)
           // radial_velocity: -39.225376 km/s -> -39225.376 m/s
-          assertEquals(tracking.radialVelocity.map(_.rv.value.toDouble), -39225.376.some)
+          assertEquals(tracking.radialVelocity.map(_.rv.value.toDouble), (-39225.376).some)
           assertEquals(
             Target.integratedBrightnessIn(Band.Gaia).headOption(result.target),
             BrightnessValue.unsafeFrom(15.083894).withUnit[VegaMagnitude].toMeasureTagged.some
@@ -144,7 +144,7 @@ class GaiaClientSuite extends CatsEffectSuite with VoTableSamples:
         case Right(result) =>
           val tracking = result.target.tracking
           assertEquals(tracking.parallax.map(_.μas.value.value), 166L.some)
-          assertEquals(tracking.radialVelocity.map(_.rv.value.toDouble), -39225.376.some)
+          assertEquals(tracking.radialVelocity.map(_.rv.value.toDouble), (-39225.376).some)
           assertEquals(
             Target.integratedBrightnessIn(Band.Gaia).headOption(result.target),
             BrightnessValue.unsafeFrom(15.083894).withUnit[VegaMagnitude].toMeasureTagged.some
@@ -166,7 +166,7 @@ class GaiaClientSuite extends CatsEffectSuite with VoTableSamples:
         case Right(result) =>
           val tracking = result.target.tracking
           assertEquals(tracking.parallax.map(_.μas.value.value), 166L.some)
-          assertEquals(tracking.radialVelocity.map(_.rv.value.toDouble), -39225.376.some)
+          assertEquals(tracking.radialVelocity.map(_.rv.value.toDouble), (-39225.376).some)
         case Left(e)       =>
           fail(s"queryById failed: ${e.toList.mkString("; ")}")
 
@@ -183,7 +183,7 @@ class GaiaClientSuite extends CatsEffectSuite with VoTableSamples:
           assertEquals(target.name.value, "Gaia DR3 538670232718296576")
           assertEquals(tracking.epoch.some, Epoch.Julian.fromEpochYears(2016.0))
           assertEquals(tracking.parallax.map(_.μas.value.value), 166L.some)
-          assertEquals(tracking.radialVelocity.map(_.rv.value.toDouble), -39225.376.some)
+          assertEquals(tracking.radialVelocity.map(_.rv.value.toDouble), (-39225.376).some)
           assertEquals(
             Target.properMotionRA.getOption(target),
             ProperMotion.μasyRA(-1434).some

--- a/modules/catalog-tests/shared/src/test/scala/lucuma/ags/9024.scala
+++ b/modules/catalog-tests/shared/src/test/scala/lucuma/ags/9024.scala
@@ -76,9 +76,9 @@ class ShortCut_9024 extends munit.FunSuite {
       case _                      => false
 
   // target like one on ifu1/ifu2 that is away from the base
-  private val noZoneTarget = coordAt(Offset(-100.arcsec.p, 0.arcsec.q))
+  private val noZoneTarget = coordAt(Offset((-100).arcsec.p, 0.arcsec.q))
   // This guide star is on top of ifu1/ifu2 it should be reject
-  private val gsOnIFU      = guidestarAt(Offset(100.arcsec.p, -100.arcsec.q))
+  private val gsOnIFU      = guidestarAt(Offset(100.arcsec.p, (-100).arcsec.q))
   // This guide star is away
   private val gsAtDistance = guidestarAt(Offset(100.arcsec.p, 0.arcsec.q))
 

--- a/modules/core/shared/src/main/scala/lucuma/core/math/Offset.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/Offset.scala
@@ -112,7 +112,7 @@ object Offset extends OffsetOptics {
 
       /** This component, reflected around the 0 .. 180° axis. Exact, invertable. */
       inline def unary_- : Component[A] =
-        -toAngle.toMicroarcseconds
+        Component(-toAngle)
 
       /** Sum of this component and `o` of the same type. Exact. */
       inline def +(o: Component[A]): Component[A] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/flamingos2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/flamingos2/package.scala
@@ -27,8 +27,8 @@ val MosTelluricDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
     TelescopeConfigAlongSlit(  40.qArcsec,  StepGuideState.Enabled),
     TelescopeConfigAlongSlit(  20.qArcsec,  StepGuideState.Enabled),
     TelescopeConfigAlongSlit(-(20.qArcsec), StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(  40.qArcsec,  StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(  60.qArcsec,  StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(40.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(60.qArcsec), StepGuideState.Enabled),
   )
 
 val NodAlongSlitDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/flamingos2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/flamingos2/package.scala
@@ -15,36 +15,36 @@ import lucuma.core.model.sequence.TelescopeConfigAlongSlit
 
 val TelluricDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
   NonEmptyList.of(
-    TelescopeConfigAlongSlit( 15.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(-15.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(-15.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 15.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  15.qArcsec,  StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(15.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(15.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  15.qArcsec,  StepGuideState.Enabled),
   )
 
 val MosTelluricDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
   NonEmptyList.of(
-    TelescopeConfigAlongSlit( 60.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 40.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 20.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(-20.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 40.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 60.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  60.qArcsec,  StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  40.qArcsec,  StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  20.qArcsec,  StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(20.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  40.qArcsec,  StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  60.qArcsec,  StepGuideState.Enabled),
   )
 
 val NodAlongSlitDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
   NonEmptyList.of(
-    TelescopeConfigAlongSlit( 10.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(-10.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(-10.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 10.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  10.qArcsec,  StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(10.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(10.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  10.qArcsec,  StepGuideState.Enabled),
   )
 
 val NodToSkyDefaultTelescopeConfigs: NonEmptyList[TelescopeConfig] =
   NonEmptyList.of(
-    TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
+    TelescopeConfig(Offset.Zero,                    StepGuideState.Enabled),
     TelescopeConfig(Offset(0.pArcsec, 300.qArcsec), StepGuideState.Disabled),
     TelescopeConfig(Offset(0.pArcsec, 310.qArcsec), StepGuideState.Disabled),
-    TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
+    TelescopeConfig(Offset.Zero,                    StepGuideState.Enabled),
   )
 
 def defaultSlitTelescopeConfigs(preset: Flamingos2SlitOffsetPreset): SlitTelescopeConfigs =
@@ -57,18 +57,18 @@ def defaultSlitTelescopeConfigs(preset: Flamingos2SlitOffsetPreset): SlitTelesco
 // MOS presets.
 val SparseFieldDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
   NonEmptyList.of(
-    TelescopeConfigAlongSlit( 1.2.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(-1.2.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(-1.2.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 1.2.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  1.2.qArcsec,  StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(1.2.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(1.2.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  1.2.qArcsec,  StepGuideState.Enabled),
   )
 
 val CrowdedFieldDefaultTelescopeConfigs: NonEmptyList[TelescopeConfig] =
   NonEmptyList.of(
-    TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
+    TelescopeConfig(Offset.Zero,                    StepGuideState.Enabled),
     TelescopeConfig(Offset(0.pArcsec, 300.qArcsec), StepGuideState.Disabled),
     TelescopeConfig(Offset(0.pArcsec, 320.qArcsec), StepGuideState.Disabled),
-    TelescopeConfig(Offset.Zero, StepGuideState.Enabled),
+    TelescopeConfig(Offset.Zero,                    StepGuideState.Enabled),
   )
 
 def defaultMosTelescopeConfigs(preset: Flamingos2MosOffsetPreset): SlitTelescopeConfigs =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/longslit/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gmos/longslit/package.scala
@@ -47,9 +47,9 @@ val DefaultAmpCount: GmosAmpCount =
 val DefaultSlitTelescopeConfigs: SlitTelescopeConfigs =
   SlitTelescopeConfigs.AlongSlit(
     NonEmptyList.of(
-      TelescopeConfigAlongSlit(  0.qArcsec, StepGuideState.Enabled),
-      TelescopeConfigAlongSlit( 15.qArcsec, StepGuideState.Enabled),
-      TelescopeConfigAlongSlit(-15.qArcsec, StepGuideState.Enabled)
+      TelescopeConfigAlongSlit(   0.qArcsec,  StepGuideState.Enabled),
+      TelescopeConfigAlongSlit(  15.qArcsec,  StepGuideState.Enabled),
+      TelescopeConfigAlongSlit(-(15.qArcsec), StepGuideState.Enabled)
     )
   )
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsAcquisitionMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsAcquisitionMode.scala
@@ -28,10 +28,10 @@ enum GnirsAcquisitionMode(val acquisitionType: GnirsAcquisitionType) derives Eq:
 object GnirsAcquisitionMode:
   object Faint {
     // The default Faint sky offset for long slit.
-    val DefaultSlitSkyOffset: Offset = Offset(0.pArcsec, -2.qArcsec)
+    val DefaultSlitSkyOffset: Offset = Offset(0.pArcsec, -(2.qArcsec))
 
     // The default Faint sky offset for IFU: the sky is imaged 10" west of the target.
-    val DefaultIfuSkyOffset: Offset = Offset(-10.pArcsec, 0.qArcsec)
+    val DefaultIfuSkyOffset: Offset = Offset(-(10.pArcsec), 0.qArcsec)
 
     // The default Faint sky offset for imaging: the field image doubles as the sky
     // frame and is taken 10" north of the target.

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/package.scala
@@ -52,34 +52,34 @@ def defaultSlitTelescopeConfigs(preset: GnirsSlitOffsetPreset, prism: GnirsPrism
 private val LowResolutionIfuPresets: NonEmptyList[(String, NonEmptyList[TelescopeConfig])] =
   NonEmptyList.of(
     "Extended" -> NonEmptyList.of(
-      TelescopeConfig(Offset(0.15.pArcsec, 0.15.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(10.pArcsec, 10.qArcsec), StepGuideState.Disabled),
-      TelescopeConfig(Offset(-0.15.pArcsec, -0.15.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(-10.pArcsec, -10.qArcsec), StepGuideState.Disabled)
+      TelescopeConfig(Offset(  0.15.pArcsec,    0.15.qArcsec),  StepGuideState.Enabled),
+      TelescopeConfig(Offset(    10.pArcsec,      10.qArcsec),  StepGuideState.Disabled),
+      TelescopeConfig(Offset(-(0.15.pArcsec), -(0.15.qArcsec)), StepGuideState.Enabled),
+      TelescopeConfig(Offset(  -(10.pArcsec),   -(10.qArcsec)), StepGuideState.Disabled)
     ),
     "Point"    -> NonEmptyList.of(
-      TelescopeConfig(Offset(0.75.pArcsec, -1.5.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(-0.75.pArcsec, -1.5.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(-0.75.pArcsec, 1.5.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(0.75.pArcsec, -1.5.qArcsec), StepGuideState.Enabled)
+      TelescopeConfig(Offset(  0.75.pArcsec,  -(1.5.qArcsec)), StepGuideState.Enabled),
+      TelescopeConfig(Offset(-(0.75.pArcsec), -(1.5.qArcsec)), StepGuideState.Enabled),
+      TelescopeConfig(Offset(-(0.75.pArcsec),   1.5.qArcsec),  StepGuideState.Enabled),
+      TelescopeConfig(Offset(  0.75.pArcsec,  -(1.5.qArcsec)), StepGuideState.Enabled)
     )
   )
 
 private val HighResolutionIfuPresets: NonEmptyList[(String, NonEmptyList[TelescopeConfig])] =
   NonEmptyList.of(
     "Science"  -> NonEmptyList.of(
-      TelescopeConfig(Offset(0.1.pArcsec, -0.1.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(10.pArcsec, 10.qArcsec), StepGuideState.Disabled),
-      TelescopeConfig(Offset(-0.1.pArcsec, 0.1.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(-10.pArcsec, -10.qArcsec), StepGuideState.Disabled)
+      TelescopeConfig(Offset(  0.1.pArcsec, -(0.1.qArcsec)), StepGuideState.Enabled),
+      TelescopeConfig(Offset(   10.pArcsec,    10.qArcsec),  StepGuideState.Disabled),
+      TelescopeConfig(Offset(-(0.1.pArcsec),  0.1.qArcsec),  StepGuideState.Enabled),
+      TelescopeConfig(Offset( -(10.pArcsec), -(10.qArcsec)), StepGuideState.Disabled)
     ),
     "Telluric" -> NonEmptyList.of(
-      TelescopeConfig(Offset(0.pArcsec, 0.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(5.pArcsec, 5.qArcsec), StepGuideState.Disabled),
-      TelescopeConfig(Offset(0.pArcsec, 0.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(0.pArcsec, 0.qArcsec), StepGuideState.Enabled),
-      TelescopeConfig(Offset(-5.pArcsec, -5.qArcsec), StepGuideState.Disabled),
-      TelescopeConfig(Offset(0.pArcsec, 0.qArcsec), StepGuideState.Enabled)
+      TelescopeConfig(Offset(  0.pArcsec,    0.qArcsec),  StepGuideState.Enabled),
+      TelescopeConfig(Offset(  5.pArcsec,    5.qArcsec),  StepGuideState.Disabled),
+      TelescopeConfig(Offset(  0.pArcsec,    0.qArcsec),  StepGuideState.Enabled),
+      TelescopeConfig(Offset(  0.pArcsec,    0.qArcsec),  StepGuideState.Enabled),
+      TelescopeConfig(Offset(-(5.pArcsec), -(5.qArcsec)), StepGuideState.Disabled),
+      TelescopeConfig(Offset(  0.pArcsec,    0.qArcsec),  StepGuideState.Enabled)
     )
   )
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/igrins2/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/igrins2/package.scala
@@ -49,10 +49,10 @@ def fowlerSamplesForExposureTime(exposure: TimeSpan): Igrins2FowlerSamples =
 
 val NodAlongSlitDefaultTelescopeConfigs: NonEmptyList[TelescopeConfigAlongSlit] =
   NonEmptyList.of(
-    TelescopeConfigAlongSlit(-1.25.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 1.25.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit( 1.25.qArcsec, StepGuideState.Enabled),
-    TelescopeConfigAlongSlit(-1.25.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(1.25.qArcsec), StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  1.25.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(  1.25.qArcsec, StepGuideState.Enabled),
+    TelescopeConfigAlongSlit(-(1.25.qArcsec), StepGuideState.Enabled),
   )
 
 val NodToSkyDefaultTelescopeConfigs: NonEmptyList[TelescopeConfig] =

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsAgsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsAgsDemo.scala
@@ -52,7 +52,7 @@ trait GmosAgsVisualizationShapes(val posAngle: Angle) extends AgsVisualizationBa
   import lucuma.core.geom.gmos.*
 
   val guideStarOffset: Offset =
-    Offset(-170543999.µas.p, -24177003.µas.q)
+    Offset(-(170543999.µas.p), -(24177003.µas.q))
 
   val defaultFpu: Either[GmosNorthFpu, GmosSouthFpu] =
     Right(GmosSouthFpu.LongSlit_5_00)
@@ -72,16 +72,16 @@ trait GmosAgsVisualizationShapes(val posAngle: Angle) extends AgsVisualizationBa
 
   val acqOffsets: AcquisitionOffsets = AcquisitionOffsets(
     NonEmptySet.of(
-      Offset(0.arcsec.p, -10.arcsec.q).guided,
-      Offset(10.arcsec.p,  0.arcsec.q).guided
+      Offset( 0.arcsec.p, -(10.arcsec.q)).guided,
+      Offset(10.arcsec.p,    0.arcsec.q).guided
     )
   )
 
   val scienceOffsets: ScienceOffsets = ScienceOffsets(
     NonEmptySet.of(
-      Offset(0.arcsec.p,  15.arcsec.q).guided,
+      Offset(0.arcsec.p,   15.arcsec.q).guided,
       Offset.Zero.guided,
-      Offset(0.arcsec.p, -15.arcsec.q).guided
+      Offset(0.arcsec.p, -(15.arcsec.q)).guided
     )
   )
 
@@ -191,7 +191,7 @@ trait GmosWithPwfsVisualizationShapes(val posAngle: Angle) extends AgsVisualizat
   import lucuma.core.geom.pwfs.probeArm
 
   val guideStarOffset: Offset =
-    Offset(200.arcsec.p, -150.arcsec.q)
+    Offset(200.arcsec.p, -(150.arcsec.q))
 
   val defaultFpu: Option[Either[GmosNorthFpu, GmosSouthFpu]] =
     Some(Right(GmosSouthFpu.LongSlit_5_00))
@@ -268,9 +268,9 @@ trait GhostWithPwfsVisualizationShapes(val posAngle: Angle) extends AgsVisualiza
     Offset(270.arcsec.p, 300.arcsec.q)
 
   // IFU1 target
-  val target1Offset: Offset = Offset(100.arcsec.p, 30.arcsec.q)
+  val target1Offset: Offset = Offset(  100.arcsec.p,    30.arcsec.q)
   // IFU2 target
-  val target2Offset: Offset = Offset(-180.arcsec.p, -70.arcsec.q)
+  val target2Offset: Offset = Offset(-(180.arcsec.p), -(70.arcsec.q))
 
   val offsetPos: Offset = Offset.Zero
 

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -45,10 +45,10 @@ trait GmosShapes extends InstrumentShapes:
     145.deg
 
   val guideStarOffset: Offset =
-    Offset(170543999.µas.p, -24177003.µas.q)
+    Offset(170543999.µas.p, -(24177003.µas.q))
 
   val offsetPos: Offset =
-    Offset(-60.arcsec.p, 60.arcsec.q)
+    Offset(-(60.arcsec.p), 60.arcsec.q)
 
   def fpu: Either[GmosNorthFpu, GmosSouthFpu]
 
@@ -80,10 +80,10 @@ trait GmosImagingShapes extends InstrumentShapes:
     145.deg
 
   val guideStarOffset: Offset =
-    Offset(170543999.µas.p, -24177003.µas.q)
+    Offset(170543999.µas.p, -(24177003.µas.q))
 
   val offsetPos: Offset =
-    Offset(-60.arcsec.p, 60.arcsec.q)
+    Offset(-(60.arcsec.p), 60.arcsec.q)
 
   val port: PortDisposition =
     PortDisposition.Side
@@ -102,8 +102,8 @@ trait GmosMosShapes extends InstrumentShapes:
   import lucuma.core.geom.gmos.oiwfs.{probeArm, patrolField}
 
   val posAngle: Angle         = 0.deg
-  val offsetPos: Offset       = Offset(-60.arcsec.p, 60.arcsec.q)
-  val guideStarOffset: Offset = Offset(-140.arcsec.p, 160.arcsec.q)
+  val offsetPos: Offset       = Offset(-(60.arcsec.p), 60.arcsec.q)
+  val guideStarOffset: Offset = Offset(-(140.arcsec.p), 160.arcsec.q)
   val port: PortDisposition   = PortDisposition.Side
 
   override def coloredShapes: List[ColoredShape] =
@@ -222,10 +222,10 @@ trait Flamingos2LSShapes extends InstrumentShapes:
     145.deg
 
   val guideStarOffset: Offset =
-    Offset(170543999.µas.p, -24177003.µas.q)
+    Offset(170543999.µas.p, -(24177003.µas.q))
 
   val offsetPos: Offset =
-    Offset(-60.arcsec.p, 60.arcsec.q)
+    Offset(-(60.arcsec.p), 60.arcsec.q)
 
   val fpu: Flamingos2FpuMask = Flamingos2FpuMask.Builtin(Flamingos2Fpu.LongSlit8)
   val lyot: Flamingos2LyotWheel = Flamingos2LyotWheel.F16
@@ -250,10 +250,10 @@ trait Flamingos2ImagingShapes extends InstrumentShapes:
     145.deg
 
   val guideStarOffset: Offset =
-    Offset(170543999.µas.p, -24177003.µas.q)
+    Offset(170543999.µas.p, -(24177003.µas.q))
 
   val offsetPos: Offset =
-    Offset(-60.arcsec.p, 60.arcsec.q)
+    Offset(-(60.arcsec.p), 60.arcsec.q)
 
   val lyot: Flamingos2LyotWheel = Flamingos2LyotWheel.F16
 
@@ -277,10 +277,10 @@ trait Flamingos2MosShapes extends InstrumentShapes:
     20.deg
 
   val guideStarOffset: Offset =
-    Offset(170543999.µas.p, -24177003.µas.q)
+    Offset(170543999.µas.p, -(24177003.µas.q))
 
   val offsetPos: Offset =
-    Offset(-5.arcsec.p, 5.arcsec.q)
+    Offset(-(5.arcsec.p), 5.arcsec.q)
 
   val lyot: Flamingos2LyotWheel = Flamingos2LyotWheel.F16
 
@@ -336,7 +336,7 @@ trait GmosWithPwfsShapes extends InstrumentShapes:
     15.deg
 
   val offsetPos: Offset =
-    Offset(-60.arcsec.p, 60.arcsec.q)
+    Offset(-(60.arcsec.p), 60.arcsec.q)
 
   val guideStarOffset: Offset =
     Offset(270.arcsec.p, 224.arcsec.q)
@@ -599,8 +599,8 @@ trait GhostShapes extends InstrumentShapes:
 
   val probe: GuideProbe = GuideProbe.PWFS2
 
-  val ifu1Offset: Offset = Offset(100.arcsec.p,  30.arcsec.q)
-  val ifu2Offset: Offset = Offset(-120.arcsec.p, -40.arcsec.q)
+  val ifu1Offset: Offset = Offset(  100.arcsec.p,    30.arcsec.q)
+  val ifu2Offset: Offset = Offset(-(120.arcsec.p), -(40.arcsec.q))
 
   private def ifuMarkerAt(offset: Offset): ShapeExpression =
     ShapeExpression.centeredRectangle(7.arcsec, 7.arcsec).rotate(posAngle) ↗ offset

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetPSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetPSuite.scala
@@ -11,7 +11,7 @@ import lucuma.core.optics.laws.discipline.*
 import monocle.law.discipline.*
 import org.scalacheck.Prop.*
 
-final class OffsetPSuite extends munit.DisciplineSuite {
+final class OffsetPSuite extends munit.DisciplineSuite:
   import ArbAngle.given
   import ArbOffset.given
 
@@ -25,28 +25,26 @@ final class OffsetPSuite extends munit.DisciplineSuite {
            SplitMonoTests(Offset.Component.signedDecimalArcseconds[Axis.P]).splitMono
   )
 
-  test("Equality must be natural") {
-    forAll { (a: Offset.Component[Axis.P], b: Offset.Component[Axis.P]) =>
+  test("Equality must be natural"):
+    forAll: (a: Offset.Component[Axis.P], b: Offset.Component[Axis.P]) =>
       assertEquals(a.equals(b),  Eq[Offset.Component[Axis.P]].eqv(a, b))
-    }
-  }
 
-  test("Equality be consistent with .toAngle") {
-    forAll { (a: Offset.Component[Axis.P], b: Offset.Component[Axis.P]) =>
+  test("Equality be consistent with .toAngle"):
+    forAll: (a: Offset.Component[Axis.P], b: Offset.Component[Axis.P]) =>
       assertEquals(Eq[Angle].eqv(a.toAngle, b.toAngle),  Eq[Offset.Component[Axis.P]].eqv(a, b))
-    }
-  }
 
-  test("Show must be natural") {
-    forAll { (a: Offset.Component[Axis.P]) =>
+  test("Show must be natural"):
+    forAll: (a: Offset.Component[Axis.P]) =>
       assertEquals(a.toString,  Show[Offset.Component[Axis.P]].show(a))
-    }
-  }
 
-  test("Conversion to angle must be invertable") {
-    forAll { (p: Offset.Component[Axis.P]) =>
+  test("Conversion to angle must be invertable"):
+    forAll: (p: Offset.Component[Axis.P]) =>
       assertEquals(Offset.Component[Axis.P](p.toAngle),  p)
-    }
-  }
 
-}
+  test("unary_- must be consistent with .toAngle"):
+    forAll: (p: Offset.Component[Axis.P]) =>
+      assertEquals((-p).toAngle,  -p.toAngle)
+
+  test("unary_- must be invertable"):
+    forAll: (p: Offset.Component[Axis.P]) =>
+      assertEquals(-(-p),  p)

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetQSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetQSuite.scala
@@ -11,7 +11,7 @@ import lucuma.core.optics.laws.discipline.*
 import monocle.law.discipline.*
 import org.scalacheck.Prop.*
 
-final class OffsetQSuite extends munit.DisciplineSuite {
+final class OffsetQSuite extends munit.DisciplineSuite:
   import ArbAngle.given
   import ArbOffset.given
 
@@ -25,28 +25,26 @@ final class OffsetQSuite extends munit.DisciplineSuite {
            SplitMonoTests(Offset.Component.signedDecimalArcseconds[Axis.Q]).splitMono
   )
 
-  test("Equality must be natural") {
-    forAll { (a: Offset.Component[Axis.Q], b: Offset.Component[Axis.Q]) =>
+  test("Equality must be natural"):
+    forAll: (a: Offset.Component[Axis.Q], b: Offset.Component[Axis.Q]) =>
       assertEquals(a.equals(b),  Eq[Offset.Component[Axis.Q]].eqv(a, b))
-    }
-  }
 
-  test("Equality be consistent with .toAngle") {
-    forAll { (a: Offset.Component[Axis.Q], b: Offset.Component[Axis.Q]) =>
+  test("Equality be consistent with .toAngle"):
+    forAll: (a: Offset.Component[Axis.Q], b: Offset.Component[Axis.Q]) =>
       assertEquals(Eq[Angle].eqv(a.toAngle, b.toAngle),  Eq[Offset.Component[Axis.Q]].eqv(a, b))
-    }
-  }
 
-  test("Show must be natural") {
-    forAll { (a: Offset.Component[Axis.Q]) =>
+  test("Show must be natural"):
+    forAll: (a: Offset.Component[Axis.Q]) =>
       assertEquals(a.toString,  Show[Offset.Component[Axis.Q]].show(a))
-    }
-  }
 
-  test("Conversion to angle must be invertable") {
-    forAll { (p: Offset.Component[Axis.Q]) =>
+  test("Conversion to angle must be invertable"):
+    forAll: (p: Offset.Component[Axis.Q]) =>
       assertEquals(Offset.Component[Axis.Q](p.toAngle),  p)
-    }
-  }
 
-}
+  test("unary_- must be consistent with .toAngle"):
+    forAll: (p: Offset.Component[Axis.Q]) =>
+      assertEquals((-p).toAngle,  -p.toAngle)
+
+  test("unary_- must be invertable"):
+    forAll: (p: Offset.Component[Axis.Q]) =>
+      assertEquals(-(-p),  p)

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetSuite.scala
@@ -12,6 +12,8 @@ import lucuma.core.optics.laws.discipline.SplitMonoTests
 import monocle.law.discipline.*
 import org.scalacheck.Prop.*
 
+import scala.language.implicitConversions
+
 final class OffsetSuite extends munit.DisciplineSuite {
   import ArbAngle.given
   import ArbOffset.given
@@ -61,23 +63,23 @@ final class OffsetSuite extends munit.DisciplineSuite {
 
   test("Fixed Rotation tests") {
     val pqa = List(
-      (-1.arcsec.p, 0.arcsec.q, 90.deg)                                     -> ((0.arcsec.p, 1.arcsec.q)),
-      (0.arcsec.p, 1.arcsec.q, 90.deg)                                      -> ((1.arcsec.p, 0.arcsec.q)),
-      (1.arcsec.p, 0.arcsec.q, 90.deg)                                      -> ((0.arcsec.p, -1.arcsec.q)),
-      (0.arcsec.p, -1.arcsec.q, 90.deg)                                     -> ((-1.arcsec.p, 0.arcsec.q)),
-      (-1.arcsec.p, 0.arcsec.q, -90.deg)                                    -> ((0.arcsec.p, -1.arcsec.q)),
-      (0.arcsec.p, 1.arcsec.q, -90.deg)                                     -> ((-1.arcsec.p, 0.arcsec.q)),
-      (1.arcsec.p, 0.arcsec.q, -90.deg)                                     -> ((0.arcsec.p, 1.arcsec.q)),
-      (0.arcsec.p, -1.arcsec.q, -90.deg)                                    -> ((1.arcsec.p, 0.arcsec.q)),
-      (-1.arcsec.p, 0.arcsec.q, 30.deg)                                     -> ((-866025.µas.p, 500000.µas.q)),
-      (-1.arcsec.p, 0.arcsec.q, -30.deg)                                    -> ((-866025.µas.p, -500000.µas.q)),
-      (-2999291.µas.p, 9537000.µas.q, Angle.fromDMS(148, 0, 54, 775, 807))  -> ((7595657.µas.p,
-                                                                                -6500470.µas.q
-                                                                               )
+      (-(1.arcsec.p),  0.arcsec.q,    90.deg)                                 -> ((  0.arcsec.p,   1.arcsec.q)),
+      (  0.arcsec.p,   1.arcsec.q,    90.deg)                                 -> ((  1.arcsec.p,   0.arcsec.q)),
+      (  1.arcsec.p,   0.arcsec.q,    90.deg)                                 -> ((  0.arcsec.p, -(1.arcsec.q))),
+      (  0.arcsec.p, -(1.arcsec.q),   90.deg)                                 -> ((-(1.arcsec.p),  0.arcsec.q)),
+      (-(1.arcsec.p),  0.arcsec.q,  -(90.deg))                                -> ((  0.arcsec.p, -(1.arcsec.q))),
+      (  0.arcsec.p,   1.arcsec.q,  -(90.deg))                                -> ((-(1.arcsec.p),  0.arcsec.q)),
+      (  1.arcsec.p,   0.arcsec.q,  -(90.deg))                                -> ((  0.arcsec.p,   1.arcsec.q)),
+      (  0.arcsec.p, -(1.arcsec.q), -(90.deg))                                -> ((  1.arcsec.p,   0.arcsec.q)),
+      (-(1.arcsec.p),  0.arcsec.q,    30.deg)                                 -> ((-(866025.µas.p),   500000.µas.q)),
+      (-(1.arcsec.p),  0.arcsec.q,  -(30.deg))                                -> ((-(866025.µas.p), -(500000.µas.q))),
+      (-(2999291.µas.p), 9537000.µas.q, Angle.fromDMS(148, 0, 54, 775, 807))  -> ((7595657.µas.p,
+                                                                                  -(6500470.µas.q)
+                                                                                 )
       ),
-      (7595657.µas.p, -6500470.µas.q, -Angle.fromDMS(148, 0, 54, 775, 807)) -> ((-2999291.µas.p,
-                                                                                 9537000.µas.q
-                                                                                )
+      (7595657.µas.p, -(6500470.µas.q), -Angle.fromDMS(148, 0, 54, 775, 807)) -> ((-(2999291.µas.p),
+                                                                                   9537000.µas.q
+                                                                                  )
       )
     )
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/math/OffsetSuite.scala
@@ -14,7 +14,7 @@ import org.scalacheck.Prop.*
 
 import scala.language.implicitConversions
 
-final class OffsetSuite extends munit.DisciplineSuite {
+final class OffsetSuite extends munit.DisciplineSuite:
   import ArbAngle.given
   import ArbOffset.given
 
@@ -29,39 +29,33 @@ final class OffsetSuite extends munit.DisciplineSuite {
   checkAll("Offset.signedMicroarcseconds", SplitMonoTests(Offset.signedMicroarcseconds).splitMono)
   checkAll("Offset.signedArcseconds", SplitMonoTests(Offset.signedDecimalArcseconds).splitMono)
 
-  test("Equality must be natural") {
-    forAll { (a: Offset, b: Offset) =>
+  test("Equality must be natural"):
+    forAll: (a: Offset, b: Offset) =>
       assertEquals(a.equals(b),  Eq[Offset].eqv(a, b))
-    }
-  }
 
-  test("it must operate pairwise") {
-    forAll { (a: Offset, b: Offset) =>
+  test("it must operate pairwise"):
+    forAll: (a: Offset, b: Offset) =>
       assertEquals(Eq[Offset.Component[Axis.P]].eqv(a.p, b.p) &&
         Eq[Offset.Component[Axis.Q]].eqv(a.q, b.q),  Eq[Offset].eqv(a, b))
-    }
-  }
 
-  test("Show must be natural") {
-    forAll { (a: Offset) =>
+  test("Show must be natural"):
+    forAll: (a: Offset) =>
       assertEquals(a.toString,  Show[Offset].show(a))
-    }
-  }
 
-  test("Conversion to components must be invertable") {
-    forAll { (o: Offset) =>
+  test("Conversion to components must be invertable"):
+    forAll: (o: Offset) =>
       val (p, q) = (o.p, o.q)
       assertEquals(Offset(p, q),  o)
-    }
-  }
 
-  test("subtraction is addition with unary_-") {
-    forAll { (a: Offset, b: Offset) =>
+  test("subtraction is addition with unary_-"):
+    forAll: (a: Offset, b: Offset) =>
       assertEquals((a - b),  (a + -b))
-    }
-  }
 
-  test("Fixed Rotation tests") {
+  test("unary_- negates each component"):
+    forAll: (o: Offset) =>
+      assertEquals(-o,  Offset(-o.p, -o.q))
+
+  test("Fixed Rotation tests"):
     val pqa = List(
       (-(1.arcsec.p),  0.arcsec.q,    90.deg)                                 -> ((  0.arcsec.p,   1.arcsec.q)),
       (  0.arcsec.p,   1.arcsec.q,    90.deg)                                 -> ((  1.arcsec.p,   0.arcsec.q)),
@@ -98,33 +92,26 @@ final class OffsetSuite extends munit.DisciplineSuite {
         """.stripMargin)
         }
     }
-  }
 
-  test("Rotation is invertable within 1 µas") {
+  test("Rotation is invertable within 1 µas"):
     // not exactly invertable because of rounding
-    forAll { (o: Offset, θ: Angle) =>
+    forAll: (o: Offset, θ: Angle) =>
       val oʹ       = o.rotate(θ).rotate(-θ)
       val (p, q)   = Offset.signedMicroarcseconds.get(o)
       val (pʹ, qʹ) = Offset.signedMicroarcseconds.get(oʹ)
       assert(
         ((p - pʹ).abs <= 1) && ((q - qʹ).abs <= 1)
       )
-    }
-  }
 
-  test("Distance is commutative") {
-    forAll { (a: Offset, b: Offset) =>
+  test("Distance is commutative"):
+    forAll: (a: Offset, b: Offset) =>
       assertEquals(a.distance(b), b.distance(a))
-    }
-  }
 
-  test("Distance is never greater than 180º") {
-    forAll { (a: Offset, b: Offset) =>
+  test("Distance is never greater than 180º"):
+    forAll: (a: Offset, b: Offset) =>
       assert(a.distance(b).toMicroarcseconds <= Angle.µasPer180)
-    }
-  }
 
-  test("Distance tests") {
+  test("Distance tests"):
     val examples = List(
       ((  0L,  0L), ( 0L,  0L)) ->  0L,
       ((  0L, 10L), ( 0L,  0L)) -> 10L,
@@ -138,5 +125,3 @@ final class OffsetSuite extends munit.DisciplineSuite {
     examples.foreach { case ((a, b), result) =>
       assertEquals(toOffset(a).distance(toOffset(b)).toMicroarcseconds, result)
     }
-  }
-}

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/flamingos2/Flamingos2ConfigSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/sequence/flamingos2/Flamingos2ConfigSuite.scala
@@ -25,10 +25,10 @@ class Flamingos2ConfigSuite extends FunSuite:
     assertEquals(cfg.offsetsType, SlitOffsetMode.NodAlongSlit)
     assertEquals(cfg.telescopeConfigs, alongSlit(StepGuideState.Enabled, 15, -15, -15, 15))
 
-  test("MosTelluric: along-slit 60,40,20,-20,40,60 arcsec, all guided"):
+  test("MosTelluric: along-slit 60,40,20,-20,-40,-60 arcsec, all guided"):
     val cfg = defaultSlitTelescopeConfigs(Flamingos2SlitOffsetPreset.MosTelluric)
     assertEquals(cfg.offsetsType, SlitOffsetMode.NodAlongSlit)
-    assertEquals(cfg.telescopeConfigs, alongSlit(StepGuideState.Enabled, 60, 40, 20, -20, 40, 60))
+    assertEquals(cfg.telescopeConfigs, alongSlit(StepGuideState.Enabled, 60, 40, 20, -20, -40, -60))
 
   test("NodAlongSlit: along-slit ±10 arcsec, all guided"):
     val cfg = defaultSlitTelescopeConfigs(Flamingos2SlitOffsetPreset.NodAlongSlit)


### PR DESCRIPTION
scala 3.9.0 added a warning about negative literals that breaks lucuma-core, see https://github.com/scala/scala3/pull/24163