### PR TITLE
Require a complete profile of every investigator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.246"
+ThisBuild / tlBaseVersion                         := "0.247"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ProgramUserRole.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ProgramUserRole.scala
@@ -14,4 +14,13 @@ enum ProgramUserRole(val tag: String) derives Enumerated:
   case SupportPrimary   extends ProgramUserRole("support_primary")
   case SupportSecondary extends ProgramUserRole("support_secondary")
 
+  /**
+   * Whether this role is an investigator's -- the PI's or a co-investigator's. The rules a
+   * proposal must satisfy before it can be submitted speak of investigators, so support and
+   * external users are not held to them.
+   */
+  def isInvestigator: Boolean = this match
+    case Pi | Coi | CoiRO                             => true
+    case External | SupportPrimary | SupportSecondary => false
+
 end ProgramUserRole

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ProposalSubmissionError.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ProposalSubmissionError.scala
@@ -69,11 +69,20 @@ enum ProposalSubmissionError(val tag: String, val message: String) derives Enume
   case UnmatchedPartnerTime
     extends ProposalSubmissionError("unmatched_partner_time", "Non-US partner time requests must have matching collaborators.")
 
-  case MissingPiEmail
-    extends ProposalSubmissionError("missing_pi_email", "PI email is required.")
+  case MissingInvestigatorName
+    extends ProposalSubmissionError("missing_investigator_name", "Every investigator must have a name.")
 
-  case InvalidPiEmail
-    extends ProposalSubmissionError("invalid_pi_email", "PI email address is invalid.")
+  case MissingInvestigatorEmail
+    extends ProposalSubmissionError("missing_investigator_email", "Every investigator must have an email address.")
+
+  case InvalidInvestigatorEmail
+    extends ProposalSubmissionError("invalid_investigator_email", "Every investigator's email address must be valid.")
+
+  case MissingInvestigatorEducationalStatus
+    extends ProposalSubmissionError("missing_investigator_educational_status", "Every investigator must have an educational status.")
+
+  case MissingInvestigatorAffiliation
+    extends ProposalSubmissionError("missing_investigator_affiliation", "Every investigator must have an affiliation.")
 
   case UninvitedInvestigator
     extends ProposalSubmissionError("uninvited_investigator", "All investigators must be invited.")


### PR DESCRIPTION
Only the PI had to have an email address, and only the partner link of
each investigator had to be set.  Nothing required a co-investigator to
have an email, and nothing required anyone to have a name, an
educational status or an institutional affiliation.

Generalize the two PI email rules to every investigator -- the PI, the
co-investigators and the read-only co-investigators alike -- and add the
three that were missing.  The new affiliation rule is about the
free-text institutional affiliation, which nothing validated before; the
partner link keeps its own rule, whose message already says
"partnership" rather than "affiliation".

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>