### PR TITLE
Separate Gnirs acquisition filter lists for spectroscopy and imaging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.247"
+ThisBuild / tlBaseVersion                         := "0.248"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
@@ -63,8 +63,13 @@ object GnirsFilter:
 
   /** Every filter that may be used for a spectroscopic acquisition, explicitly or automatically. */
   // Declaration order matters for range match. Since H2 is completely contained in Order3, it needs to come before or it will never be selected.
-  val AcquisitionFilters: NonEmptyList[GnirsFilter] =
+  val SpectroscopyAcquisitionFilters: NonEmptyList[GnirsFilter] =
     NonEmptyList.of(Order6, Order5, Order4, H2, Order3, PAH)
+
+  /** Every filter that may be used for an imaging acquisition, explicitly or automatically. */
+  // Wavelength order, which is the order the filters are offered in.
+  val ImagingAcquisitionFilters: NonEmptyList[GnirsFilter] =
+    NonEmptyList.of(Y, Order6, J, Order4, H2, K)
 
   /**
    * The filters that automatic acquisition selection may produce by wavelength coverage.
@@ -72,7 +77,7 @@ object GnirsFilter:
    * does not belong, and above `ThermalAcquisitionCutoff` `ThermalAcquisitionFilter` is used
    * instead of a coverage match.  It remains available as an explicit choice.
    */
-  // Declaration order matters here too (see AcquisitionFilters).
+  // Declaration order matters here too (see SpectroscopyAcquisitionFilters).
   val AutoAcquisitionFilters: NonEmptyList[GnirsFilter] =
     NonEmptyList.of(Order6, Order5, Order4, H2, Order3)
 

--- a/modules/tests/shared/src/test/scala/lucuma/core/enums/GnirsFilterSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/enums/GnirsFilterSuite.scala
@@ -3,6 +3,7 @@
 
 package lucuma.core.enums
 
+import cats.syntax.eq.*
 import lucuma.core.math.Wavelength
 import munit.DisciplineSuite
 
@@ -56,7 +57,23 @@ final class GnirsFilterSuite extends DisciplineSuite {
 
   test("automatic acquisition selection never produces PAH") {
     assert(!GnirsFilter.AutoAcquisitionFilters.toList.contains(GnirsFilter.PAH))
-    assert(GnirsFilter.AcquisitionFilters.toList.contains(GnirsFilter.PAH))
+    assert(GnirsFilter.SpectroscopyAcquisitionFilters.toList.contains(GnirsFilter.PAH))
+  }
+
+  test("imaging acquisition filters are the imaging filters, plus H2") {
+    // Order is presentational, so compare membership.
+    val (h2, imaging) = GnirsFilter.ImagingAcquisitionFilters.toList.partition(_ === GnirsFilter.H2)
+    assertEquals(h2, List(GnirsFilter.H2))
+    assertEquals(imaging.toSet, GnirsFilter.values.filter(_.imagingWidth.isDefined).toSet)
+  }
+
+  test("the J and K of an imaging acquisition are the photometric filters, not the orders") {
+    val imaging = GnirsFilter.ImagingAcquisitionFilters.toList
+    assert(imaging.contains(GnirsFilter.J) && imaging.contains(GnirsFilter.K))
+    assert(!imaging.contains(GnirsFilter.Order5) && !imaging.contains(GnirsFilter.Order3))
+    val spectroscopy = GnirsFilter.SpectroscopyAcquisitionFilters.toList
+    assert(spectroscopy.contains(GnirsFilter.Order5) && spectroscopy.contains(GnirsFilter.Order3))
+    assert(!spectroscopy.contains(GnirsFilter.J) && !spectroscopy.contains(GnirsFilter.K))
   }
 
   test("science filter") {


### PR DESCRIPTION
The selectable acquitision filters for GNIRS spectroscopy and imaging are different.