### PR TITLE
Interval seq union all

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/math/BoundedInterval.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/math/BoundedInterval.scala
@@ -18,6 +18,8 @@ import spire.math.Point
 import spire.math.extras.interval.IntervalSeq
 import spire.math.interval.ValueBound
 
+import scala.annotation.tailrec
+
 /**
   * A `BoundedInterval` is a `spire.math.Interval` but with both bounds defined.
   * Therefore, it can only be a `Bounded` or `Point`. It simplifies usage,
@@ -167,6 +169,20 @@ object BoundedInterval:
   extension (self: IntervalSeq.type)
     def apply[T: Order](i: BoundedInterval[T]): IntervalSeq[T] =
       self(i.toInterval)
+
+    /**
+     * The union of any number of `IntervalSeq`s.
+     */
+    def unionAll[T: Order](seqs: Iterable[IntervalSeq[T]]): IntervalSeq[T] =
+      // Spire's `|` allocates a new IntervalSeq and copies its operands.
+      // Folding left-to-right repeatedly copies the growing result, which
+      // can make merging many sequences quadratic. Merging pairwise keeps
+      // the merge tree balanced and avoids repeatedly copying the same data.
+      @tailrec
+      def go(v: Vector[IntervalSeq[T]]): IntervalSeq[T] =
+        if (v.sizeIs <= 1) v.headOption.getOrElse(self.empty[T])
+        else go(v.grouped(2).map(_.reduce(_ | _)).toVector)
+      go(seqs.toVector)
 
    /**
    * Makes a best-effort attempt to convert the tuple (a, b) into interval [a, b) or [b, a).

--- a/modules/core/shared/src/main/scala/lucuma/core/model/TimingWindow.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/TimingWindow.scala
@@ -11,6 +11,7 @@ import eu.timepit.refined.cats.given
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.TimingWindowInclusion
 import lucuma.core.math.BoundedInterval
+import lucuma.core.math.BoundedInterval.unionAll
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import monocle.Focus
@@ -74,11 +75,10 @@ final case class TimingWindow(
    */
   def toIntervalSeq(within: BoundedInterval[Instant]): IntervalSeq[Instant] = {
     // Builds a bunch of single-interval `IntervalSeq`s, for each of the `starts` provided, each lasting `duration`.
-    // Returns the union of all of them.
+    // Returns the union of all of them.  A short repeat period over a long `within` (say, every
+    // minute for a semester) is hundreds of thousands of starts, hence `unionAll` rather than a fold.
     def intervalsForStarts(starts: List[Instant], duration: Duration): IntervalSeq[Instant] =
-      starts
-        .map(start => IntervalSeq(Interval(start, start.plus(duration))))
-        .foldLeft(IntervalSeq.empty[Instant])(_ | _)
+      IntervalSeq.unionAll(starts.map(start => IntervalSeq(Interval(start, start.plus(duration)))))
 
     val windowStart = start.toInstant
 

--- a/modules/core/shared/src/main/scala/lucuma/core/optics/Spire.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/optics/Spire.scala
@@ -4,6 +4,7 @@
 package lucuma.core.optics
 
 import cats.Order
+import lucuma.core.math.BoundedInterval.unionAll
 import monocle.Iso
 import spire.math.*
 import spire.math.extras.interval.IntervalSeq
@@ -51,7 +52,7 @@ object Spire {
    */
   def intervalListUnion[A: Order]: SplitEpi[List[Interval[A]], IntervalSeq[A]] =
     SplitEpi[List[Interval[A]], IntervalSeq[A]](
-      _.foldLeft(IntervalSeq.empty[A])((s, i) => s | i),
+      is => IntervalSeq.unionAll(is.map(IntervalSeq(_))),
       _.intervals.toList
     )
 }

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TimingWindowSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TimingWindowSuite.scala
@@ -17,9 +17,16 @@ import org.typelevel.cats.time.given
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import scala.concurrent.duration.*
 
 final class TimingWindowSuite extends DisciplineSuite {
   import ArbTimingWindow.given
+
+  // Every test here should run in milliseconds.  The bound exists for the
+  // "tractable" test below: munit runs each test body under this timeout (on
+  // the JVM, synchronous tests included), so a quadratic regression fails at
+  // ten seconds instead of grinding for minutes.
+  override def munitTimeout: FiniteDuration = 10.seconds
 
   // Laws
   checkAll("Order[TimingWindow]", OrderTests[TimingWindow].eqv)
@@ -63,7 +70,7 @@ final class TimingWindowSuite extends DisciplineSuite {
   test("toIntervalSeq: a short period over a long interval is tractable") {
     // 30 seconds every minute for 180 days: 259,200 repeats.  A left fold of
     // spire unions over that many singletons is quadratic and takes minutes;
-    // this must complete in well under a second.
+    // this must complete within `munitTimeout` (and does, in well under a second).
     val seq = repeating(lower, Duration.ofSeconds(30), Duration.ofMinutes(1), None).toIntervalSeq(within(180))
     assertEquals(seq.intervals.size, 259200)
     assertEquals(seq.duration, Duration.ofDays(90))

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/TimingWindowSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/TimingWindowSuite.scala
@@ -4,12 +4,69 @@
 package lucuma.core.model
 
 import cats.kernel.laws.discipline.OrderTests
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.TimingWindowInclusion
+import lucuma.core.math.BoundedInterval
 import lucuma.core.model.arb.ArbTimingWindow
+import lucuma.core.syntax.time.*
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
 import munit.*
+import org.typelevel.cats.time.given
+
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 final class TimingWindowSuite extends DisciplineSuite {
   import ArbTimingWindow.given
 
   // Laws
   checkAll("Order[TimingWindow]", OrderTests[TimingWindow].eqv)
+
+  private val lower: Instant = Instant.parse("2026-02-01T00:00:00Z")
+
+  private def within(days: Long): BoundedInterval[Instant] =
+    BoundedInterval.unsafeOpenUpper(lower, lower.plus(days, ChronoUnit.DAYS))
+
+  private def repeating(start: Instant, duration: Duration, period: Duration, times: Option[Int]): TimingWindow =
+    TimingWindow(
+      TimingWindowInclusion.Include,
+      Timestamp.unsafeFromInstant(start),
+      Some(
+        TimingWindowEnd.After(
+          TimeSpan.unsafeFromDuration(duration),
+          Some(TimingWindowRepeat(TimeSpan.unsafeFromDuration(period), times.map(PosInt.unsafeFrom)))
+        )
+      )
+    )
+
+  test("toIntervalSeq: repeat forever unfolds one interval per period within the bounds") {
+    val seq = repeating(lower, Duration.ofHours(1), Duration.ofDays(1), None).toIntervalSeq(within(10))
+    assertEquals(seq.intervals.size, 10)
+    assertEquals(seq.duration, Duration.ofHours(10))
+  }
+
+  test("toIntervalSeq: repeat n times stops after the repeats even when the bounds continue") {
+    val seq = repeating(lower, Duration.ofHours(1), Duration.ofDays(1), Some(3)).toIntervalSeq(within(10))
+    // The initial window plus three repeats.
+    assertEquals(seq.intervals.size, 4)
+    assertEquals(seq.duration, Duration.ofHours(4))
+  }
+
+  test("toIntervalSeq: a repeating window starting after the bounds is empty") {
+    val seq = repeating(lower.plus(20, ChronoUnit.DAYS), Duration.ofHours(1), Duration.ofDays(1), None)
+      .toIntervalSeq(within(10))
+    assert(seq.isEmpty)
+  }
+
+  test("toIntervalSeq: a short period over a long interval is tractable") {
+    // 30 seconds every minute for 180 days: 259,200 repeats.  A left fold of
+    // spire unions over that many singletons is quadratic and takes minutes;
+    // this must complete in well under a second.
+    val seq = repeating(lower, Duration.ofSeconds(30), Duration.ofMinutes(1), None).toIntervalSeq(within(180))
+    assertEquals(seq.intervals.size, 259200)
+    assertEquals(seq.duration, Duration.ofDays(90))
+  }
+
 }


### PR DESCRIPTION
Adds a more efficient `unionAll` method to our `IntervalSeq.type` syntax and uses it where before we were doing a fold (with much repetitive copying) over a list of `IntervalSeq`.