### PR TITLE
Replaces recursion with a loop when evaluating a chain of geometric operations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.248"
+ThisBuild / tlBaseVersion                         := "0.247"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.247"
+ThisBuild / tlBaseVersion                         := "0.248"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
@@ -3,6 +3,8 @@
 
 package lucuma.core.geom
 
+import cats.Eq
+import cats.syntax.eq.*
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 
@@ -121,5 +123,34 @@ object ShapeExpression {
    * @group Transformations
    */
   final case class Translate(e: ShapeExpression, o: Offset) extends ShapeExpression
+
+  private[geom] enum BinaryOp:
+    case Difference, Intersection, Union
+
+  private given Eq[BinaryOp] = Eq.fromUniversalEquals
+
+  /**
+   * Operands of the left-nested chain of `op` rooted at `e`, in evaluation order.
+   * AGS builds `∩` chains with one operand per science offset, so interpreters fold this
+   * list in a loop instead of recursing once per offset.
+   */
+  private[geom] def leftSpine(e: ShapeExpression, op: BinaryOp): List[ShapeExpression] =
+    var operands: List[ShapeExpression] = Nil
+    var cur                             = e
+    var descending                      = true
+    while descending do
+      cur match
+        case Difference(a, b) if op === BinaryOp.Difference     =>
+          operands = b :: operands
+          cur = a
+        case Intersection(a, b) if op === BinaryOp.Intersection =>
+          operands = b :: operands
+          cur = a
+        case Union(a, b) if op === BinaryOp.Union               =>
+          operands = b :: operands
+          cur = a
+        case _                                                  =>
+          descending = false
+    cur :: operands
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
@@ -3,8 +3,7 @@
 
 package lucuma.core.geom
 
-import cats.Eq
-import cats.syntax.eq.*
+import scala.annotation.tailrec
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 
@@ -127,30 +126,20 @@ object ShapeExpression {
   private[geom] enum BinaryOp:
     case Difference, Intersection, Union
 
-  private given Eq[BinaryOp] = Eq.fromUniversalEquals
-
   /**
-   * Operands of the left-nested chain of `op` rooted at `e`, in evaluation order.
-   * AGS builds `∩` chains with one operand per science offset, so interpreters fold this
-   * list in a loop instead of recursing once per offset.
+   * Operands of the left-nested chain of `op` rooted at `e`, in evaluation order: the leftmost
+   * leaf first, then the right operand of each node from the bottom up. AGS builds `∩` chains
+   * with one operand per science offset, so interpreters fold this list in a loop instead of
+   * recursing once per offset.
    */
-  private[geom] def leftSpine(e: ShapeExpression, op: BinaryOp): List[ShapeExpression] =
-    var operands: List[ShapeExpression] = Nil
-    var cur                             = e
-    var descending                      = true
-    while descending do
+  private[geom] def leftSpine(e: ShapeExpression, op: BinaryOp): (ShapeExpression, List[ShapeExpression]) =
+    @tailrec
+    def go(cur: ShapeExpression, acc: List[ShapeExpression]): (ShapeExpression, List[ShapeExpression]) =
       cur match
-        case Difference(a, b) if op === BinaryOp.Difference     =>
-          operands = b :: operands
-          cur = a
-        case Intersection(a, b) if op === BinaryOp.Intersection =>
-          operands = b :: operands
-          cur = a
-        case Union(a, b) if op === BinaryOp.Union               =>
-          operands = b :: operands
-          cur = a
-        case _                                                  =>
-          descending = false
-    cur :: operands
+        case Difference(a, b) if op == BinaryOp.Difference     => go(a, b :: acc)
+        case Intersection(a, b) if op == BinaryOp.Intersection => go(a, b :: acc)
+        case Union(a, b) if op == BinaryOp.Union               => go(a, b :: acc)
+        case _                                                 => (cur, acc)
+    go(e, Nil)
 
 }

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/ShapeExpression.scala
@@ -3,9 +3,10 @@
 
 package lucuma.core.geom
 
-import scala.annotation.tailrec
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
+
+import scala.annotation.tailrec
 
 /**
  * Describes a `Shape`, which is produced by evaluating the expression using

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShapeInterpreter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShapeInterpreter.scala
@@ -30,6 +30,10 @@ object JtsShapeInterpreter extends ShapeInterpreter {
       if ((a.p === b.p) || (a.q === b.q)) EmptyGeometry
       else f(a.shapeFactory(b))
 
+    def foldChain(op: BinaryOp)(combine: (Geometry, Geometry) => Geometry): Geometry =
+      val operands = ShapeExpression.leftSpine(e, op)
+      operands.tail.foldLeft(toGeometry(operands.head))((acc, x) => combine(acc, toGeometry(x)))
+
     def safePolygon(os: List[Offset]): Geometry =
       // We need at least 3 distinct points.
       if (os.toSet.size < 3)
@@ -52,10 +56,10 @@ object JtsShapeInterpreter extends ShapeInterpreter {
         val (a, b) = Jts.boundingOffsets(toGeometry(e))
         safeRectangularBoundedShape(a, b)(_.createRectangle)
 
-      // Combinations
-      case Difference(a, b)      => toGeometry(a).difference(toGeometry(b))
-      case Intersection(a, b)    => toGeometry(a).intersection(toGeometry(b))
-      case Union(a, b)           => toGeometry(a).union(toGeometry(b))
+      // Combinations: fold the chain of same-kind nodes in a loop, see ShapeExpression.leftSpine
+      case Difference(_, _)      => foldChain(BinaryOp.Difference)(_.difference(_))
+      case Intersection(_, _)    => foldChain(BinaryOp.Intersection)(_.intersection(_))
+      case Union(_, _)           => foldChain(BinaryOp.Union)(_.union(_))
 
       // Transformations
       case FlipP(e)                    =>

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShapeInterpreter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/jts/JtsShapeInterpreter.scala
@@ -31,8 +31,8 @@ object JtsShapeInterpreter extends ShapeInterpreter {
       else f(a.shapeFactory(b))
 
     def foldChain(op: BinaryOp)(combine: (Geometry, Geometry) => Geometry): Geometry =
-      val operands = ShapeExpression.leftSpine(e, op)
-      operands.tail.foldLeft(toGeometry(operands.head))((acc, x) => combine(acc, toGeometry(x)))
+      val (head, rest) = ShapeExpression.leftSpine(e, op)
+      rest.foldLeft(toGeometry(head))((acc, x) => combine(acc, toGeometry(x)))
 
     def safePolygon(os: List[Offset]): Geometry =
       // We need at least 3 distinct points.

--- a/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
@@ -30,6 +30,7 @@ class ShapeExpressionSuite extends munit.DisciplineSuite with RetryFlakyTests {
 
   def at(arcseconds: Int): Offset = Offset.symmetric(arcseconds.arcsec)
 
+  // Regression test on Scala.js only: the JVM stack is deep enough that 2000 levels pass either way
   test("deep chains of one operation evaluate without recursion per operand"):
     val rect: ShapeExpression = Rectangle(at(-10), at(2000))
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/geom/ShapeExpressionSuite.scala
@@ -28,6 +28,31 @@ class ShapeExpressionSuite extends munit.DisciplineSuite with RetryFlakyTests {
   import ArbShapeExpression.*
   import ShapeExpressionSpec.*
 
+  def at(arcseconds: Int): Offset = Offset.symmetric(arcseconds.arcsec)
+
+  test("deep chains of one operation evaluate without recursion per operand"):
+    val rect: ShapeExpression = Rectangle(at(-10), at(2000))
+
+    // Each operand is the square shifted by i mas along both axes
+    def shifted(i: Int): ShapeExpression = rect ↗ Offset.symmetric(i.mas)
+
+    // JTS overlays cost a few ms each, so only the intersection chain is deep
+    val squares = (1 to 2000).map(shifted)
+
+    // Test for intersection (Used by AGS)
+    val chain = squares.reduce(_ ∩ _) // [-8", 2000.001"]^2
+    assertEquals(chain.contains(at(1000)), true)
+    assertEquals(chain.contains(at(-9)), false)
+
+    // Test for union.
+    val union = squares.take(200).reduce(_ ∪ _) // [-9.999", 2000.2"]^2
+    assertEquals(union.contains(at(-9)), true)
+
+    // Test for difference
+    val diff = squares.take(200).foldLeft(rect)(_ - _)
+    assertEquals(diff.contains(Offset(Offset.P((-9_999_500).µas), Offset.Q(1000.arcsec))), true)
+    assertEquals(diff.contains(at(1000)), false)
+
   test("intersection contains") {
     forAll(genTwoCenteredShapesAndAnOffset) { case (tcs, off) =>
       assertEquals(


### PR DESCRIPTION
In explore, the AGS worker failed in Chrome with `RangeError: Maximum call stack size exceeded` at about 200 science offsets. `AgsParams.posCalculations` combines the per-offset patrol fields with `reduce(using _ ∩ _)`, giving a left-nested tree with one Intersection node per offset.

In `toGeometry`, `case Intersection(a, b) => toGeometry(a).intersection(...)` recurses into the left child before computing anything, so stack depth grows with the offset count.

Fix

`ShapeExpression.leftSpine` collapses a run of the same operation into a flat list of operands (sort of replacing recursion with a loop). It follows left children from the root and stops at the first node of a different kind, so nesting of a different operator stays a single operand.

```scala
Intersection(Intersection(Intersection(pf1, pf2), pf3), pf4)
  -> (Intersection, List(pf1, pf2, pf3, pf4))
```

Tested it in explore and the error disappears, tested with up to 500 offsets, it is still very slow but at least it converges